### PR TITLE
contrib/pagestore: copy-on-write branches (timelines)

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -38,6 +38,9 @@
 /* GUC: name of the POSIX shm object shared with the daemon */
 static char *localsvc_shm_name = NULL;
 
+/* GUC: timeline this backend reads/writes on (0 = main; >0 = a branch) */
+static int	localsvc_timeline = 0;
+
 /* per-backend attachment state */
 static void *ls_shm = NULL;
 static int	ls_shm_fd = -1;
@@ -195,6 +198,7 @@ ls_fill_key(PsChannel *ch, const PageStoreRelKey *key)
 	ch->key.dbOid = key->dbOid;
 	ch->key.relNumber = key->relNumber;
 	ch->key.forkNum = key->forkNum;
+	ch->timeline = (uint32) localsvc_timeline;	/* this backend's timeline */
 }
 
 /*
@@ -452,7 +456,25 @@ pagestore_localsvc_read_at(const PageStoreRelKey *key, BlockNumber blocknum,
 	memcpy(out, ch->data, BLCKSZ);
 }
 
-/* Called from _PG_init to register the GUC owned by this backend. */
+/*
+ * Create a branch (new timeline) forking from parent_tl at branch_lsn.  This is
+ * an O(1) metadata operation in the daemon -- no page data is copied.  Exposed
+ * for the pagestore_create_branch() SQL function.
+ */
+void
+pagestore_localsvc_create_branch(uint32 new_tl, uint32 parent_tl,
+								 uint64 branch_lsn)
+{
+	PsChannel  *ch = ls_chan();
+
+	ch->opcode = PS_OP_CREATE_BRANCH;
+	ch->timeline = new_tl;
+	ch->parent_timeline = parent_tl;
+	ch->req_lsn = branch_lsn;
+	ls_exec(ch);
+}
+
+/* Called from _PG_init to register the GUCs owned by this backend. */
 void
 pagestore_localsvc_init(void)
 {
@@ -464,4 +486,14 @@ pagestore_localsvc_init(void)
 							   PGC_POSTMASTER,
 							   0,
 							   NULL, NULL, NULL);
+
+	DefineCustomIntVariable("pagestore.timeline",
+							"Timeline (branch) this backend reads and writes on; 0 is the main timeline.",
+							NULL,
+							&localsvc_timeline,
+							0,
+							0, 1023,
+							PGC_POSTMASTER,
+							0,
+							NULL, NULL, NULL);
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -419,6 +419,32 @@ pagestore_read_at(PG_FUNCTION_ARGS)
 	PG_RETURN_BYTEA_P(result);
 }
 
+/*
+ * pagestore_create_branch(new_timeline int, parent_timeline int, lsn pg_lsn)
+ *
+ * Create a copy-on-write branch: a new timeline forked from parent_timeline at
+ * the given LSN.  Instant -- no page data is copied; the branch shares the
+ * parent's pages until it writes.  A compute can then run on the branch by
+ * setting pagestore.timeline to new_timeline.
+ */
+PG_FUNCTION_INFO_V1(pagestore_create_branch);
+
+Datum
+pagestore_create_branch(PG_FUNCTION_ARGS)
+{
+	int32		new_tl = PG_GETARG_INT32(0);
+	int32		parent_tl = PG_GETARG_INT32(1);
+	XLogRecPtr	lsn = PG_GETARG_LSN(2);
+
+	if (new_tl <= 0)
+		ereport(ERROR,
+				(errmsg("pagestore branch timeline must be > 0 (0 is the main timeline)")));
+
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) lsn);
+	PG_RETURN_VOID();
+}
+
 void
 _PG_init(void)
 {

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -143,5 +143,7 @@ extern const PageStoreBackend PageStoreBackendLocalSvc;
 extern void pagestore_localsvc_init(void);
 extern void pagestore_localsvc_read_at(const PageStoreRelKey *key,
 									   BlockNumber blocknum, uint64 lsn, void *out);
+extern void pagestore_localsvc_create_branch(uint32 new_tl, uint32 parent_tl,
+											 uint64 branch_lsn);
 
 #endif							/* PAGESTORE_BACKEND_H */

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -361,6 +361,35 @@ timeline_has_parent(uint32_t timeline)
 }
 
 /*
+ * Validate a branch-creation request before it is recorded.  read_through() and
+ * the fork-size walks follow the parent chain assuming it is finite and well
+ * formed, so a bad CREATE_BRANCH must be rejected rather than persisted.  Refuse:
+ *	- a new id that is out of range, the root (0), or already defined (otherwise
+ *	  re-creating an id silently rewrites an existing branch's ancestry);
+ *	- a parent that is out of range or not yet defined (the requested parent must
+ *	  actually exist, else the branch silently inherits from nothing);
+ *	- a parent whose ancestry already reaches the new id, which would turn the
+ *	  parent walk into an infinite loop (e.g. new == parent, or A->B->A).
+ * Returns 1 if (new_tl, parent) is safe to define.
+ */
+static int
+branch_request_ok(uint32_t new_tl, int parent)
+{
+	if (new_tl == 0 || new_tl >= MAX_TIMELINES || timelines[new_tl].defined)
+		return 0;
+	if (parent < 0 || parent >= MAX_TIMELINES || !timelines[parent].defined)
+		return 0;
+	for (int t = parent; t >= 0 && t < MAX_TIMELINES; t = timelines[t].parent)
+	{
+		if ((uint32_t) t == new_tl)
+			return 0;			/* cycle */
+		if (!timelines[t].defined)
+			return 0;			/* broken chain: refuse rather than risk a loop */
+	}
+	return 1;
+}
+
+/*
  * Resolve a read by walking the timeline ancestry: return the newest version of
  * (key, block) visible at read_lsn on 'timeline'; if the timeline never wrote
  * the page (or only after read_lsn), descend to the parent, capping read_lsn at
@@ -694,15 +723,15 @@ handle_request(PsChannel *ch)
 			 * copied -- the branch shares the parent's pages by read-through
 			 * until it writes (copy-on-write).
 			 */
-			if (ch->timeline == 0 || ch->timeline >= MAX_TIMELINES)
-				ch->status = PS_STATUS_ERROR;
-			else
+			if (branch_request_ok(ch->timeline, (int) ch->parent_timeline))
 			{
 				timeline_define(ch->timeline, (int) ch->parent_timeline,
 								ch->req_lsn);
 				timeline_persist(ch->timeline, (int) ch->parent_timeline,
 								 ch->req_lsn);
 			}
+			else
+				ch->status = PS_STATUS_ERROR;
 			break;
 
 		case PS_OP_IMMEDSYNC:

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -71,6 +71,7 @@ on_signal(int sig)
 typedef struct SegRecHdr
 {
 	uint32_t	magic;			/* SEG_MAGIC; also the end-of-log sentinel */
+	uint32_t	timeline;		/* timeline the version belongs to */
 	PsKey		key;
 	uint32_t	block;
 	uint64_t	lsn;			/* the page's pd_lsn at write time */
@@ -127,11 +128,13 @@ seg_fd(int id, int create)
  * Two chained hash tables form the indirection map that lets a single logical
  * page be located inside the large append-only segments:
  *
- *	 page_idx: (key, block) -> chain of every stored version {lsn, seg, off}
- *	 fork_idx: (key)        -> current size of the fork in blocks
+ *	 page_idx: (timeline, key, block) -> chain of versions {lsn, seg, off}
+ *	 fork_idx: (timeline, key)        -> size of the fork on that timeline
  *
- * Both are pure in-memory state, rebuilt from the segments by recover() at
- * startup.  (Prototype: no GC/compaction, so the version chain only grows.)
+ * Entries are keyed by timeline so a branch's writes are isolated; reads that
+ * miss on a timeline fall through to its parent (see read_through()).  Both
+ * tables are in-memory state, rebuilt from the segments by recover().
+ * (Prototype: no GC/compaction, so the version chain only grows.)
  */
 #define IDX_BUCKETS		(1 << 16)
 #define IDX_MASK		(IDX_BUCKETS - 1)
@@ -144,10 +147,11 @@ typedef struct PageVer
 	uint64_t	off;			/* byte offset of the page within that segment */
 } PageVer;
 
-/* Hash entry: all versions ever written for one (key, block), in arrival order. */
+/* Hash entry: all versions of one (timeline, key, block), in arrival order. */
 typedef struct PageEnt
 {
 	struct PageEnt *next;		/* bucket chain */
+	uint32_t	timeline;
 	PsKey		key;
 	uint32_t	block;
 	PageVer    *vers;			/* dynamic array, length nver, capacity cap */
@@ -155,16 +159,33 @@ typedef struct PageEnt
 	int			cap;
 } PageEnt;
 
-/* Hash entry: the block count of one relation fork. */
+/* Hash entry: the block count of one fork on one timeline. */
 typedef struct ForkEnt
 {
 	struct ForkEnt *next;		/* bucket chain */
+	uint32_t	timeline;
 	PsKey		key;
 	uint32_t	nblocks;
 } ForkEnt;
 
 static PageEnt *page_idx[IDX_BUCKETS];
 static ForkEnt *fork_idx[IDX_BUCKETS];
+
+/*
+ * Timeline metadata.  Timeline 0 is the root (no parent).  A branch records its
+ * parent and the LSN at which it forked; reads of pages the branch never wrote
+ * fall through to the parent as-of that branch LSN, so the branch is a stable
+ * copy-on-write snapshot.
+ */
+#define MAX_TIMELINES	1024
+typedef struct TimelineMeta
+{
+	int			defined;		/* 1 if this timeline exists */
+	int			parent;			/* parent timeline id, or -1 for the root */
+	uint64_t	branch_lsn;		/* parent LSN this timeline forked at */
+} TimelineMeta;
+
+static TimelineMeta timelines[MAX_TIMELINES];
 
 /* FNV-1a hash over a byte range (used to hash keys into buckets). */
 
@@ -189,37 +210,44 @@ key_eq(const PsKey *a, const PsKey *b)
 		a->relNumber == b->relNumber && a->forkNum == b->forkNum;
 }
 
-/* --- page index --- */
+/* --- page index (keyed by timeline, key, block) --- */
+
+static uint32_t
+page_hash(uint32_t timeline, const PsKey *key, uint32_t block)
+{
+	return fnv(key, sizeof(*key)) ^ (block * 2654435761u) ^ (timeline * 40503u);
+}
 
 static PageEnt *
-page_find(const PsKey *key, uint32_t block)
+page_find(uint32_t timeline, const PsKey *key, uint32_t block)
 {
-	uint32_t	h = fnv(key, sizeof(*key)) ^ (block * 2654435761u);
+	uint32_t	h = page_hash(timeline, key, block);
 	PageEnt    *e;
 
 	for (e = page_idx[h & IDX_MASK]; e; e = e->next)
-		if (e->block == block && key_eq(&e->key, key))
+		if (e->timeline == timeline && e->block == block && key_eq(&e->key, key))
 			return e;
 	return NULL;
 }
 
 /*
- * Record a new version of (key, block).  This only ever appends to the version
- * chain -- existing versions are never dropped -- which is what makes the store
- * copy-on-write.  Called both from the live write path (append_page) and from
+ * Record a new version of (timeline, key, block).  Only ever appends to the
+ * version chain -- existing versions are never dropped -- which is what makes
+ * the store copy-on-write.  The version is tagged with the writing timeline, so
+ * a branch's writes never disturb its parent.  Called from append_page and from
  * recover() while replaying segments.
  */
 static void
-page_add_version(const PsKey *key, uint32_t block, uint64_t lsn,
-				 int seg, uint64_t off)
+page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
+				 uint64_t lsn, int seg, uint64_t off)
 {
-	uint32_t	h = fnv(key, sizeof(*key)) ^ (block * 2654435761u);
-	PageEnt    *e = page_find(key, block);
+	uint32_t	h = page_hash(timeline, key, block);
+	PageEnt    *e = page_find(timeline, key, block);
 
 	if (!e)
 	{
-		/* first version of this page: create the bucket entry */
 		e = calloc(1, sizeof(*e));
+		e->timeline = timeline;
 		e->key = *key;
 		e->block = block;
 		e->next = page_idx[h & IDX_MASK];
@@ -236,66 +264,46 @@ page_add_version(const PsKey *key, uint32_t block, uint64_t lsn,
 	e->nver++;
 }
 
-/* Newest version overall -- what an ordinary (current) read returns. */
+/* Newest version on this entry with lsn <= read_lsn, or NULL if none. */
 static PageVer *
-page_current(PageEnt *e)
+page_visible(PageEnt *e, uint64_t read_lsn)
 {
 	PageVer    *best = NULL;
-
-	for (int i = 0; i < e->nver; i++)
-		if (!best || e->vers[i].lsn >= best->lsn)
-			best = &e->vers[i];
-	return best;
-}
-
-/*
- * Time-travel read: the version visible as-of snapshot LSN 'target', i.e. the
- * newest version with lsn <= target.  If the target predates every recorded
- * version (none qualifies) we fall back to the oldest version we have, so an
- * as-of read never returns "nothing" for a page that exists.  This is the read
- * side of COW.
- */
-static PageVer *
-page_asof(PageEnt *e, uint64_t target)
-{
-	PageVer    *best = NULL;	/* best so far with lsn <= target */
-	PageVer    *oldest = NULL;	/* fallback if nothing is <= target */
 
 	for (int i = 0; i < e->nver; i++)
 	{
 		PageVer    *v = &e->vers[i];
 
-		if (!oldest || v->lsn < oldest->lsn)
-			oldest = v;
-		if (v->lsn <= target && (!best || v->lsn >= best->lsn))
+		if (v->lsn <= read_lsn && (!best || v->lsn >= best->lsn))
 			best = v;
 	}
-	return best ? best : oldest;
+	return best;
 }
 
-/* --- fork size index --- */
+/* --- fork size index (keyed by timeline, key) --- */
 
 static ForkEnt *
-fork_find(const PsKey *key)
+fork_find(uint32_t timeline, const PsKey *key)
 {
-	uint32_t	h = fnv(key, sizeof(*key));
+	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
 	ForkEnt    *e;
 
 	for (e = fork_idx[h & IDX_MASK]; e; e = e->next)
-		if (key_eq(&e->key, key))
+		if (e->timeline == timeline && key_eq(&e->key, key))
 			return e;
 	return NULL;
 }
 
 static ForkEnt *
-fork_get_or_create(const PsKey *key)
+fork_get_or_create(uint32_t timeline, const PsKey *key)
 {
-	uint32_t	h = fnv(key, sizeof(*key));
-	ForkEnt    *e = fork_find(key);
+	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
+	ForkEnt    *e = fork_find(timeline, key);
 
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
+		e->timeline = timeline;
 		e->key = *key;
 		e->nblocks = 0;
 		e->next = fork_idx[h & IDX_MASK];
@@ -305,23 +313,23 @@ fork_get_or_create(const PsKey *key)
 }
 
 static void
-fork_grow(const PsKey *key, uint32_t to_nblocks)
+fork_grow(uint32_t timeline, const PsKey *key, uint32_t to_nblocks)
 {
-	ForkEnt    *e = fork_get_or_create(key);
+	ForkEnt    *e = fork_get_or_create(timeline, key);
 
 	if (to_nblocks > e->nblocks)
 		e->nblocks = to_nblocks;
 }
 
 static void
-fork_remove(const PsKey *key)
+fork_remove(uint32_t timeline, const PsKey *key)
 {
-	uint32_t	h = fnv(key, sizeof(*key));
+	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
 	ForkEnt   **pp = &fork_idx[h & IDX_MASK];
 
 	while (*pp)
 	{
-		if (key_eq(&(*pp)->key, key))
+		if ((*pp)->timeline == timeline && key_eq(&(*pp)->key, key))
 		{
 			ForkEnt    *dead = *pp;
 
@@ -331,6 +339,127 @@ fork_remove(const PsKey *key)
 		}
 		pp = &(*pp)->next;
 	}
+}
+
+/* --- timeline metadata + read-through --- */
+
+static void
+timeline_define(uint32_t id, int parent, uint64_t branch_lsn)
+{
+	if (id >= MAX_TIMELINES)
+		return;
+	timelines[id].defined = 1;
+	timelines[id].parent = parent;
+	timelines[id].branch_lsn = branch_lsn;
+}
+
+static int
+timeline_has_parent(uint32_t timeline)
+{
+	return timeline < MAX_TIMELINES && timelines[timeline].defined &&
+		timelines[timeline].parent >= 0;
+}
+
+/*
+ * Resolve a read by walking the timeline ancestry: return the newest version of
+ * (key, block) visible at read_lsn on 'timeline'; if the timeline never wrote
+ * the page (or only after read_lsn), descend to the parent, capping read_lsn at
+ * the branch LSN so the branch sees a frozen snapshot of the parent.  Returns
+ * the chosen PageVer, or NULL if no ancestor has the page.
+ */
+static PageVer *
+read_through(uint32_t timeline, const PsKey *key, uint32_t block,
+			 uint64_t read_lsn)
+{
+	for (;;)
+	{
+		PageEnt    *e = page_find(timeline, key, block);
+		PageVer    *v = e ? page_visible(e, read_lsn) : NULL;
+
+		if (v)
+			return v;
+		if (!timeline_has_parent(timeline))
+			return NULL;
+		if (timelines[timeline].branch_lsn < read_lsn)
+			read_lsn = timelines[timeline].branch_lsn;
+		timeline = (uint32_t) timelines[timeline].parent;
+	}
+}
+
+/* Fork size visible on 'timeline', inheriting the parent's when not local. */
+static uint32_t
+fork_nblocks_through(uint32_t timeline, const PsKey *key)
+{
+	for (;;)
+	{
+		ForkEnt    *e = fork_find(timeline, key);
+
+		if (e)
+			return e->nblocks;
+		if (!timeline_has_parent(timeline))
+			return 0;
+		timeline = (uint32_t) timelines[timeline].parent;
+	}
+}
+
+/* Does the fork exist on 'timeline' or any ancestor? */
+static int
+fork_exists_through(uint32_t timeline, const PsKey *key)
+{
+	for (;;)
+	{
+		if (fork_find(timeline, key))
+			return 1;
+		if (!timeline_has_parent(timeline))
+			return 0;
+		timeline = (uint32_t) timelines[timeline].parent;
+	}
+}
+
+/*
+ * Timeline metadata is persisted as an append-only log of fixed records in
+ * "<store>/timelines", so branches survive a daemon restart.  (The page data
+ * itself is already durable in the segments.)
+ */
+typedef struct TimelineRec
+{
+	uint32_t	id;
+	int32_t		parent;
+	uint64_t	branch_lsn;
+} TimelineRec;
+
+static void
+timeline_persist(uint32_t id, int parent, uint64_t branch_lsn)
+{
+	char		path[4096];
+	int			fd;
+	TimelineRec rec = {id, (int32_t) parent, branch_lsn};
+
+	snprintf(path, sizeof(path), "%s/timelines", store_dir);
+	fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
+	if (fd < 0)
+		return;					/* best-effort */
+	if (write(fd, &rec, sizeof(rec)) != (ssize_t) sizeof(rec))
+	{
+		/* ignore: best-effort */
+	}
+	close(fd);
+}
+
+static void
+load_timelines(void)
+{
+	char		path[4096];
+	int			fd;
+	TimelineRec rec;
+
+	snprintf(path, sizeof(path), "%s/timelines", store_dir);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return;					/* none yet */
+	while (read(fd, &rec, sizeof(rec)) == (ssize_t) sizeof(rec))
+		timeline_define(rec.id, rec.parent, rec.branch_lsn);
+	close(fd);
 }
 
 /* ===================== write / read primitives ========================= */
@@ -354,7 +483,8 @@ page_lsn(const unsigned char *page)
  * NVMe/SPDK and network transports.
  */
 static int
-append_page(const PsKey *key, uint32_t block, const unsigned char *page)
+append_page(uint32_t timeline, const PsKey *key, uint32_t block,
+			const unsigned char *page)
 {
 	SegRecHdr	hdr;
 	uint64_t	reclen = sizeof(SegRecHdr) + page_size;
@@ -372,6 +502,7 @@ append_page(const PsKey *key, uint32_t block, const unsigned char *page)
 		return -1;
 
 	hdr.magic = SEG_MAGIC;
+	hdr.timeline = timeline;
 	hdr.key = *key;
 	hdr.block = block;
 	hdr.lsn = page_lsn(page);	/* version key taken from the page itself */
@@ -385,7 +516,7 @@ append_page(const PsKey *key, uint32_t block, const unsigned char *page)
 		return -1;
 
 	/* index points at the page bytes (data_off), so reads skip the header */
-	page_add_version(key, block, hdr.lsn, cur_seg, data_off);
+	page_add_version(timeline, key, block, hdr.lsn, cur_seg, data_off);
 	cur_off += reclen;
 	return 0;
 }
@@ -445,9 +576,9 @@ recover(void)
 				hdr.len != page_size)
 				break;
 
-			page_add_version(&hdr.key, hdr.block, hdr.lsn, id,
+			page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn, id,
 							 off + sizeof(hdr));
-			fork_grow(&hdr.key, hdr.block + 1);
+			fork_grow(hdr.timeline, &hdr.key, hdr.block + 1);
 			off += sizeof(hdr) + hdr.len;
 		}
 		close(fd);
@@ -466,51 +597,49 @@ recover(void)
 static void
 handle_request(PsChannel *ch)
 {
+	uint32_t	tl = ch->timeline;
+
 	ch->status = PS_STATUS_OK;
 	ch->result = 0;
 
 	switch ((PsOpcode) ch->opcode)
 	{
 		case PS_OP_CREATE:
-			fork_get_or_create(&ch->key);
+			fork_get_or_create(tl, &ch->key);
 			break;
 
 		case PS_OP_EXISTS:
-			ch->result = (fork_find(&ch->key) != NULL) ? 1 : 0;
+			ch->result = fork_exists_through(tl, &ch->key) ? 1 : 0;
 			break;
 
 		case PS_OP_UNLINK:
-			fork_remove(&ch->key);
+			fork_remove(tl, &ch->key);
 			break;
 
 		case PS_OP_NBLOCKS:
-			{
-				ForkEnt    *fe = fork_find(&ch->key);
-
-				ch->result = fe ? fe->nblocks : 0;
-				break;
-			}
+			ch->result = fork_nblocks_through(tl, &ch->key);
+			break;
 
 		case PS_OP_TRUNCATE:
-			fork_get_or_create(&ch->key)->nblocks = ch->nblocks;
+			fork_get_or_create(tl, &ch->key)->nblocks = ch->nblocks;
 			break;
 
 		case PS_OP_EXTEND:
-			if (append_page(&ch->key, ch->blocknum, ch->data) != 0)
+			if (append_page(tl, &ch->key, ch->blocknum, ch->data) != 0)
 				ch->status = PS_STATUS_ERROR;
 			else
-				fork_grow(&ch->key, ch->blocknum + 1);
+				fork_grow(tl, &ch->key, ch->blocknum + 1);
 			break;
 
 		case PS_OP_ZEROEXTEND:
 			/* allocation only: grow size, no page data stored (reads -> 0) */
-			fork_grow(&ch->key, ch->blocknum + ch->nblocks);
+			fork_grow(tl, &ch->key, ch->blocknum + ch->nblocks);
 			break;
 
 		case PS_OP_WRITEV:
 			for (uint32_t i = 0; i < ch->nblocks; i++)
 			{
-				if (append_page(&ch->key, ch->blocknum + i,
+				if (append_page(tl, &ch->key, ch->blocknum + i,
 								 ch->data + (size_t) i * page_size) != 0)
 				{
 					ch->status = PS_STATUS_ERROR;
@@ -518,15 +647,16 @@ handle_request(PsChannel *ch)
 				}
 			}
 			if (ch->status == PS_STATUS_OK)
-				fork_grow(&ch->key, ch->blocknum + ch->nblocks);
+				fork_grow(tl, &ch->key, ch->blocknum + ch->nblocks);
 			break;
 
 		case PS_OP_READV:
+			/* "current" read on this timeline: read-through at max LSN */
 			for (uint32_t i = 0; i < ch->nblocks; i++)
 			{
 				unsigned char *dst = ch->data + (size_t) i * page_size;
-				PageEnt    *e = page_find(&ch->key, ch->blocknum + i);
-				PageVer    *v = e ? page_current(e) : NULL;
+				PageVer    *v = read_through(tl, &ch->key, ch->blocknum + i,
+											 UINT64_MAX);
 
 				if (!v || read_version(v, dst) != 0)
 					memset(dst, 0, page_size);	/* unwritten -> zeros */
@@ -535,13 +665,32 @@ handle_request(PsChannel *ch)
 
 		case PS_OP_READ_AT:
 			{
-				PageEnt    *e = page_find(&ch->key, ch->blocknum);
-				PageVer    *v = e ? page_asof(e, ch->req_lsn) : NULL;
+				/* as-of read on this timeline, honoring branch ancestry */
+				PageVer    *v = read_through(tl, &ch->key, ch->blocknum,
+											 ch->req_lsn);
 
 				if (!v || read_version(v, ch->data) != 0)
 					memset(ch->data, 0, page_size);
 				break;
 			}
+
+		case PS_OP_CREATE_BRANCH:
+			/*
+			 * Instant clone: just record metadata.  Timeline ch->timeline forks
+			 * from ch->parent_timeline at LSN ch->req_lsn.  No page data is
+			 * copied -- the branch shares the parent's pages by read-through
+			 * until it writes (copy-on-write).
+			 */
+			if (ch->timeline == 0 || ch->timeline >= MAX_TIMELINES)
+				ch->status = PS_STATUS_ERROR;
+			else
+			{
+				timeline_define(ch->timeline, (int) ch->parent_timeline,
+								ch->req_lsn);
+				timeline_persist(ch->timeline, (int) ch->parent_timeline,
+								 ch->req_lsn);
+			}
+			break;
 
 		case PS_OP_IMMEDSYNC:
 			for (int id = 0; id < segs_cap; id++)
@@ -593,7 +742,9 @@ main(int argc, char **argv)
 		return 1;
 	}
 
-	/* rebuild indexes from existing segments before serving any request */
+	/* timeline 0 is the root; load any persisted branches, then replay data */
+	timeline_define(0, -1, 0);
+	load_timelines();
 	recover();
 
 	fd = shm_open(shm_name, O_CREAT | O_RDWR, 0600);

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -386,18 +386,31 @@ read_through(uint32_t timeline, const PsKey *key, uint32_t block,
 	}
 }
 
-/* Fork size visible on 'timeline', inheriting the parent's when not local. */
+/*
+ * Fork size visible on 'timeline': the maximum block count across the timeline
+ * and all its ancestors.  A branch that has written only some blocks of a fork
+ * still inherits the parent's full size (the unwritten blocks are served by
+ * read_through), so we must take the max rather than the first entry found --
+ * otherwise the branch would under-report the size and reads of inherited
+ * blocks would look out of range.
+ *
+ * (Prototype limitation: nblocks is not itself versioned, so if the parent
+ * *grows* a fork after the branch point the branch sees the larger size; for a
+ * quiescent parent -- the usual branch case -- this is correct.)
+ */
 static uint32_t
 fork_nblocks_through(uint32_t timeline, const PsKey *key)
 {
+	uint32_t	maxnb = 0;
+
 	for (;;)
 	{
 		ForkEnt    *e = fork_find(timeline, key);
 
-		if (e)
-			return e->nblocks;
+		if (e && e->nblocks > maxnb)
+			maxnb = e->nblocks;
 		if (!timeline_has_parent(timeline))
-			return 0;
+			return maxnb;
 		timeline = (uint32_t) timelines[timeline].parent;
 	}
 }

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 #define PS_SHM_MAGIC		0x50414753	/* "PAGS" */
-#define PS_SHM_VERSION		2
+#define PS_SHM_VERSION		3
 
 /* Default logical page size (overridable via the daemon's --page-size). */
 #define PS_DEFAULT_PAGE_SIZE	8192
@@ -65,6 +65,7 @@ typedef enum PsOpcode
 	PS_OP_READV,				/* read nblocks pages at blocknum into data */
 	PS_OP_IMMEDSYNC,
 	PS_OP_READ_AT,				/* read 1 page at blocknum as-of req_lsn (COW) */
+	PS_OP_CREATE_BRANCH,		/* create timeline from parent_timeline @ req_lsn */
 } PsOpcode;
 
 /* Status codes */
@@ -93,8 +94,9 @@ typedef struct PsChannel
 	uint32_t	blocknum;
 	uint32_t	nblocks;
 	uint32_t	old_nblocks;
-	uint32_t	pad0;
-	uint64_t	req_lsn;		/* READ_AT: snapshot LSN to read as-of */
+	uint32_t	timeline;		/* timeline this op targets (0 = main) */
+	uint32_t	parent_timeline;	/* CREATE_BRANCH: parent timeline */
+	uint64_t	req_lsn;		/* READ_AT: as-of LSN; CREATE_BRANCH: branch LSN */
 	PsKey		key;
 
 	/* result */

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -153,6 +153,7 @@ cl_setkey(PsChannel *ch, uint32_t rel, int32_t fork)
 	ch->key.dbOid = 1;
 	ch->key.relNumber = rel;
 	ch->key.forkNum = fork;
+	ch->timeline = 0;			/* default to the main timeline */
 }
 
 /* --- typed operations --- */
@@ -253,6 +254,69 @@ op_read_at(uint32_t rel, int32_t fork, uint32_t block, uint64_t lsn,
 	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
 
 	cl_setkey(ch, rel, fork);
+	ch->opcode = PS_OP_READ_AT;
+	ch->blocknum = block;
+	ch->req_lsn = lsn;
+	cl_exec();
+	memcpy(out, ch->data, cl_page_size);
+}
+
+/* --- timeline-aware operations (for branch tests) --- */
+
+/* Create timeline new_tl as a branch of parent_tl forked at branch_lsn. */
+static void
+op_create_branch(uint32_t new_tl, uint32_t parent_tl, uint64_t branch_lsn)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	ch->opcode = PS_OP_CREATE_BRANCH;
+	ch->timeline = new_tl;
+	ch->parent_timeline = parent_tl;
+	ch->req_lsn = branch_lsn;
+	cl_exec();
+}
+
+/* Write one page on a specific timeline. */
+static void
+op_write_tl(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
+			const unsigned char *page)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	cl_setkey(ch, rel, fork);
+	ch->timeline = tl;
+	ch->opcode = PS_OP_WRITEV;
+	ch->blocknum = block;
+	ch->nblocks = 1;
+	memcpy(ch->data, page, cl_page_size);
+	cl_exec();
+}
+
+/* Read one page (current) on a specific timeline. */
+static void
+op_read_tl(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
+		   unsigned char *out)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	cl_setkey(ch, rel, fork);
+	ch->timeline = tl;
+	ch->opcode = PS_OP_READV;
+	ch->blocknum = block;
+	ch->nblocks = 1;
+	cl_exec();
+	memcpy(out, ch->data, cl_page_size);
+}
+
+/* Read one page as-of an LSN on a specific timeline. */
+static void
+op_read_at_tl(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
+			  uint64_t lsn, unsigned char *out)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	cl_setkey(ch, rel, fork);
+	ch->timeline = tl;
 	ch->opcode = PS_OP_READ_AT;
 	ch->blocknum = block;
 	ch->req_lsn = lsn;
@@ -363,6 +427,7 @@ stop_daemon(pid_t pid)
 /* ===================== the test suite ================================== */
 
 #define REL_A	16000
+#define REL_B	17000
 #define FORK0	0
 
 static void
@@ -470,6 +535,101 @@ run_suite(const char *daemon_path, const char *tmpbase, uint32_t page_size)
 	free(rb);
 }
 
+/*
+ * Branch / snapshot isolation: a branch is an instant, copy-on-write clone.
+ * It shares the parent's pages by read-through until it writes; its writes do
+ * not affect the parent or sibling branches; and it sees the parent frozen at
+ * the branch LSN, not the parent's later writes.
+ */
+static void
+run_branch_suite(const char *daemon_path, const char *tmpbase)
+{
+	char		shm[64];
+	char		store[256];
+	pid_t		dpid;
+	uint32_t	ps = 8192;
+	unsigned char *p,
+			   *rb;
+
+	fprintf(stderr, "== branches ==\n");
+
+	snprintf(shm, sizeof(shm), "/pstest_%d_br", (int) getpid());
+	snprintf(store, sizeof(store), "%s/store_br", tmpbase);
+	rm_rf(store);
+	shm_unlink(shm);
+
+	p = malloc(ps);
+	rb = malloc(ps);
+
+	dpid = spawn_daemon(daemon_path, shm, store, ps);
+	wait_ready(shm, ps);
+	client_attach(shm, ps);
+
+	/* base data on the main timeline (block 0 = tag 11 @ lsn 1000) */
+	fill_page(p, ps, 1000, 11);
+	op_write_tl(0, REL_B, FORK0, 0, p);
+
+	/* branch T1 off main at LSN 1500 -- instant, no data copied */
+	op_create_branch(1, 0, 1500);
+	op_read_tl(1, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 11), "branch sees parent page via read-through (no copy)");
+
+	/* writing on T1 diverges it (copy-on-write) */
+	fill_page(p, ps, 2000, 22);
+	op_write_tl(1, REL_B, FORK0, 0, p);
+	op_read_tl(1, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 22), "branch read sees its own write");
+	op_read_tl(0, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 11), "parent unaffected by branch write (isolation)");
+
+	/* a second, independent branch off main */
+	op_create_branch(2, 0, 1500);
+	op_read_tl(2, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 11), "second branch independent, sees parent");
+	fill_page(p, ps, 3000, 33);
+	op_write_tl(2, REL_B, FORK0, 0, p);
+	op_read_tl(2, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 33), "T2 read sees T2 write");
+	op_read_tl(1, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 22), "T1 unaffected by T2 (three-way isolation)");
+	op_read_tl(0, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 11), "main unaffected by T1/T2");
+
+	/* as-of read on a branch, before its own write, falls through to parent */
+	op_read_at_tl(1, REL_B, FORK0, 0, 1900, rb);
+	check(page_has_tag(rb, ps, 11), "as-of read on branch before its write -> parent");
+
+	/* snapshot semantics: parent evolves after the branch point (LSN > 1500) */
+	fill_page(p, ps, 1200, 51);
+	op_write_tl(0, REL_B, FORK0, 5, p);		/* block5 @ lsn 1200 (< branch) */
+	fill_page(p, ps, 2000, 52);
+	op_write_tl(0, REL_B, FORK0, 5, p);		/* block5 @ lsn 2000 (> branch) */
+	op_read_tl(1, REL_B, FORK0, 5, rb);
+	check(page_has_tag(rb, ps, 51),
+		  "branch sees parent as-of branch LSN, not later writes (snapshot)");
+	op_read_tl(0, REL_B, FORK0, 5, rb);
+	check(page_has_tag(rb, ps, 52), "main sees its latest write to block5");
+
+	/* branches survive a daemon restart (timeline metadata is persisted) */
+	client_detach();
+	stop_daemon(dpid);
+	shm_unlink(shm);
+	dpid = spawn_daemon(daemon_path, shm, store, ps);
+	wait_ready(shm, ps);
+	client_attach(shm, ps);
+	op_read_tl(1, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 22), "branch write survives daemon restart");
+	op_read_tl(1, REL_B, FORK0, 5, rb);
+	check(page_has_tag(rb, ps, 51), "branch snapshot view survives restart");
+
+	client_detach();
+	stop_daemon(dpid);
+	rm_rf(store);
+	shm_unlink(shm);
+	free(p);
+	free(rb);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -495,6 +655,9 @@ main(int argc, char **argv)
 	/* run the whole suite once per page size: proves page-size independence */
 	for (size_t i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++)
 		run_suite(daemon_path, tmpbase, sizes[i]);
+
+	/* branch / snapshot isolation (page-size independent, run once) */
+	run_branch_suite(daemon_path, tmpbase);
 
 	rmdir(tmpbase);
 

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -276,6 +276,19 @@ op_create_branch(uint32_t new_tl, uint32_t parent_tl, uint64_t branch_lsn)
 	cl_exec();
 }
 
+/* Like op_create_branch but returns the daemon's status (for negative tests). */
+static int
+op_create_branch_status(uint32_t new_tl, uint32_t parent_tl, uint64_t branch_lsn)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	ch->opcode = PS_OP_CREATE_BRANCH;
+	ch->timeline = new_tl;
+	ch->parent_timeline = parent_tl;
+	ch->req_lsn = branch_lsn;
+	return cl_exec()->status;
+}
+
 /* Write one page on a specific timeline. */
 static void
 op_write_tl(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
@@ -621,6 +634,21 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 	check(page_has_tag(rb, ps, 22), "branch write survives daemon restart");
 	op_read_tl(1, REL_B, FORK0, 5, rb);
 	check(page_has_tag(rb, ps, 51), "branch snapshot view survives restart");
+
+	/* CREATE_BRANCH validation: reject requests that would corrupt the parent
+	 * walk (timelines 0,1,2 are defined here) */
+	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_ERROR,
+		  "reject re-creating an existing timeline id");
+	check(op_create_branch_status(9, 900, 1500) == PS_STATUS_ERROR,
+		  "reject branch off an undefined parent");
+	check(op_create_branch_status(9, 9, 1500) == PS_STATUS_ERROR,
+		  "reject self-parent (would loop the read path)");
+	check(op_create_branch_status(0, 0, 1500) == PS_STATUS_ERROR,
+		  "reject redefining the root timeline");
+	check(op_create_branch_status(7, 2, 1500) == PS_STATUS_OK,
+		  "valid branch off a defined branch still accepted");
+	op_read_tl(7, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 11), "new valid branch reads through to root");
 
 	client_detach();
 	stop_daemon(dpid);


### PR DESCRIPTION
## What

Adds **instant copy-on-write branches** (timelines / snapshots / clones) to the
page store — the headline COW capability. Builds on the versioned store from
the previous PR.

A branch is a new timeline forked from a parent at a given LSN:
- **Instant**: `CREATE_BRANCH` records metadata only — O(1), no page data copied.
- **Shared until written**: reads walk the timeline ancestry (`read_through`) —
  a page the branch never wrote is served from the parent, with the read LSN
  capped at the branch point. So a branch is a **frozen snapshot** of its parent
  and shares unmodified pages at zero cost.
- **Isolated on write**: a write tags the version with its timeline, so it never
  disturbs the parent or sibling branches (copy-on-write).

## Changes
- **IPC**: requests carry a `timeline`; new `PS_OP_CREATE_BRANCH`; `SegRecHdr`
  gains a timeline tag; shm version → 3.
- **Daemon**: index keyed by `(timeline, key, block)`; `read_through()` resolves
  reads up the ancestry; timeline metadata persisted to a `timelines` file
  (branches survive a daemon restart).
- **PostgreSQL side**: `pagestore.timeline` GUC pins a backend to a branch;
  `pagestore_create_branch(new, parent, lsn)` SQL function creates one.

## Testing
- **Standalone** (`meson test --suite pagestore`, also in CI, no PostgreSQL):
  branch suite added — read-through sharing, COW divergence, three-way isolation,
  snapshot semantics (parent writes after the branch point stay invisible), as-of
  reads on a branch, and branch survival across a daemon restart. **76 checks
  across page sizes 4K/8K/16K, all pass.**
- **In-engine smoke**: `pagestore_create_branch(1, 0, pg_current_wal_lsn())`
  executes and the daemon persists the branch record.

## Not in this PR (follow-on)
Running a full PostgreSQL compute *on* a branch needs the whole database
(catalogs included) on the page store, i.e. full `route_all` + bootstrap
support. This PR delivers the store-level branch capability and the plumbing;
the compute-on-branch wiring is the next milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)