### PR TITLE
contrib/pagestore: whole-database routing + compute-on-branch

### DIFF
--- a/contrib/pagestore/compute_on_branch_demo.sh
+++ b/contrib/pagestore/compute_on_branch_demo.sh
@@ -28,9 +28,17 @@ set -euo pipefail
 
 BUILD=${1:?usage: compute_on_branch_demo.sh <meson-build-dir>}
 SRC=$(cd "$(dirname "$0")/../.." && pwd)
-ROOT="$BUILD/tmp_install$BUILD/install"
-BIN="$ROOT/bin"
-export LD_LIBRARY_PATH="$ROOT/lib64"
+
+# Locate the installed binaries under the meson tmp_install tree by finding
+# pg_ctl, rather than hard-coding the install prefix (which varies by build).
+PGCTL=$(find "$BUILD/tmp_install" -path '*/bin/pg_ctl' 2>/dev/null | head -1)
+if [ -z "$PGCTL" ]; then
+	echo "could not find pg_ctl under $BUILD/tmp_install (run 'meson install' / a build that stages tmp_install)" >&2
+	exit 1
+fi
+BIN=$(dirname "$PGCTL")
+ROOT=$(dirname "$BIN")
+export LD_LIBRARY_PATH="$ROOT/lib64:$ROOT/lib"
 
 DAEMON="$BUILD/contrib/pagestore/pagestore_daemon"
 IMPORT="$BUILD/contrib/pagestore/pagestore_import"

--- a/contrib/pagestore/compute_on_branch_demo.sh
+++ b/contrib/pagestore/compute_on_branch_demo.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# compute_on_branch_demo.sh -- demonstrate a whole PostgreSQL database running
+# on the pagestore, branched, with a single compute switching between the main
+# timeline and a branch.
+#
+# This is a manual demo (not a CI test): it needs a full PostgreSQL build and
+# runs real initdb / postgres.  Pass the meson build directory as $1.
+#
+#   contrib/pagestore/compute_on_branch_demo.sh /path/to/build
+#
+# What it shows:
+#   - initdb a cluster, then import its entire relation set into the daemon
+#     (timeline 0) so the whole database -- catalogs included -- lives on the
+#     page store.
+#   - start PostgreSQL with pagestore.route_all=on: every relation is read from
+#     and written to the store.
+#   - create a branch (instant, copy-on-write), then restart the *same* compute
+#     onto the branch by changing pagestore.timeline.  The branch sees a clone
+#     of the database; writes on the branch do not affect the main timeline.
+#
+# Scope / limitations: WAL, pg_control and SLRU (clog) are NOT branched -- they
+# stay in the local PGDATA -- so this works for a single compute switching
+# timelines across *clean* restarts, not for multiple concurrent computes.
+# Independent concurrent computes on different branches need WAL shipping.
+#
+set -euo pipefail
+
+BUILD=${1:?usage: compute_on_branch_demo.sh <meson-build-dir>}
+SRC=$(cd "$(dirname "$0")/../.." && pwd)
+ROOT="$BUILD/tmp_install$BUILD/install"
+BIN="$ROOT/bin"
+export LD_LIBRARY_PATH="$ROOT/lib64"
+
+DAEMON="$BUILD/contrib/pagestore/pagestore_daemon"
+IMPORT="$BUILD/contrib/pagestore/pagestore_import"
+
+DATA=$(mktemp -d)/pgdata
+STORE=$(mktemp -d)/store
+SHM=/pscob_$$
+PORT=54450
+P="$BIN/psql -p $PORT -U postgres -tA"
+
+cleanup() {
+	"$BIN/pg_ctl" -D "$DATA" -m immediate -w stop >/dev/null 2>&1 || true
+	[ -n "${DPID:-}" ] && kill "$DPID" 2>/dev/null || true
+	rm -rf "$(dirname "$DATA")" "$(dirname "$STORE")"
+	rm -f "/dev/shm$SHM"
+}
+trap cleanup EXIT
+
+restart_tl() {  # $1 = timeline
+	"$BIN/pg_ctl" -D "$DATA" -m fast -w stop >/dev/null 2>&1
+	sed -i "s/^pagestore.timeline = .*/pagestore.timeline = $1/" "$DATA/postgresql.conf"
+	"$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
+}
+
+"$BIN/initdb" -D "$DATA" -U postgres -A trust >/dev/null 2>&1
+echo "initdb done"
+
+"$DAEMON" --shm "$SHM" --store "$STORE" >/dev/null 2>&1 &
+DPID=$!
+sleep 0.5
+
+"$IMPORT" --shm "$SHM" --pgdata "$DATA" >/dev/null 2>&1
+echo "whole database imported to page store (timeline 0)"
+
+cat >> "$DATA/postgresql.conf" <<EOF
+shared_preload_libraries = 'pagestore'
+pagestore.route_all = on
+pagestore.backend = 'localsvc'
+pagestore.localsvc_shm = '$SHM'
+pagestore.timeline = 0
+io_method = sync
+port = $PORT
+EOF
+
+"$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
+echo "PostgreSQL running entirely on the page store (timeline 0)"
+
+$P -c "CREATE FUNCTION pagestore_create_branch(int,int,pg_lsn) RETURNS void AS 'pagestore','pagestore_create_branch' LANGUAGE C STRICT;" >/dev/null
+$P -c "CREATE TABLE demo(id int primary key, note text); INSERT INTO demo VALUES (1,'main-v1'); CHECKPOINT;" >/dev/null
+$P -c "SELECT pagestore_create_branch(1, 0, pg_current_wal_lsn());" >/dev/null
+echo "branch 1 created at the current LSN"
+
+echo "  [1] timeline 0, initial          : $($P -c 'SELECT note FROM demo WHERE id=1;')   (expect main-v1)"
+restart_tl 1
+echo "  [2] switch to branch 1 (clone)   : $($P -c 'SELECT note FROM demo WHERE id=1;')   (expect main-v1)"
+$P -c "UPDATE demo SET note='branch-v2' WHERE id=1; CHECKPOINT;" >/dev/null
+echo "  [3] modify on branch 1           : $($P -c 'SELECT note FROM demo WHERE id=1;')   (expect branch-v2)"
+restart_tl 0
+echo "  [4] back to timeline 0 (isolated): $($P -c 'SELECT note FROM demo WHERE id=1;')   (expect main-v1)"
+restart_tl 1
+echo "  [5] branch 1 again (persisted)   : $($P -c 'SELECT note FROM demo WHERE id=1;')   (expect branch-v2)"
+
+echo "compute-on-branch demo OK"

--- a/contrib/pagestore/meson.build
+++ b/contrib/pagestore/meson.build
@@ -26,6 +26,14 @@ pagestore_daemon = executable('pagestore_daemon',
 )
 contrib_targets += pagestore_daemon
 
+# Import an existing PGDATA's relation files into the daemon, so a whole
+# database can be moved onto the page store.  Freestanding like the daemon.
+pagestore_import = executable('pagestore_import',
+  files('pagestore_import.c'),
+  kwargs: default_bin_args,
+)
+contrib_targets += pagestore_import
+
 # Standalone test harness: drives the daemon over the shared-memory protocol
 # with no PostgreSQL instance.  Run independently of the PG test suites with:
 #   meson test -C <build> --suite pagestore

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -361,6 +361,35 @@ timeline_has_parent(uint32_t timeline)
 }
 
 /*
+ * Validate a branch-creation request before it is recorded.  read_through() and
+ * the fork-size walks follow the parent chain assuming it is finite and well
+ * formed, so a bad CREATE_BRANCH must be rejected rather than persisted.  Refuse:
+ *	- a new id that is out of range, the root (0), or already defined (otherwise
+ *	  re-creating an id silently rewrites an existing branch's ancestry);
+ *	- a parent that is out of range or not yet defined (the requested parent must
+ *	  actually exist, else the branch silently inherits from nothing);
+ *	- a parent whose ancestry already reaches the new id, which would turn the
+ *	  parent walk into an infinite loop (e.g. new == parent, or A->B->A).
+ * Returns 1 if (new_tl, parent) is safe to define.
+ */
+static int
+branch_request_ok(uint32_t new_tl, int parent)
+{
+	if (new_tl == 0 || new_tl >= MAX_TIMELINES || timelines[new_tl].defined)
+		return 0;
+	if (parent < 0 || parent >= MAX_TIMELINES || !timelines[parent].defined)
+		return 0;
+	for (int t = parent; t >= 0 && t < MAX_TIMELINES; t = timelines[t].parent)
+	{
+		if ((uint32_t) t == new_tl)
+			return 0;			/* cycle */
+		if (!timelines[t].defined)
+			return 0;			/* broken chain: refuse rather than risk a loop */
+	}
+	return 1;
+}
+
+/*
  * Resolve a read by walking the timeline ancestry: return the newest version of
  * (key, block) visible at read_lsn on 'timeline'; if the timeline never wrote
  * the page (or only after read_lsn), descend to the parent, capping read_lsn at
@@ -694,15 +723,15 @@ handle_request(PsChannel *ch)
 			 * copied -- the branch shares the parent's pages by read-through
 			 * until it writes (copy-on-write).
 			 */
-			if (ch->timeline == 0 || ch->timeline >= MAX_TIMELINES)
-				ch->status = PS_STATUS_ERROR;
-			else
+			if (branch_request_ok(ch->timeline, (int) ch->parent_timeline))
 			{
 				timeline_define(ch->timeline, (int) ch->parent_timeline,
 								ch->req_lsn);
 				timeline_persist(ch->timeline, (int) ch->parent_timeline,
 								 ch->req_lsn);
 			}
+			else
+				ch->status = PS_STATUS_ERROR;
 			break;
 
 		case PS_OP_IMMEDSYNC:

--- a/contrib/pagestore/pagestore_import.c
+++ b/contrib/pagestore/pagestore_import.c
@@ -15,6 +15,11 @@
  * blocks to the daemon over the shared-memory protocol -- exactly the keys the
  * smgr shim will later use.  Freestanding: only pagestore_ipc.h and libc.
  *
+ * Limitation: only the default tablespace (base/) and shared catalogs (global/)
+ * are imported; relations in user-created tablespaces (pg_tblspc/<oid>/...) are
+ * not, and would be missing under route_all.  The tool warns if any exist.  Use
+ * the default tablespace, or extend the walk to resolve pg_tblspc links.
+ *
  * Usage: pagestore_import --shm NAME --pgdata DIR [--page-size N]
  *
  * src/../contrib/pagestore/pagestore_import.c
@@ -23,6 +28,7 @@
  */
 #include <ctype.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,10 +70,13 @@ client_attach(const char *shm_name)
 	}
 	close(fd);
 	hdr = (PsShmHeader *) shm;
-	if (hdr->magic != PS_SHM_MAGIC || hdr->page_size != page_size)
+	if (hdr->magic != PS_SHM_MAGIC || hdr->version != PS_SHM_VERSION ||
+		hdr->page_size != page_size)
 	{
-		fprintf(stderr, "shm header mismatch (daemon page_size=%u, expected %u)\n",
-				hdr->page_size, page_size);
+		fprintf(stderr, "shm header mismatch (daemon magic=0x%x version=%u "
+				"page_size=%u; expected version=%u page_size=%u)\n",
+				hdr->magic, hdr->version, hdr->page_size,
+				PS_SHM_VERSION, page_size);
 		exit(2);
 	}
 	for (uint32_t i = 0; i < hdr->nchannels; i++)
@@ -204,10 +213,15 @@ import_dir(const char *dirpath, uint32_t spc, uint32_t db)
 
 		put_create(spc, db, rel, fork);
 
-		while ((n = read(fd, page, page_size)) > 0)
+		while ((n = read(fd, page, page_size)) != 0)
 		{
 			uint32_t	block;
 
+			if (n < 0)			/* I/O error: abort rather than import partially */
+			{
+				fprintf(stderr, "read %s: %s\n", path, strerror(errno));
+				exit(2);
+			}
 			if ((uint32_t) n < page_size)	/* pad a short trailing block */
 				memset((char *) page + n, 0, page_size - n);
 			block = seg * seg_blocks + local_blk;
@@ -275,6 +289,29 @@ main(int argc, char **argv)
 			import_dir(dbpath, DEFAULTTABLESPACE_OID, db);
 		}
 		closedir(based);
+	}
+
+	/*
+	 * Limitation: only the default tablespace (base/) and shared catalogs
+	 * (global/) are imported.  Relations in user-created tablespaces live under
+	 * pg_tblspc/<oid>/... and are NOT walked, so route_all=on would miss them.
+	 * Warn loudly rather than silently produce a partial import.
+	 */
+	snprintf(path, sizeof(path), "%s/pg_tblspc", pgdata);
+	based = opendir(path);
+	if (based)
+	{
+		int			n = 0;
+
+		while ((de = readdir(based)) != NULL)
+			if (de->d_name[0] != '.')
+				n++;
+		closedir(based);
+		if (n > 0)
+			fprintf(stderr, "pagestore_import: WARNING: %d user tablespace(s) in "
+					"pg_tblspc are NOT imported; relations there will be missing "
+					"under route_all (unsupported -- use the default tablespace)\n",
+					n);
 	}
 
 	fprintf(stderr, "pagestore_import: done (%s -> timeline 0)\n", pgdata);

--- a/contrib/pagestore/pagestore_import.c
+++ b/contrib/pagestore/pagestore_import.c
@@ -1,0 +1,282 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_import.c
+ *	  Import an existing PostgreSQL data directory's relation files into the
+ *	  pagestore daemon (timeline 0).
+ *
+ * This bootstraps "whole-database on the page store" without needing the
+ * library loaded during initdb: run initdb normally, start the daemon, then
+ * import.  Afterwards PostgreSQL can run with pagestore.route_all = on and read
+ * every relation (catalogs included) from the store.
+ *
+ * It walks the per-database directories under PGDATA/base and the shared
+ * PGDATA/global directory, parses each relation file name into
+ * (tablespace, database, relfilenode, fork, segment), and writes its
+ * blocks to the daemon over the shared-memory protocol -- exactly the keys the
+ * smgr shim will later use.  Freestanding: only pagestore_ipc.h and libc.
+ *
+ * Usage: pagestore_import --shm NAME --pgdata DIR [--page-size N]
+ *
+ * src/../contrib/pagestore/pagestore_import.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <ctype.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "pagestore_ipc.h"
+
+/* Physical tablespace OIDs (stable PostgreSQL constants). */
+#define DEFAULTTABLESPACE_OID	1663
+#define GLOBALTABLESPACE_OID	1664
+
+/* Blocks per 1GB segment in a default build (RELSEG_SIZE for the page size). */
+static uint32_t seg_blocks;
+static uint32_t page_size = PS_DEFAULT_PAGE_SIZE;
+
+/* shared-memory client state */
+static void *shm;
+static int	chan;
+
+static void
+client_attach(const char *shm_name)
+{
+	int			fd = shm_open(shm_name, O_RDWR, 0600);
+	PsShmHeader *hdr;
+
+	if (fd < 0)
+	{
+		perror("shm_open (is the daemon running?)");
+		exit(2);
+	}
+	shm = mmap(NULL, PS_SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (shm == MAP_FAILED)
+	{
+		perror("mmap");
+		exit(2);
+	}
+	close(fd);
+	hdr = (PsShmHeader *) shm;
+	if (hdr->magic != PS_SHM_MAGIC || hdr->page_size != page_size)
+	{
+		fprintf(stderr, "shm header mismatch (daemon page_size=%u, expected %u)\n",
+				hdr->page_size, page_size);
+		exit(2);
+	}
+	for (uint32_t i = 0; i < hdr->nchannels; i++)
+		if (ps_cas(&ps_channel(shm, i)->claimed, 0, 1))
+		{
+			chan = (int) i;
+			return;
+		}
+	fprintf(stderr, "no free channel\n");
+	exit(2);
+}
+
+static void
+cl_exec(PsChannel *ch)
+{
+	ps_store_release(&ch->state, PS_STATE_REQUEST);
+	while (ps_load_acquire(&ch->state) != PS_STATE_DONE)
+		;
+	if (ch->status != PS_STATUS_OK)
+	{
+		fprintf(stderr, "daemon error on op %u\n", ch->opcode);
+		exit(1);
+	}
+}
+
+static void
+put_create(uint32_t spc, uint32_t db, uint32_t rel, int32_t fork)
+{
+	PsChannel  *ch = ps_channel(shm, chan);
+
+	ch->timeline = 0;
+	ch->key.spcOid = spc;
+	ch->key.dbOid = db;
+	ch->key.relNumber = rel;
+	ch->key.forkNum = fork;
+	ch->opcode = PS_OP_CREATE;
+	cl_exec(ch);
+}
+
+static void
+put_block(uint32_t spc, uint32_t db, uint32_t rel, int32_t fork,
+		  uint32_t block, const void *page)
+{
+	PsChannel  *ch = ps_channel(shm, chan);
+
+	ch->timeline = 0;
+	ch->key.spcOid = spc;
+	ch->key.dbOid = db;
+	ch->key.relNumber = rel;
+	ch->key.forkNum = fork;
+	ch->opcode = PS_OP_WRITEV;
+	ch->blocknum = block;
+	ch->nblocks = 1;
+	memcpy(ch->data, page, page_size);
+	cl_exec(ch);
+}
+
+/*
+ * Parse a relation file name into relfilenode, fork and segment.
+ * Forms: "<n>", "<n>.<seg>", "<n>_fsm[.<seg>]", "<n>_vm[.<seg>]",
+ * "<n>_init[.<seg>]".  Returns 0 on success, -1 if not a relation file.
+ */
+static int
+parse_relfile(const char *name, uint32_t *rel, int32_t *fork, uint32_t *seg)
+{
+	char		buf[256];
+	char	   *dot,
+			   *us;
+
+	if (!isdigit((unsigned char) name[0]))
+		return -1;
+	if (strlen(name) >= sizeof(buf))
+		return -1;
+	strcpy(buf, name);
+
+	*seg = 0;
+	dot = strchr(buf, '.');
+	if (dot)
+	{
+		*seg = (uint32_t) strtoul(dot + 1, NULL, 10);
+		*dot = '\0';
+	}
+
+	*fork = 0;					/* MAIN_FORKNUM */
+	us = strchr(buf, '_');
+	if (us)
+	{
+		if (strcmp(us, "_fsm") == 0)
+			*fork = 1;			/* FSM_FORKNUM */
+		else if (strcmp(us, "_vm") == 0)
+			*fork = 2;			/* VISIBILITYMAP_FORKNUM */
+		else if (strcmp(us, "_init") == 0)
+			*fork = 3;			/* INIT_FORKNUM */
+		else
+			return -1;			/* unknown suffix */
+		*us = '\0';
+	}
+
+	for (char *p = buf; *p; p++)
+		if (!isdigit((unsigned char) *p))
+			return -1;			/* not a pure relfilenode */
+	*rel = (uint32_t) strtoul(buf, NULL, 10);
+	return 0;
+}
+
+/* Import every relation file in one directory (one database, or global/). */
+static void
+import_dir(const char *dirpath, uint32_t spc, uint32_t db)
+{
+	DIR		   *d = opendir(dirpath);
+	struct dirent *de;
+	void	   *page = malloc(page_size);
+
+	if (!d)
+		return;
+
+	while ((de = readdir(d)) != NULL)
+	{
+		char		path[8192];
+		uint32_t	rel,
+					seg;
+		int32_t		fork;
+		int			fd;
+		ssize_t		n;
+		uint32_t	local_blk = 0;
+
+		if (parse_relfile(de->d_name, &rel, &fork, &seg) != 0)
+			continue;
+
+		snprintf(path, sizeof(path), "%s/%s", dirpath, de->d_name);
+		fd = open(path, O_RDONLY);
+		if (fd < 0)
+			continue;
+
+		put_create(spc, db, rel, fork);
+
+		while ((n = read(fd, page, page_size)) > 0)
+		{
+			uint32_t	block;
+
+			if ((uint32_t) n < page_size)	/* pad a short trailing block */
+				memset((char *) page + n, 0, page_size - n);
+			block = seg * seg_blocks + local_blk;
+			put_block(spc, db, rel, fork, block, page);
+			local_blk++;
+		}
+		close(fd);
+	}
+	closedir(d);
+	free(page);
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *shm_name = NULL;
+	const char *pgdata = NULL;
+	char		path[8192];
+	DIR		   *based;
+	struct dirent *de;
+
+	for (int i = 1; i < argc; i++)
+	{
+		if (strcmp(argv[i], "--shm") == 0 && i + 1 < argc)
+			shm_name = argv[++i];
+		else if (strcmp(argv[i], "--pgdata") == 0 && i + 1 < argc)
+			pgdata = argv[++i];
+		else if (strcmp(argv[i], "--page-size") == 0 && i + 1 < argc)
+			page_size = (uint32_t) strtoul(argv[++i], NULL, 10);
+		else
+		{
+			fprintf(stderr, "usage: %s --shm NAME --pgdata DIR [--page-size N]\n",
+					argv[0]);
+			return 2;
+		}
+	}
+	if (!shm_name || !pgdata)
+	{
+		fprintf(stderr, "usage: %s --shm NAME --pgdata DIR [--page-size N]\n",
+				argv[0]);
+		return 2;
+	}
+	seg_blocks = (uint32_t) ((1024ULL * 1024 * 1024) / page_size);
+
+	client_attach(shm_name);
+
+	/* shared catalogs in global/ (tablespace 1664, database 0) */
+	snprintf(path, sizeof(path), "%s/global", pgdata);
+	import_dir(path, GLOBALTABLESPACE_OID, 0);
+
+	/* per-database relations in base/<dboid>/ (default tablespace 1663) */
+	snprintf(path, sizeof(path), "%s/base", pgdata);
+	based = opendir(path);
+	if (based)
+	{
+		while ((de = readdir(based)) != NULL)
+		{
+			char		dbpath[8192];
+			uint32_t	db;
+
+			if (!isdigit((unsigned char) de->d_name[0]))
+				continue;
+			db = (uint32_t) strtoul(de->d_name, NULL, 10);
+			snprintf(dbpath, sizeof(dbpath), "%s/base/%s", pgdata, de->d_name);
+			import_dir(dbpath, DEFAULTTABLESPACE_OID, db);
+		}
+		closedir(based);
+	}
+
+	fprintf(stderr, "pagestore_import: done (%s -> timeline 0)\n", pgdata);
+	return 0;
+}

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -276,6 +276,19 @@ op_create_branch(uint32_t new_tl, uint32_t parent_tl, uint64_t branch_lsn)
 	cl_exec();
 }
 
+/* Like op_create_branch but returns the daemon's status (for negative tests). */
+static int
+op_create_branch_status(uint32_t new_tl, uint32_t parent_tl, uint64_t branch_lsn)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	ch->opcode = PS_OP_CREATE_BRANCH;
+	ch->timeline = new_tl;
+	ch->parent_timeline = parent_tl;
+	ch->req_lsn = branch_lsn;
+	return cl_exec()->status;
+}
+
 /* Write one page on a specific timeline. */
 static void
 op_write_tl(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
@@ -621,6 +634,21 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 	check(page_has_tag(rb, ps, 22), "branch write survives daemon restart");
 	op_read_tl(1, REL_B, FORK0, 5, rb);
 	check(page_has_tag(rb, ps, 51), "branch snapshot view survives restart");
+
+	/* CREATE_BRANCH validation: reject requests that would corrupt the parent
+	 * walk (timelines 0,1,2 are defined here) */
+	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_ERROR,
+		  "reject re-creating an existing timeline id");
+	check(op_create_branch_status(9, 900, 1500) == PS_STATUS_ERROR,
+		  "reject branch off an undefined parent");
+	check(op_create_branch_status(9, 9, 1500) == PS_STATUS_ERROR,
+		  "reject self-parent (would loop the read path)");
+	check(op_create_branch_status(0, 0, 1500) == PS_STATUS_ERROR,
+		  "reject redefining the root timeline");
+	check(op_create_branch_status(7, 2, 1500) == PS_STATUS_OK,
+		  "valid branch off a defined branch still accepted");
+	op_read_tl(7, REL_B, FORK0, 0, rb);
+	check(page_has_tag(rb, ps, 11), "new valid branch reads through to root");
 
 	client_detach();
 	stop_daemon(dpid);


### PR DESCRIPTION
Stacked on #3 (branches). Base will retarget to `branchdb_18` once #3 merges.

## What

Makes an **entire PostgreSQL database run on the page store** and demonstrates
a single compute being **branched** — the user-visible payoff of the COW work.

- **`pagestore_import`**: loads an existing `PGDATA`'s whole relation set
  (catalogs + data, `base/<db>/*` and `global/*`) into the daemon's timeline 0.
  Bootstrap can't load `shared_preload_libraries`, so this is how a cluster
  gets onto the store without patching initdb.
- With `pagestore.route_all = on`, PostgreSQL then reads/writes **every**
  relation from the store. A branch (`pagestore_create_branch`) is an instant
  clone; restarting the compute with a different `pagestore.timeline` runs it on
  that branch.
- **Bug fix** (in the base branch commit): `fork_nblocks_through()` now spans
  the timeline ancestry, so a branch that wrote only some blocks of a fork still
  inherits the parent's full size. Without this, opening a partially
  hint-bit-dirtied system index after switching onto a branch PANICked.

## Demo (`compute_on_branch_demo.sh`, verified)
initdb → import → run on store (t0) → create branch 1 → switch timelines:
```
[1] timeline 0, initial          : main-v1
[2] switch to branch 1 (clone)   : main-v1     # branch sees the whole DB
[3] modify on branch 1           : branch-v2
[4] back to timeline 0 (isolated): main-v1     # main unaffected
[5] branch 1 again (persisted)   : branch-v2   # branch divergence persists
```

## Scope / limitations
WAL, `pg_control` and SLRU (clog) stay in the local `PGDATA` and are **not**
branched. So this is one compute switching timelines across **clean** restarts,
not multiple concurrent computes. Independent concurrent computes on different
branches need WAL shipping (the next milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)