### PR TITLE
contrib/pagestore: WAL shipping (transport + durability) and broader tests

### DIFF
--- a/.github/workflows/pagestore-test.yml
+++ b/.github/workflows/pagestore-test.yml
@@ -62,3 +62,6 @@ jobs:
 
       - name: Run WAL-redo worker demo
         run: contrib/pagestore/redo_worker_demo.sh "$(pwd)/build"
+
+      - name: Run WAL-only (non-redundant) redo demo
+        run: contrib/pagestore/wal_only_redo_demo.sh "$(pwd)/build"

--- a/.github/workflows/pagestore-test.yml
+++ b/.github/workflows/pagestore-test.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: Run pagestore integration test
         run: contrib/pagestore/integration_test.sh "$(pwd)/build"
+
+      - name: Run WAL-redo worker demo
+        run: contrib/pagestore/redo_worker_demo.sh "$(pwd)/build"

--- a/.github/workflows/pagestore-test.yml
+++ b/.github/workflows/pagestore-test.yml
@@ -34,3 +34,28 @@ jobs:
       - name: Run standalone test suite
         working-directory: contrib/pagestore
         run: ./pagestore_test ./pagestore_daemon
+
+  # In-engine test: build PostgreSQL and exercise the real path (smgr hijack,
+  # localsvc backend over the daemon, COW read_at, WAL shipping).  Heavier --
+  # it compiles PostgreSQL -- so it is a separate job.
+  integration-test:
+    name: in-engine integration test (PostgreSQL + daemon)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential bison flex meson ninja-build pkg-config perl python3
+
+      - name: Configure and build PostgreSQL (minimal)
+        run: |
+          meson setup build -Dcassert=true -Dauto_features=disabled
+          ninja -C build
+
+      - name: Prepare temporary install tree
+        run: meson test -C build --suite setup
+
+      - name: Run pagestore integration test
+        run: contrib/pagestore/integration_test.sh "$(pwd)/build"

--- a/contrib/pagestore/DESIGN_NOTES.md
+++ b/contrib/pagestore/DESIGN_NOTES.md
@@ -1,0 +1,69 @@
+# pagestore — design notes & planned evolution
+
+This module is a working prototype of a disaggregated, copy-on-write page store
+for PostgreSQL.  Several pieces are deliberately simplified to get the end-to-end
+architecture working and tested; this file records the directions they must take
+to become production-grade.
+
+## 1. Storage & indexes should become LSM-like
+
+**Current.**  The daemon keeps its metadata as plain in-memory chained hash
+tables:
+
+- page versions: `(timeline, key, block) -> list of {lsn, segment, offset}`
+- fork sizes:    `(timeline, key) -> nblocks`
+- per-page WAL index: `(timeline, key, block) -> ascending list of record LSNs`
+
+Page data is appended to flat segment files (`seg_NNNNNNNN`); shipped WAL goes to
+flat per-timeline logs (`wal_<tl>`).  There is **no compaction and no GC**: the
+version lists and the per-page LSN lists grow without bound, and the indexes are
+rebuilt by scanning everything on restart.
+
+**Target.**  An LSM-like layered store, along the lines of Neon's pageserver:
+
+- **image layers** — materialized page images at an LSN, over a key range.
+- **delta layers** — WAL records / page deltas over a (key range × LSN range).
+- a **layer map** indexing layers by (key range, LSN range); a read finds the
+  covering image layer plus the delta layers above it and applies redo.
+- layers are **on-disk and immutable**, with **compaction** (merge deltas into
+  fresh image layers) and **GC** (drop layers/records below the retained-LSN
+  horizon, e.g. once a page is materialized past them).
+
+This bounds per-page replay chains and space, makes the index naturally
+persistent (it *is* the on-disk layers), and enables tiering (e.g. cold layers
+to object storage).
+
+## 2. The daemon must run on multiple CPUs
+
+**Current.**  The daemon is **single-threaded**: one poll loop scans all
+channels and processes requests serially, with synchronous blocking I/O
+(`pread`/`pwrite`/`open`).  It uses a single core.  This is precisely why the
+in-memory indexes above need no locking — there is only one accessor.  It is
+also a serialization point and a hard throughput ceiling.
+
+**Target.**  The daemon must scale across cores, and the data structures must be
+designed for multi-core from the start (not retrofitted):
+
+- **Shard the key space across cores** — one thread (or SPDK reactor) per core
+  owns a partition of relations; a backend's channel is routed to the owning
+  core.  Each core's indexes/layers stay single-owner, so they remain lock-free
+  by construction (the property we rely on today, preserved under sharding).
+- Where structures must be shared, use **sharded locks or lock-free layer maps**.
+- **Asynchronous / overlapped I/O** (io_uring, or per-core SPDK reactors) so a
+  single disk I/O does not stall unrelated requests.
+
+Items 1 and 2 should be **co-designed**: partition the LSM layers by key shard,
+keep a per-core layer map, and run compaction/GC per shard.  In other words, the
+choice of data structure (item 1) must account for how it is owned and accessed
+across cores (item 2).
+
+## Other known simplifications (smaller)
+
+- Indexes are in-memory and rebuilt on restart; the per-page WAL index is not
+  yet persisted at all.
+- The IPC channel uses busy-polling (no eventfd) and one copy via the channel
+  buffer (no zero-copy into shared_buffers); see the performance discussion.
+- WAL is parsed by reusing PostgreSQL's reader, never reimplemented in the daemon
+  (see WAL_REDO.md); the per-page WAL index population follows that rule.
+- `recovery_prefetch=off` is required by the redo worker (the backend's
+  recovery-prefetch/AIO path is not wired).

--- a/contrib/pagestore/WAL_REDO.md
+++ b/contrib/pagestore/WAL_REDO.md
@@ -45,13 +45,20 @@ read pages at an LSN.
      post-backup change is recovered.  Reuses PostgreSQL's redo wholesale.
      Caveat: the redo instance runs with `recovery_prefetch = off` (the
      backend's recovery-prefetch/AIO path is not wired yet).
+   - **3d-1** WAL-only compute -> non-redundant redo. ✅ `wal_only_redo_demo.sh`:
+     the writer runs with `route_all = off`, so its relation pages stay local
+     and only its WAL is shipped; the redo worker (`route_all = on`) then
+     materializes the relations into the store purely by replaying that WAL.
+     Verified the table never reached the store from the compute (its file is
+     local) yet exists in the store after redo, and the store grew.  This is the
+     point of redo: the store's pages come from WAL, not from the compute.
    - **3c** Materialize-on-demand: when a read misses a page at an LSN, drive
      redo for just that page (Neon's per-page model) instead of replaying
-     everything.  This is where a `--wal-redo`-style single-page helper, or a
-     bounded recovery, comes in.
-   - **3d** Branch WAL read-through (serve a branch's WAL across its fork point)
-     and SLRU/clog + `pg_control` on the store, so an independent compute can
-     run on a branch with no local state.
+     everything.  A `--wal-redo`-style single-page helper, or bounded recovery.
+   - **3d-2/3** SLRU/clog + `pg_control` on the store, and branch WAL
+     read-through (serve a branch's WAL across its fork point), so multiple
+     independent computes can run concurrently on different branches with no
+     shared local state.
 
 ## Known scope boundaries
 

--- a/contrib/pagestore/WAL_REDO.md
+++ b/contrib/pagestore/WAL_REDO.md
@@ -31,9 +31,11 @@ read pages at an LSN.
 2. **WAL serving** — store hands WAL back by LSN range, so a redo worker can pull
    it. ✅ (`PS_OP_WAL_READ`; `wal_read()` assembles bytes across records.)
 3. **Redo worker** — a recovery PostgreSQL that consumes the store's WAL and
-   materializes pages into the store. ⬜ Next milestones:
-   - **3a** Reconstruct standard WAL segment files from the `wal_<tl>` log (or a
-     `restore_command`/streaming shim) so recovery can consume it.
+   materializes pages into the store. 🔶 In progress:
+   - **3a** Reconstruct standard WAL segment files from the `wal_<tl>` log. ✅
+     `pagestore_walrestore` does this and works as a `restore_command`
+     (`pagestore_walrestore --shm NAME --timeline N --segsize B %f %p`); the
+     integration test reconstructs a shipped segment as a full standard segment.
    - **3b** Bring up a PG node in standby/recovery with `route_all` on the store
      and point its WAL source at the store; verify it materializes pages.
    - **3c** Materialize-on-demand: when a read misses a page at an LSN, drive

--- a/contrib/pagestore/WAL_REDO.md
+++ b/contrib/pagestore/WAL_REDO.md
@@ -61,7 +61,16 @@ read pages at an LSN.
          This is the lookup the single-page redo needs.  (Populating it by
          decoding shipped WAL via PostgreSQL's XLogReader / pg_walinspect is next;
          reimplementing the WAL format in the daemon is deliberately avoided.)
-       - **3c-2** A `--wal-redo`-style single-page helper: take a page's newest
+       - **3c-2** Populate the index by decoding shipped WAL. ✅ Reuses
+         PostgreSQL's own WAL reader (`read_local_xlog_page`), exposed as
+         `pagestore_index_wal(start, end)`.  Note: decoding **must run in a
+         normal backend** -- the archiver process lacks the recovery/timeline
+         context the reader asserts on (both `read_local_xlog_page` and `WALRead`
+         abort there).  In production a background worker would call it as WAL is
+         shipped; the SQL function lets a test drive it (integration test indexes
+         a fresh table and confirms its block has records).  No daemon-side WAL
+         parser is written.
+       - **3c-3** A `--wal-redo`-style single-page helper: take a page's newest
          stored image plus its indexed records up to L and apply rm_redo.
    - **3d-2/3** SLRU/clog + `pg_control` on the store, and branch WAL
      read-through (serve a branch's WAL across its fork point), so multiple

--- a/contrib/pagestore/WAL_REDO.md
+++ b/contrib/pagestore/WAL_REDO.md
@@ -70,8 +70,18 @@ read pages at an LSN.
          shipped; the SQL function lets a test drive it (integration test indexes
          a fresh table and confirms its block has records).  No daemon-side WAL
          parser is written.
-       - **3c-3** A `--wal-redo`-style single-page helper: take a page's newest
-         stored image plus its indexed records up to L and apply rm_redo.
+       - **3c-3** Reconstruct a single page's base image from WAL. ✅
+         `pagestore_redo_page(rel, fork, block, lsn)` uses the per-page index to
+         find the newest full-page image at/below lsn and restores it
+         (`RestoreBlockImage`) -- rebuilding one page from WAL on demand.  Note a
+         WAL full-page image is the page *before* that record's change (torn-page
+         protection), so this returns the base image, not the page exactly as-of
+         lsn.
+       - **3c-4** The `--wal-redo`-style helper: apply the delta records after
+         the base image with `rm_redo` to get the page exactly as-of lsn.  This
+         is the one piece that needs PostgreSQL's redo run against a single held
+         page (Neon's wal-redo process / a small core mode) -- the last hard
+         piece of the read path.
    - **3d-2/3** SLRU/clog + `pg_control` on the store, and branch WAL
      read-through (serve a branch's WAL across its fork point), so multiple
      independent computes can run concurrently on different branches with no

--- a/contrib/pagestore/WAL_REDO.md
+++ b/contrib/pagestore/WAL_REDO.md
@@ -36,8 +36,15 @@ read pages at an LSN.
      `pagestore_walrestore` does this and works as a `restore_command`
      (`pagestore_walrestore --shm NAME --timeline N --segsize B %f %p`); the
      integration test reconstructs a shipped segment as a full standard segment.
-   - **3b** Bring up a PG node in standby/recovery with `route_all` on the store
-     and point its WAL source at the store; verify it materializes pages.
+   - **3b** Bring up a PG node in archive recovery with `route_all` on the store
+     and its WAL fetched from the store; verify it materializes pages. ✅
+     `redo_worker_demo.sh`: a base backup (`pg_backup_start`/`stop`) marks the
+     recovery start, then the instance recovers with
+     `restore_command = pagestore_walrestore` and empty local pg_wal, so all WAL
+     comes from the store; recovery's rm_redo replays it into the store and the
+     post-backup change is recovered.  Reuses PostgreSQL's redo wholesale.
+     Caveat: the redo instance runs with `recovery_prefetch = off` (the
+     backend's recovery-prefetch/AIO path is not wired yet).
    - **3c** Materialize-on-demand: when a read misses a page at an LSN, drive
      redo for just that page (Neon's per-page model) instead of replaying
      everything.  This is where a `--wal-redo`-style single-page helper, or a

--- a/contrib/pagestore/WAL_REDO.md
+++ b/contrib/pagestore/WAL_REDO.md
@@ -54,7 +54,15 @@ read pages at an LSN.
      point of redo: the store's pages come from WAL, not from the compute.
    - **3c** Materialize-on-demand: when a read misses a page at an LSN, drive
      redo for just that page (Neon's per-page model) instead of replaying
-     everything.  A `--wal-redo`-style single-page helper, or bounded recovery.
+     everything.
+       - **3c-1** Per-page WAL index. ✅ The store maps (timeline, key, block) ->
+         the LSNs of WAL records that modify that page (`PS_OP_WAL_INDEX_ADD` /
+         `PS_OP_WAL_INDEX_GET`, with branch read-through capped at the fork LSN).
+         This is the lookup the single-page redo needs.  (Populating it by
+         decoding shipped WAL via PostgreSQL's XLogReader / pg_walinspect is next;
+         reimplementing the WAL format in the daemon is deliberately avoided.)
+       - **3c-2** A `--wal-redo`-style single-page helper: take a page's newest
+         stored image plus its indexed records up to L and apply rm_redo.
    - **3d-2/3** SLRU/clog + `pg_control` on the store, and branch WAL
      read-through (serve a branch's WAL across its fork point), so multiple
      independent computes can run concurrently on different branches with no

--- a/contrib/pagestore/WAL_REDO.md
+++ b/contrib/pagestore/WAL_REDO.md
@@ -1,0 +1,51 @@
+# WAL redo design (reconstructing pages from WAL in the store)
+
+This is the third and largest WAL-shipping layer: having the store **reconstruct
+pages by replaying WAL**, so that a read compute can be stateless and a branch
+is a complete clone.  It is a multi-step effort; this document records the plan
+and what is implemented so far.
+
+## Why not reimplement redo
+
+PostgreSQL applies WAL per resource manager (`heap`, `btree`, `gin`, `xact`,
+`clog`, ... — each with an `rm_redo`).  Reimplementing all of that in the daemon
+would be rewriting half of PostgreSQL and would break every major version.
+
+So we **reuse PostgreSQL's own redo** (the approach Neon takes).  The cleanest
+realization that needs *no* redo reimplementation: a dedicated PostgreSQL
+instance in **continuous recovery** whose storage is the page store —
+
+- relations routed to the store (`pagestore.route_all`),
+- WAL fed from the store (the shipped WAL, M6),
+- recovery's `rm_redo` reads base pages from the store via smgr, applies the
+  records, and writes the resulting pages back to the store via smgr.
+
+That "redo worker" materializes pages into the store using stock recovery code.
+Write computes ship WAL; the redo worker turns WAL into pages; read computes
+read pages at an LSN.
+
+## Layers and status
+
+1. **WAL transport** — compute ships WAL to the store. ✅ (M6: archive module →
+   `PS_OP_WAL_APPEND`, per-timeline `wal_<tl>` log.)
+2. **WAL serving** — store hands WAL back by LSN range, so a redo worker can pull
+   it. ✅ (`PS_OP_WAL_READ`; `wal_read()` assembles bytes across records.)
+3. **Redo worker** — a recovery PostgreSQL that consumes the store's WAL and
+   materializes pages into the store. ⬜ Next milestones:
+   - **3a** Reconstruct standard WAL segment files from the `wal_<tl>` log (or a
+     `restore_command`/streaming shim) so recovery can consume it.
+   - **3b** Bring up a PG node in standby/recovery with `route_all` on the store
+     and point its WAL source at the store; verify it materializes pages.
+   - **3c** Materialize-on-demand: when a read misses a page at an LSN, drive
+     redo for just that page (Neon's per-page model) instead of replaying
+     everything.  This is where a `--wal-redo`-style single-page helper, or a
+     bounded recovery, comes in.
+   - **3d** Branch WAL read-through (serve a branch's WAL across its fork point)
+     and SLRU/clog + `pg_control` on the store, so an independent compute can
+     run on a branch with no local state.
+
+## Known scope boundaries
+
+Until 3c/3d land, branches remain single-compute-at-a-time and WAL/SLRU/control
+are not fully branched (see compute_on_branch_demo.sh).  The redo worker is the
+piece that removes those boundaries.

--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -492,6 +492,34 @@ pagestore_localsvc_wal_append(uint64 start_lsn, const void *data, uint32 len)
 	ls_exec(ch);
 }
 
+/* Record in the store that the WAL record at 'lsn' modifies (key, block). */
+void
+pagestore_localsvc_walidx_add(const PageStoreRelKey *key, BlockNumber block,
+							  uint64 lsn)
+{
+	PsChannel  *ch = ls_chan();
+
+	ls_fill_key(ch, key);
+	ch->opcode = PS_OP_WAL_INDEX_ADD;
+	ch->blocknum = block;
+	ch->req_lsn = lsn;
+	ls_exec(ch);
+}
+
+/* Number of indexed WAL records that modify (key, block) on this timeline. */
+int
+pagestore_localsvc_walidx_count(const PageStoreRelKey *key, BlockNumber block)
+{
+	PsChannel  *ch = ls_chan();
+
+	ls_fill_key(ch, key);
+	ch->opcode = PS_OP_WAL_INDEX_GET;
+	ch->blocknum = block;
+	ch->req_lsn = PG_UINT64_MAX;	/* all records */
+	ls_exec(ch);
+	return (int) ch->result;
+}
+
 /* Called from _PG_init to register the GUCs owned by this backend. */
 void
 pagestore_localsvc_init(void)

--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -520,6 +520,27 @@ pagestore_localsvc_walidx_count(const PageStoreRelKey *key, BlockNumber block)
 	return (int) ch->result;
 }
 
+/* Fetch up to maxn record LSNs (<= lsn_max) for (key, block) into out;
+ * returns how many.  Ascending order. */
+int
+pagestore_localsvc_walidx_get(const PageStoreRelKey *key, BlockNumber block,
+							  uint64 lsn_max, uint64 *out, int maxn)
+{
+	PsChannel  *ch = ls_chan();
+	int			n;
+
+	ls_fill_key(ch, key);
+	ch->opcode = PS_OP_WAL_INDEX_GET;
+	ch->blocknum = block;
+	ch->req_lsn = lsn_max;
+	ls_exec(ch);
+	n = (int) ch->result;
+	if (n > maxn)
+		n = maxn;
+	memcpy(out, ch->data, (size_t) n * sizeof(uint64));
+	return n;
+}
+
 /* Called from _PG_init to register the GUCs owned by this backend. */
 void
 pagestore_localsvc_init(void)

--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -474,6 +474,24 @@ pagestore_localsvc_create_branch(uint32 new_tl, uint32 parent_tl,
 	ls_exec(ch);
 }
 
+/*
+ * Ship a chunk of WAL (len bytes starting at WAL position start_lsn) to the
+ * daemon, tagged with this process's timeline.  Used by the archive module to
+ * stream completed WAL segments into the store.  len must be <= PS_IO_UNIT.
+ */
+void
+pagestore_localsvc_wal_append(uint64 start_lsn, const void *data, uint32 len)
+{
+	PsChannel  *ch = ls_chan();
+
+	ch->timeline = (uint32) localsvc_timeline;
+	ch->opcode = PS_OP_WAL_APPEND;
+	ch->req_lsn = start_lsn;
+	ch->datalen = len;
+	memcpy(ch->data, data, len);
+	ls_exec(ch);
+}
+
 /* Called from _PG_init to register the GUCs owned by this backend. */
 void
 pagestore_localsvc_init(void)

--- a/contrib/pagestore/compute_on_branch_demo.sh
+++ b/contrib/pagestore/compute_on_branch_demo.sh
@@ -47,7 +47,7 @@ DATA=$(mktemp -d)/pgdata
 STORE=$(mktemp -d)/store
 SHM=/pscob_$$
 PORT=54450
-P="$BIN/psql -p $PORT -U postgres -tA"
+P="$BIN/psql -h 127.0.0.1 -p $PORT -U postgres -tA"
 
 cleanup() {
 	"$BIN/pg_ctl" -D "$DATA" -m immediate -w stop >/dev/null 2>&1 || true

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -138,6 +138,28 @@ else
 	fail=1
 fi
 
+# --- 6. base page image reconstructed from a WAL full-page image (redo 3c-3) -
+# pagestore_redo_page returns the newest full-page image <= lsn -- the base a
+# single-page redo would then apply deltas onto.  (Applying the deltas needs
+# rm_redo; that wal-redo helper is the remaining step.)
+$P -c "CREATE FUNCTION pagestore_redo_page(regclass,int,int,pg_lsn) RETURNS bytea
+        AS 'pagestore','pagestore_redo_page' LANGUAGE C STRICT;" >/dev/null
+rlsn0=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "CREATE TABLE rp(id int primary key, v text) TABLESPACE ts;
+       INSERT INTO rp VALUES (1,'rp_committed'); CHECKPOINT;" >/dev/null
+# first modify after the checkpoint logs a full-page image of rp's block 0
+$P -c "UPDATE rp SET v='rp_later' WHERE id=1;" >/dev/null
+rlsn1=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "SELECT pagestore_index_wal('$rlsn0', '$rlsn1');" >/dev/null
+# reconstruct rp's block 0 image from WAL alone; it carries the committed row
+rebuilt=$($P -c "SELECT position('rp_committed'::bytea in pagestore_redo_page('rp',0,0,'$rlsn1')) > 0;")
+if [ "$rebuilt" = "t" ]; then
+	echo "ok   - base page image reconstructed from a WAL full-page image"
+else
+	echo "FAIL - could not reconstruct page image from WAL FPI (got '$rebuilt')"
+	fail=1
+fi
+
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
 exit $fail

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -108,6 +108,18 @@ sleep 2
 walsz=$(stat -c %s "$STORE/wal_0" 2>/dev/null || echo 0)
 if [ "$walsz" -gt 0 ]; then echo "ok   - WAL shipped to daemon (wal_0 = $walsz bytes)"; else echo "FAIL - no WAL shipped"; fail=1; fi
 
+# --- 4. reconstruct a standard WAL segment from the store (redo step 3a) ----
+seg=$(basename "$(ls "$DATA"/pg_wal/archive_status/*.done 2>/dev/null | head -1)" .done)
+out=$(mktemp)
+if [ -n "$seg" ] && "$BUILD/contrib/pagestore/pagestore_walrestore" \
+		--shm "$SHM" --timeline 0 --segsize 16777216 "$seg" "$out"; then
+	assert "$(stat -c %s "$out")" "16777216" "restored WAL segment $seg is a full standard segment"
+else
+	echo "FAIL - walrestore could not reconstruct segment '$seg'"
+	fail=1
+fi
+rm -f "$out"
+
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
 exit $fail

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -30,7 +30,9 @@ TS=$(mktemp -d)/ts
 STORE=$(mktemp -d)/store
 SHM=/psint_$$
 PORT=54460
-P="$BIN/psql -p $PORT -U postgres -tA"
+# connect over TCP: the server's unix-socket directory varies by build/distro,
+# but -A trust allows 127.0.0.1, so TCP is portable across environments (CI).
+P="$BIN/psql -h 127.0.0.1 -p $PORT -U postgres -tA"
 fail=0
 
 assert() {  # $1=actual $2=expected $3=message

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -120,6 +120,24 @@ else
 fi
 rm -f "$out"
 
+# --- 5. per-page WAL index: decode WAL (reusing PG's reader) and query it ---
+$P -c "CREATE FUNCTION pagestore_index_wal(pg_lsn,pg_lsn) RETURNS void
+        AS 'pagestore','pagestore_index_wal' LANGUAGE C STRICT;" >/dev/null
+$P -c "CREATE FUNCTION pagestore_walidx_count(regclass,int,int) RETURNS int
+        AS 'pagestore','pagestore_walidx_count' LANGUAGE C STRICT;" >/dev/null
+# write a fresh table and decode just-written WAL (still present in pg_wal)
+lsn0=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "CREATE TABLE widx(id int) TABLESPACE ts; INSERT INTO widx SELECT generate_series(1,1000);" >/dev/null
+lsn1=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "SELECT pagestore_index_wal('$lsn0', '$lsn1');" >/dev/null
+widx=$($P -c "SELECT pagestore_walidx_count('widx', 0, 0);")
+if [ "${widx:-0}" -gt 0 ]; then
+	echo "ok   - per-page WAL index built by decoding WAL (widx block 0 has $widx records)"
+else
+	echo "FAIL - per-page WAL index empty for widx block 0 (got '$widx')"
+	fail=1
+fi
+
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
 exit $fail

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# integration_test.sh -- in-engine (PostgreSQL + daemon) integration test for
+# the pagestore module.  Unlike the standalone test, this exercises the real
+# path: the smgr hijack, the localsvc backend talking to the daemon, the COW
+# read_at SQL function, and WAL shipping via the archive module.
+#
+# Self-asserting: prints "ok"/"FAIL" lines and exits non-zero on any failure.
+# Needs a full PostgreSQL build; pass the meson build directory as $1.
+#
+#   contrib/pagestore/integration_test.sh /path/to/build
+#
+set -uo pipefail
+
+BUILD=${1:?usage: integration_test.sh <meson-build-dir>}
+# Locate the temporary install tree robustly (its path depends on the configured
+# prefix), by finding pg_ctl under tmp_install.
+PGCTL=$(find "$BUILD/tmp_install" -path '*/bin/pg_ctl' -type f 2>/dev/null | head -1)
+if [ -z "$PGCTL" ]; then
+	echo "FAIL - no tmp_install found under $BUILD/tmp_install (run: meson test -C $BUILD --suite setup)"
+	exit 1
+fi
+BIN=$(dirname "$PGCTL")
+ROOT=$(dirname "$BIN")
+export LD_LIBRARY_PATH="$ROOT/lib:$ROOT/lib64"
+DAEMON="$BUILD/contrib/pagestore/pagestore_daemon"
+
+DATA=$(mktemp -d)/pgdata
+TS=$(mktemp -d)/ts
+STORE=$(mktemp -d)/store
+SHM=/psint_$$
+PORT=54460
+P="$BIN/psql -p $PORT -U postgres -tA"
+fail=0
+
+assert() {  # $1=actual $2=expected $3=message
+	if [ "$1" = "$2" ]; then
+		echo "ok   - $3"
+	else
+		echo "FAIL - $3 (got '$1', want '$2')"
+		fail=1
+	fi
+}
+
+cleanup() {
+	"$BIN/pg_ctl" -D "$DATA" -m immediate -w stop >/dev/null 2>&1 || true
+	[ -n "${DPID:-}" ] && kill "$DPID" 2>/dev/null || true
+	rm -rf "$(dirname "$DATA")" "$(dirname "$TS")" "$(dirname "$STORE")"
+	rm -f "/dev/shm$SHM"
+}
+trap cleanup EXIT
+
+mkdir -p "$TS"
+"$BIN/initdb" -D "$DATA" -U postgres -A trust >/dev/null 2>&1
+"$DAEMON" --shm "$SHM" --store "$STORE" >/dev/null 2>&1 &
+DPID=$!
+sleep 0.5
+
+cat >> "$DATA/postgresql.conf" <<EOF
+shared_preload_libraries = 'pagestore'
+pagestore.backend = 'localsvc'
+pagestore.localsvc_shm = '$SHM'
+pagestore.route_user_tablespaces = on
+io_method = sync
+archive_mode = on
+archive_library = 'pagestore'
+port = $PORT
+EOF
+"$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
+
+# --- 1. localsvc round-trip: a routed table's I/O goes to the daemon --------
+$P -c "CREATE TABLESPACE ts LOCATION '$TS';" >/dev/null
+$P -c "CREATE TABLE t(id int primary key, v text) TABLESPACE ts;
+       INSERT INTO t SELECT g, md5(g::text) FROM generate_series(1,20000) g;
+       CHECKPOINT;" >/dev/null
+ck1=$($P -c "SELECT md5(string_agg(v,',' ORDER BY id)) FROM t;")
+nfiles=$(find "$TS" -type f | wc -l | tr -d ' ')
+assert "$nfiles" "0" "routed tablespace has no local relation files (I/O went to daemon)"
+
+"$BIN/pg_ctl" -D "$DATA" -w restart >/dev/null 2>&1   # evict shared_buffers
+ck2=$($P -c "SELECT md5(string_agg(v,',' ORDER BY id)) FROM t;")
+assert "$ck2" "$ck1" "data intact after restart (read back from daemon)"
+assert "$($P -c 'SELECT count(*) FROM t;')" "20000" "row count after restart"
+
+# --- 2. copy-on-write time-travel read -------------------------------------
+$P -c "CREATE FUNCTION pagestore_read_at(regclass,int,int,pg_lsn) RETURNS bytea
+        AS 'pagestore','pagestore_read_at' LANGUAGE C STRICT;" >/dev/null
+$P -c "CREATE TABLE c(id int, note text) TABLESPACE ts;
+       INSERT INTO c VALUES (1,'cow_old'); CHECKPOINT;" >/dev/null
+l1=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "UPDATE c SET note='cow_new' WHERE id=1; CHECKPOINT;" >/dev/null
+has_old=$($P -c "SELECT position('cow_old'::bytea in pagestore_read_at('c',0,0,'$l1'::pg_lsn))>0;")
+has_new=$($P -c "SELECT position('cow_new'::bytea in pagestore_read_at('c',0,0,'$l1'::pg_lsn))=0;")
+cur_new=$($P -c "SELECT position('cow_new'::bytea in pagestore_read_at('c',0,0,'FFFFFFFF/FFFFFFFF'))>0;")
+assert "$has_old" "t" "as-of read returns the pre-update page (COW retained)"
+assert "$has_new" "t" "as-of read does not contain the post-update value"
+assert "$cur_new" "t" "current page contains the new value"
+
+# --- 3. WAL shipping: completed segments reach the daemon ------------------
+$P -c "CREATE TABLE wgen(x text) TABLESPACE ts;" >/dev/null
+for i in 1 2; do
+	$P -c "INSERT INTO wgen SELECT repeat('w',100) FROM generate_series(1,50000);
+	       SELECT pg_switch_wal();" >/dev/null
+done
+sleep 2
+walsz=$(stat -c %s "$STORE/wal_0" 2>/dev/null || echo 0)
+if [ "$walsz" -gt 0 ]; then echo "ok   - WAL shipped to daemon (wal_0 = $walsz bytes)"; else echo "FAIL - no WAL shipped"; fail=1; fi
+
+echo "----"
+[ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
+exit $fail

--- a/contrib/pagestore/meson.build
+++ b/contrib/pagestore/meson.build
@@ -34,6 +34,14 @@ pagestore_import = executable('pagestore_import',
 )
 contrib_targets += pagestore_import
 
+# Reconstruct a standard WAL segment from the store's shipped WAL; usable as a
+# restore_command so a recovery instance can replay store-resident WAL.
+pagestore_walrestore = executable('pagestore_walrestore',
+  files('pagestore_walrestore.c'),
+  kwargs: default_bin_args,
+)
+contrib_targets += pagestore_walrestore
+
 # Standalone test harness: drives the daemon over the shared-memory protocol
 # with no PostgreSQL instance.  Run independently of the PG test suites with:
 #   meson test -C <build> --suite pagestore

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -30,11 +30,17 @@
  */
 #include "postgres.h"
 
+#include <fcntl.h>
+#include <unistd.h>
+
 #include "access/relation.h"
+#include "access/xlog_internal.h"
+#include "archive/archive_module.h"
 #include "catalog/pg_tablespace_d.h"
 #include "fmgr.h"
 #include "miscadmin.h"
 #include "pagestore_backend.h"
+#include "pagestore_ipc.h"
 #include "port/pg_iovec.h"
 #include "storage/aio.h"
 #include "storage/md.h"
@@ -443,6 +449,81 @@ pagestore_create_branch(PG_FUNCTION_ARGS)
 	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
 									 (uint64) lsn);
 	PG_RETURN_VOID();
+}
+
+/* --- archive module: ship completed WAL segments to the store ---------- */
+
+/*
+ * pagestore can also act as an archive_library: when a WAL segment fills, the
+ * archiver hands it here and we stream it to the daemon's per-timeline WAL log.
+ * This is the compute-side half of WAL shipping (transport + durability).  It
+ * uses the official archive module API, so no core changes are needed; the
+ * granularity is one completed segment (force one with pg_switch_wal()).
+ */
+static bool
+pagestore_archive_configured(ArchiveModuleState *state)
+{
+	/* only meaningful when relations are served by the localsvc backend */
+	return strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") == 0;
+}
+
+static bool
+pagestore_archive_file(ArchiveModuleState *state, const char *file,
+					   const char *path)
+{
+	TimeLineID	tli;
+	XLogSegNo	segno;
+	XLogRecPtr	seg_start;
+	int			fd;
+	char	   *buf;
+	uint64		off = 0;
+
+	XLogFromFileName(file, &tli, &segno, wal_segment_size);
+	XLogSegNoOffsetToRecPtr(segno, 0, wal_segment_size, seg_start);
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+	{
+		ereport(WARNING,
+				(errcode_for_file_access(),
+				 errmsg("pagestore archive: could not open WAL segment \"%s\": %m",
+						path)));
+		return false;
+	}
+
+	buf = palloc(PS_IO_UNIT);
+	for (;;)
+	{
+		ssize_t		n = read(fd, buf, PS_IO_UNIT);
+
+		if (n < 0)
+		{
+			pfree(buf);
+			close(fd);
+			return false;
+		}
+		if (n == 0)
+			break;
+		/* ship this chunk at its WAL position */
+		pagestore_localsvc_wal_append(seg_start + off, buf, (uint32) n);
+		off += (uint64) n;
+	}
+	pfree(buf);
+	close(fd);
+	return true;
+}
+
+static const ArchiveModuleCallbacks pagestore_archive_callbacks = {
+	.startup_cb = NULL,
+	.check_configured_cb = pagestore_archive_configured,
+	.archive_file_cb = pagestore_archive_file,
+	.shutdown_cb = NULL,
+};
+
+const ArchiveModuleCallbacks *
+_PG_archive_module_init(void)
+{
+	return &pagestore_archive_callbacks;
 }
 
 void

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -644,6 +644,111 @@ pagestore_walidx_count(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(n);
 }
 
+/*
+ * pagestore_redo_page(rel regclass, forknum int, blocknum int, lsn pg_lsn)
+ *   -> bytea
+ *
+ * Single-page materialization, base-image step: return the newest full-page
+ * image of the page at/below 'lsn', found via the per-page index and restored
+ * with RestoreBlockImage -- reconstructing a page from WAL alone, on demand,
+ * for one page (instead of replaying everything).
+ *
+ * Note this returns the *base* image: a WAL full-page image is the page as it
+ * was when that record needed torn-page protection, so to get the page exactly
+ * as-of 'lsn' a single-page redo must then apply the delta records after the
+ * image with rm_redo (the `--wal-redo`-style helper -- the remaining step).
+ * Returns NULL if no full-page image for the page is indexed at/below lsn.
+ */
+#define PS_REDO_MAX_RECS 4096
+
+PG_FUNCTION_INFO_V1(pagestore_redo_page);
+
+Datum
+pagestore_redo_page(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	int32		forknum = PG_GETARG_INT32(1);
+	int32		blocknum = PG_GETARG_INT32(2);
+	XLogRecPtr	lsn = PG_GETARG_LSN(3);
+	Relation	rel;
+	PageStoreRelKey key;
+	uint64	   *lsns;
+	int			n;
+	ReadLocalXLogPageNoWaitPrivate *pd;
+	XLogReaderState *reader;
+	char	   *page;
+	bytea	   *result = NULL;
+
+	rel = relation_open(relid, AccessShareLock);
+	key.spcOid = rel->rd_locator.spcOid;
+	key.dbOid = rel->rd_locator.dbOid;
+	key.relNumber = rel->rd_locator.relNumber;
+	key.forkNum = forknum;
+	relation_close(rel, AccessShareLock);
+
+	lsns = palloc(sizeof(uint64) * PS_REDO_MAX_RECS);
+	n = pagestore_localsvc_walidx_get(&key, (BlockNumber) blocknum, (uint64) lsn,
+									  lsns, PS_REDO_MAX_RECS);
+	if (n == 0)
+		PG_RETURN_NULL();
+
+	pd = palloc0(sizeof(ReadLocalXLogPageNoWaitPrivate));
+	reader = XLogReaderAllocate(wal_segment_size, NULL,
+								XL_ROUTINE(.page_read = &read_local_xlog_page_no_wait,
+										   .segment_open = &wal_segment_open,
+										   .segment_close = &wal_segment_close),
+								pd);
+	if (reader == NULL)
+	{
+		pfree(pd);
+		PG_RETURN_NULL();
+	}
+	page = palloc(BLCKSZ);
+
+	/* newest indexed record first: find one carrying a full-page image */
+	for (int i = n - 1; i >= 0 && result == NULL; i--)
+	{
+		char	   *errm;
+		XLogRecord *rec;
+
+		XLogBeginRead(reader, lsns[i]);
+		rec = XLogReadRecord(reader, &errm);
+		if (rec == NULL)
+			continue;
+
+		for (int b = 0; b <= XLogRecMaxBlockId(reader); b++)
+		{
+			RelFileLocator rloc;
+			ForkNumber	fk;
+			BlockNumber blk;
+
+			if (!XLogRecHasBlockImage(reader, b))
+				continue;
+			XLogRecGetBlockTagExtended(reader, b, &rloc, &fk, &blk, NULL);
+			if (rloc.relNumber != key.relNumber || rloc.dbOid != key.dbOid ||
+				rloc.spcOid != key.spcOid || fk != forknum ||
+				blk != (BlockNumber) blocknum)
+				continue;
+			if (RestoreBlockImage(reader, b, page))
+			{
+				result = (bytea *) palloc(BLCKSZ + VARHDRSZ);
+				SET_VARSIZE(result, BLCKSZ + VARHDRSZ);
+				memcpy(VARDATA(result), page, BLCKSZ);
+			}
+			break;
+		}
+	}
+
+	XLogReaderFree(reader);
+	pfree(pd);
+	pfree(lsns);
+	pfree(page);
+
+	if (result == NULL)
+		PG_RETURN_NULL();
+	PG_RETURN_BYTEA_P(result);
+}
+
 void
 _PG_init(void)
 {

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -35,6 +35,8 @@
 
 #include "access/relation.h"
 #include "access/xlog_internal.h"
+#include "access/xlogreader.h"
+#include "access/xlogutils.h"
 #include "archive/archive_module.h"
 #include "catalog/pg_tablespace_d.h"
 #include "fmgr.h"
@@ -467,6 +469,84 @@ pagestore_archive_configured(ArchiveModuleState *state)
 	return strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") == 0;
 }
 
+/*
+ * Decode the WAL in [start, end) and record, for each block a record modifies,
+ * an entry in the store's per-page WAL index.  Reuses PostgreSQL's WAL reader
+ * (read_local_xlog_page) -- which is why this must run in a normal backend, not
+ * the archiver (the archiver lacks the recovery/timeline context the reader
+ * asserts on).  In production a background worker would call this as WAL is
+ * shipped; the SQL wrapper below lets a test drive it.
+ */
+static void
+pagestore_index_wal_range(XLogRecPtr start, XLogRecPtr end)
+{
+	ReadLocalXLogPageNoWaitPrivate *pd;
+	XLogReaderState *reader;
+	XLogRecPtr	first;
+
+	pd = palloc0(sizeof(ReadLocalXLogPageNoWaitPrivate));
+	reader = XLogReaderAllocate(wal_segment_size, NULL,
+								XL_ROUTINE(.page_read = &read_local_xlog_page_no_wait,
+										   .segment_open = &wal_segment_open,
+										   .segment_close = &wal_segment_close),
+								pd);
+	if (reader == NULL)
+	{
+		pfree(pd);
+		return;
+	}
+
+	first = XLogFindNextRecord(reader, start);
+	while (!XLogRecPtrIsInvalid(first))
+	{
+		char	   *errm;
+		XLogRecord *rec = XLogReadRecord(reader, &errm);
+
+		if (rec == NULL)
+			break;				/* end of flushed WAL / torn tail */
+		if (reader->ReadRecPtr >= end)
+			break;
+
+		for (int b = 0; b <= XLogRecMaxBlockId(reader); b++)
+		{
+			RelFileLocator rloc;
+			ForkNumber	fk;
+			BlockNumber blk;
+			PageStoreRelKey key;
+
+			if (!XLogRecHasBlockRef(reader, b))
+				continue;
+			XLogRecGetBlockTagExtended(reader, b, &rloc, &fk, &blk, NULL);
+			key.spcOid = rloc.spcOid;
+			key.dbOid = rloc.dbOid;
+			key.relNumber = rloc.relNumber;
+			key.forkNum = fk;
+			pagestore_localsvc_walidx_add(&key, blk, reader->ReadRecPtr);
+		}
+	}
+
+	XLogReaderFree(reader);
+	pfree(pd);
+}
+
+/*
+ * pagestore_index_wal(start_lsn pg_lsn, end_lsn pg_lsn) -> void
+ *
+ * Decode WAL in [start, end) and populate the per-page WAL index.  Stand-in for
+ * the background worker that would do this continuously.
+ */
+PG_FUNCTION_INFO_V1(pagestore_index_wal);
+
+Datum
+pagestore_index_wal(PG_FUNCTION_ARGS)
+{
+	XLogRecPtr	start = PG_GETARG_LSN(0);
+	XLogRecPtr	end = PG_GETARG_LSN(1);
+
+	pagestore_index_wal_range(start, end);
+	PG_RETURN_VOID();
+}
+
 static bool
 pagestore_archive_file(ArchiveModuleState *state, const char *file,
 					   const char *path)
@@ -533,6 +613,35 @@ const ArchiveModuleCallbacks *
 _PG_archive_module_init(void)
 {
 	return &pagestore_archive_callbacks;
+}
+
+/*
+ * pagestore_walidx_count(rel regclass, forknum int, blocknum int) -> int
+ *
+ * How many shipped WAL records the store has indexed as modifying that page.
+ * Lets a test confirm the per-page WAL index is populated from real WAL.
+ */
+PG_FUNCTION_INFO_V1(pagestore_walidx_count);
+
+Datum
+pagestore_walidx_count(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	int32		forknum = PG_GETARG_INT32(1);
+	int32		blocknum = PG_GETARG_INT32(2);
+	Relation	rel;
+	PageStoreRelKey key;
+	int			n;
+
+	rel = relation_open(relid, AccessShareLock);
+	key.spcOid = rel->rd_locator.spcOid;
+	key.dbOid = rel->rd_locator.dbOid;
+	key.relNumber = rel->rd_locator.relNumber;
+	key.forkNum = forknum;
+	n = pagestore_localsvc_walidx_count(&key, (BlockNumber) blocknum);
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_INT32(n);
 }
 
 void

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -478,6 +478,15 @@ pagestore_archive_file(ArchiveModuleState *state, const char *file,
 	char	   *buf;
 	uint64		off = 0;
 
+	/*
+	 * Only ship real WAL segment files.  The archiver also offers backup
+	 * history (".backup") and timeline history (".history") files, whose names
+	 * begin with a segment number -- shipping them would clobber that segment's
+	 * WAL in the store.  Report them archived without storing them.
+	 */
+	if (!IsXLogFileName(file))
+		return true;
+
 	XLogFromFileName(file, &tli, &segno, wal_segment_size);
 	XLogSegNoOffsetToRecPtr(segno, 0, wal_segment_size, seg_start);
 

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -145,5 +145,7 @@ extern void pagestore_localsvc_read_at(const PageStoreRelKey *key,
 									   BlockNumber blocknum, uint64 lsn, void *out);
 extern void pagestore_localsvc_create_branch(uint32 new_tl, uint32 parent_tl,
 											 uint64 branch_lsn);
+extern void pagestore_localsvc_wal_append(uint64 start_lsn, const void *data,
+										  uint32 len);
 
 #endif							/* PAGESTORE_BACKEND_H */

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -147,5 +147,9 @@ extern void pagestore_localsvc_create_branch(uint32 new_tl, uint32 parent_tl,
 											 uint64 branch_lsn);
 extern void pagestore_localsvc_wal_append(uint64 start_lsn, const void *data,
 										  uint32 len);
+extern void pagestore_localsvc_walidx_add(const PageStoreRelKey *key,
+										  BlockNumber block, uint64 lsn);
+extern int	pagestore_localsvc_walidx_count(const PageStoreRelKey *key,
+											BlockNumber block);
 
 #endif							/* PAGESTORE_BACKEND_H */

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -151,5 +151,8 @@ extern void pagestore_localsvc_walidx_add(const PageStoreRelKey *key,
 										  BlockNumber block, uint64 lsn);
 extern int	pagestore_localsvc_walidx_count(const PageStoreRelKey *key,
 											BlockNumber block);
+extern int	pagestore_localsvc_walidx_get(const PageStoreRelKey *key,
+										  BlockNumber block, uint64 lsn_max,
+										  uint64 *out, int maxn);
 
 #endif							/* PAGESTORE_BACKEND_H */

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -504,6 +504,83 @@ load_timelines(void)
 	close(fd);
 }
 
+/* ===================== shipped WAL log (per timeline) ================== */
+
+/*
+ * Each timeline has an append-only WAL log "wal_<tl>" of self-describing
+ * records [WalRecHdr | bytes].  This is the durability/transport half of WAL
+ * shipping: the compute ships its WAL stream here so it is persisted by the
+ * store, per timeline.  (Replaying these records to materialize pages -- redo
+ * -- is a later milestone; it would reuse PostgreSQL's rmgr redo.)
+ */
+#define WAL_MAGIC	0x57414c52	/* "WALR" */
+
+typedef struct WalRecHdr
+{
+	uint32_t	magic;
+	uint32_t	len;			/* WAL bytes following the header */
+	uint64_t	start_lsn;		/* LSN of the first byte */
+} WalRecHdr;
+
+/* highest end LSN (start+len) received per timeline */
+static uint64_t wal_end[MAX_TIMELINES];
+
+static int
+wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,
+		   uint32_t len)
+{
+	char		path[4096];
+	int			fd;
+	WalRecHdr	h;
+
+	if (tl >= MAX_TIMELINES)
+		return -1;
+	snprintf(path, sizeof(path), "%s/wal_%u", store_dir, tl);
+	fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
+	if (fd < 0)
+		return -1;
+
+	h.magic = WAL_MAGIC;
+	h.len = len;
+	h.start_lsn = start_lsn;
+	if (write(fd, &h, sizeof(h)) != (ssize_t) sizeof(h) ||
+		write(fd, data, len) != (ssize_t) len)
+	{
+		close(fd);
+		return -1;
+	}
+	close(fd);
+
+	if (start_lsn + len > wal_end[tl])
+		wal_end[tl] = start_lsn + len;
+	return 0;
+}
+
+/* Rebuild wal_end[tl] by scanning the timeline's WAL log at startup. */
+static void
+wal_recover_one(uint32_t tl)
+{
+	char		path[4096];
+	int			fd;
+	off_t		off = 0;
+	WalRecHdr	h;
+
+	if (tl >= MAX_TIMELINES)
+		return;
+	snprintf(path, sizeof(path), "%s/wal_%u", store_dir, tl);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return;
+	while (pread(fd, &h, sizeof(h), off) == (ssize_t) sizeof(h) &&
+		   h.magic == WAL_MAGIC)
+	{
+		if (h.start_lsn + h.len > wal_end[tl])
+			wal_end[tl] = h.start_lsn + h.len;
+		off += sizeof(h) + h.len;
+	}
+	close(fd);
+}
+
 /* ===================== write / read primitives ========================= */
 
 /* The page's own pd_lsn lives in its first 8 bytes (xlogid, xrecoff). */
@@ -734,6 +811,15 @@ handle_request(PsChannel *ch)
 				ch->status = PS_STATUS_ERROR;
 			break;
 
+		case PS_OP_WAL_APPEND:
+			if (wal_append(tl, ch->req_lsn, ch->data, ch->datalen) != 0)
+				ch->status = PS_STATUS_ERROR;
+			break;
+
+		case PS_OP_WAL_SIZE:
+			ch->req_lsn = wal_end[tl];	/* output: end LSN of this timeline's WAL */
+			break;
+
 		case PS_OP_IMMEDSYNC:
 			for (int id = 0; id < segs_cap; id++)
 				if (seg_fds[id] >= 0)
@@ -788,6 +874,11 @@ main(int argc, char **argv)
 	timeline_define(0, -1, 0);
 	load_timelines();
 	recover();
+
+	/* rebuild each timeline's shipped-WAL end LSN from its log */
+	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
+		if (tl == 0 || timelines[tl].defined)
+			wal_recover_one(tl);
 
 	fd = shm_open(shm_name, O_CREAT | O_RDWR, 0600);
 	if (fd < 0)

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -628,6 +628,100 @@ wal_recover_one(uint32_t tl)
 	close(fd);
 }
 
+/* ===================== per-page WAL index ============================== */
+
+/*
+ * Maps (timeline, key, block) -> the LSNs of WAL records that modify that page,
+ * in ascending order.  This is the lookup single-page materialization needs: to
+ * rebuild page P as-of LSN L, take P's newest stored image and replay the WAL
+ * records whose LSNs fall after it and <= L.  Populated by decoding shipped WAL
+ * (next milestone); queried via PS_OP_WAL_INDEX_GET.
+ *
+ * In-memory only for now (rebuilt by re-decoding WAL after a restart).
+ */
+typedef struct WalIdxEnt
+{
+	struct WalIdxEnt *next;
+	uint32_t	timeline;
+	PsKey		key;
+	uint32_t	block;
+	uint64_t   *lsns;			/* ascending */
+	int			n;
+	int			cap;
+} WalIdxEnt;
+
+static WalIdxEnt *walidx[IDX_BUCKETS];
+
+static void
+walidx_add(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
+{
+	uint32_t	h = page_hash(tl, key, block);
+	WalIdxEnt  *e;
+
+	for (e = walidx[h & IDX_MASK]; e; e = e->next)
+		if (e->timeline == tl && e->block == block && key_eq(&e->key, key))
+			break;
+	if (!e)
+	{
+		e = calloc(1, sizeof(*e));
+		e->timeline = tl;
+		e->key = *key;
+		e->block = block;
+		e->next = walidx[h & IDX_MASK];
+		walidx[h & IDX_MASK] = e;
+	}
+	if (e->n == e->cap)
+	{
+		e->cap = e->cap ? e->cap * 2 : 4;
+		e->lsns = realloc(e->lsns, (size_t) e->cap * sizeof(uint64_t));
+	}
+	/* keep ascending; WAL is appended in LSN order, so usually just append */
+	if (e->n == 0 || lsn >= e->lsns[e->n - 1])
+		e->lsns[e->n++] = lsn;
+	else
+	{
+		int			i = e->n;
+
+		while (i > 0 && e->lsns[i - 1] > lsn)
+		{
+			e->lsns[i] = e->lsns[i - 1];
+			i--;
+		}
+		e->lsns[i] = lsn;
+		e->n++;
+	}
+}
+
+/* Copy the record LSNs for (tl,key,block) that are <= lsn_max into out (cap
+ * max_out); return how many.  Walks the timeline ancestry. */
+static int
+walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
+		   uint64_t *out, int max_out)
+{
+	int			got = 0;
+
+	for (;;)
+	{
+		uint32_t	h = page_hash(tl, key, block);
+		WalIdxEnt  *e;
+
+		for (e = walidx[h & IDX_MASK]; e; e = e->next)
+			if (e->timeline == tl && e->block == block && key_eq(&e->key, key))
+			{
+				for (int i = 0; i < e->n && got < max_out; i++)
+					if (e->lsns[i] <= lsn_max)
+						out[got++] = e->lsns[i];
+				break;
+			}
+		if (!timeline_has_parent(tl))
+			break;
+		if (timelines[tl].branch_lsn < lsn_max)
+			lsn_max = timelines[tl].branch_lsn;
+		tl = (uint32_t) timelines[tl].parent;
+	}
+	return got;
+}
+
 /* ===================== write / read primitives ========================= */
 
 /* The page's own pd_lsn lives in its first 8 bytes (xlogid, xrecoff). */
@@ -869,6 +963,16 @@ handle_request(PsChannel *ch)
 
 		case PS_OP_WAL_READ:
 			ch->result = wal_read(tl, ch->req_lsn, ch->datalen, ch->data);
+			break;
+
+		case PS_OP_WAL_INDEX_ADD:
+			walidx_add(tl, &ch->key, ch->blocknum, ch->req_lsn);
+			break;
+
+		case PS_OP_WAL_INDEX_GET:
+			ch->result = (uint32_t) walidx_get(tl, &ch->key, ch->blocknum,
+											   ch->req_lsn, (uint64_t *) ch->data,
+											   (int) (PS_IO_UNIT / sizeof(uint64_t)));
 			break;
 
 		case PS_OP_IMMEDSYNC:

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -362,8 +362,9 @@ timeline_has_parent(uint32_t timeline)
 
 /*
  * Validate a branch-creation request before it is recorded.  read_through() and
- * the fork-size walks follow the parent chain assuming it is finite and well
- * formed, so a bad CREATE_BRANCH must be rejected rather than persisted.  Refuse:
+ * the fork-size / per-page WAL ancestry walks follow the parent chain assuming
+ * it is finite and well formed, so a bad CREATE_BRANCH must be rejected rather
+ * than persisted.  Refuse:
  *	- a new id that is out of range, the root (0), or already defined (otherwise
  *	  re-creating an id silently rewrites an existing branch's ancestry);
  *	- a parent that is out of range or not yet defined (the requested parent must

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -556,6 +556,53 @@ wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,
 	return 0;
 }
 
+/*
+ * Read up to 'len' WAL bytes starting at WAL position 'start' from a timeline's
+ * log into 'out'; returns the number of bytes filled.  Bytes not covered by any
+ * record are left as-is.  This is what a redo worker uses to pull WAL from the
+ * store for replay.  (Single timeline for now; reading a branch's WAL across
+ * its fork point is a refinement.)
+ */
+static uint32_t
+wal_read(uint32_t tl, uint64_t start, uint32_t len, unsigned char *out)
+{
+	char		path[4096];
+	int			fd;
+	off_t		off = 0;
+	WalRecHdr	h;
+	uint32_t	filled = 0;
+
+	if (tl >= MAX_TIMELINES)
+		return 0;
+	snprintf(path, sizeof(path), "%s/wal_%u", store_dir, tl);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return 0;
+
+	while (pread(fd, &h, sizeof(h), off) == (ssize_t) sizeof(h) &&
+		   h.magic == WAL_MAGIC)
+	{
+		uint64_t	rs = h.start_lsn;
+		uint64_t	re = rs + h.len;
+		uint64_t	ws = start;
+		uint64_t	we = start + len;
+		uint64_t	os = rs > ws ? rs : ws;	/* overlap start */
+		uint64_t	oe = re < we ? re : we;	/* overlap end */
+
+		if (os < oe)
+		{
+			off_t		src = off + sizeof(h) + (off_t) (os - rs);
+			ssize_t		n = pread(fd, out + (os - start), (size_t) (oe - os), src);
+
+			if (n > 0)
+				filled += (uint32_t) n;
+		}
+		off += sizeof(h) + h.len;
+	}
+	close(fd);
+	return filled;
+}
+
 /* Rebuild wal_end[tl] by scanning the timeline's WAL log at startup. */
 static void
 wal_recover_one(uint32_t tl)
@@ -818,6 +865,10 @@ handle_request(PsChannel *ch)
 
 		case PS_OP_WAL_SIZE:
 			ch->req_lsn = wal_end[tl];	/* output: end LSN of this timeline's WAL */
+			break;
+
+		case PS_OP_WAL_READ:
+			ch->result = wal_read(tl, ch->req_lsn, ch->datalen, ch->data);
 			break;
 
 		case PS_OP_IMMEDSYNC:

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 #define PS_SHM_MAGIC		0x50414753	/* "PAGS" */
-#define PS_SHM_VERSION		3
+#define PS_SHM_VERSION		4
 
 /* Default logical page size (overridable via the daemon's --page-size). */
 #define PS_DEFAULT_PAGE_SIZE	8192
@@ -66,6 +66,8 @@ typedef enum PsOpcode
 	PS_OP_IMMEDSYNC,
 	PS_OP_READ_AT,				/* read 1 page at blocknum as-of req_lsn (COW) */
 	PS_OP_CREATE_BRANCH,		/* create timeline from parent_timeline @ req_lsn */
+	PS_OP_WAL_APPEND,			/* append datalen WAL bytes at LSN req_lsn (timeline) */
+	PS_OP_WAL_SIZE,				/* return end LSN of the timeline's WAL in req_lsn */
 } PsOpcode;
 
 /* Status codes */
@@ -96,7 +98,9 @@ typedef struct PsChannel
 	uint32_t	old_nblocks;
 	uint32_t	timeline;		/* timeline this op targets (0 = main) */
 	uint32_t	parent_timeline;	/* CREATE_BRANCH: parent timeline */
-	uint64_t	req_lsn;		/* READ_AT: as-of LSN; CREATE_BRANCH: branch LSN */
+	uint32_t	datalen;		/* WAL_APPEND: number of WAL bytes in data[] */
+	uint32_t	pad1;
+	uint64_t	req_lsn;		/* READ_AT/WAL_APPEND: LSN; WAL_SIZE: out end LSN */
 	PsKey		key;
 
 	/* result */

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -68,6 +68,7 @@ typedef enum PsOpcode
 	PS_OP_CREATE_BRANCH,		/* create timeline from parent_timeline @ req_lsn */
 	PS_OP_WAL_APPEND,			/* append datalen WAL bytes at LSN req_lsn (timeline) */
 	PS_OP_WAL_SIZE,				/* return end LSN of the timeline's WAL in req_lsn */
+	PS_OP_WAL_READ,				/* read datalen WAL bytes from LSN req_lsn into data */
 } PsOpcode;
 
 /* Status codes */

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -69,6 +69,8 @@ typedef enum PsOpcode
 	PS_OP_WAL_APPEND,			/* append datalen WAL bytes at LSN req_lsn (timeline) */
 	PS_OP_WAL_SIZE,				/* return end LSN of the timeline's WAL in req_lsn */
 	PS_OP_WAL_READ,				/* read datalen WAL bytes from LSN req_lsn into data */
+	PS_OP_WAL_INDEX_ADD,		/* record: WAL at req_lsn modifies (key, blocknum) */
+	PS_OP_WAL_INDEX_GET,		/* list record LSNs <= req_lsn for (key, blocknum) */
 } PsOpcode;
 
 /* Status codes */

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -247,6 +247,36 @@ op_read_one(uint32_t rel, int32_t fork, uint32_t block, unsigned char *out)
 	memcpy(out, ch->data, cl_page_size);
 }
 
+/* Vectored write of n contiguous pages in a single op. */
+static void
+op_writev(uint32_t rel, int32_t fork, uint32_t block, const unsigned char *pages,
+		  uint32_t n)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	cl_setkey(ch, rel, fork);
+	ch->opcode = PS_OP_WRITEV;
+	ch->blocknum = block;
+	ch->nblocks = n;
+	memcpy(ch->data, pages, (size_t) n * cl_page_size);
+	cl_exec();
+}
+
+/* Vectored read of n contiguous pages in a single op. */
+static void
+op_readv(uint32_t rel, int32_t fork, uint32_t block, unsigned char *out,
+		 uint32_t n)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	cl_setkey(ch, rel, fork);
+	ch->opcode = PS_OP_READV;
+	ch->blocknum = block;
+	ch->nblocks = n;
+	cl_exec();
+	memcpy(out, ch->data, (size_t) n * cl_page_size);
+}
+
 static void
 op_read_at(uint32_t rel, int32_t fork, uint32_t block, uint64_t lsn,
 		   unsigned char *out)
@@ -740,6 +770,134 @@ run_wal_suite(const char *daemon_path, const char *tmpbase)
 	shm_unlink(shm);
 }
 
+/*
+ * Vectored I/O: a single WRITEV/READV carrying many pages, exercising the
+ * daemon's multi-block loop (the single-block suites never do nblocks > 1).
+ */
+static void
+run_vectored_suite(const char *daemon_path, const char *tmpbase)
+{
+	char		shm[64];
+	char		store[256];
+	pid_t		dpid;
+	uint32_t	ps = 8192;
+	uint32_t	nb = 16;		/* fits one io_unit (256K / 8K = 32) */
+	unsigned char *wbuf,
+			   *rbuf;
+	int			ok = 1;
+
+	fprintf(stderr, "== vectored I/O ==\n");
+	snprintf(shm, sizeof(shm), "/pstest_%d_vec", (int) getpid());
+	snprintf(store, sizeof(store), "%s/store_vec", tmpbase);
+	rm_rf(store);
+	shm_unlink(shm);
+
+	wbuf = malloc((size_t) nb * ps);
+	rbuf = malloc((size_t) nb * ps);
+
+	dpid = spawn_daemon(daemon_path, shm, store, ps);
+	wait_ready(shm, ps);
+	client_attach(shm, ps);
+
+	for (uint32_t i = 0; i < nb; i++)
+		fill_page(wbuf + (size_t) i * ps, ps, 1000 + i, (unsigned char) (i + 1));
+
+	op_writev(REL_A, FORK0, 5, wbuf, nb);	/* one op, nb pages, at block 5 */
+	check(op_nblocks(REL_A, FORK0) == 5 + nb, "nblocks after vectored write");
+
+	op_readv(REL_A, FORK0, 5, rbuf, nb);	/* one op, read them all back */
+	for (uint32_t i = 0; i < nb; i++)
+		if (!page_has_tag(rbuf + (size_t) i * ps, ps, (unsigned char) (i + 1)))
+			ok = 0;
+	check(ok, "vectored read returns every page intact");
+
+	/* and each block is individually addressable */
+	op_read_one(REL_A, FORK0, 5 + nb / 2, rbuf);
+	check(page_has_tag(rbuf, ps, (unsigned char) (nb / 2 + 1)),
+		  "single-block read of a vector-written block");
+
+	client_detach();
+	stop_daemon(dpid);
+	rm_rf(store);
+	shm_unlink(shm);
+	free(wbuf);
+	free(rbuf);
+}
+
+/* One concurrent client: own channel, own relation, write then verify. */
+static int
+conc_child(const char *shm_name, uint32_t ps, int id)
+{
+	uint32_t	rel = 20000 + (uint32_t) id;
+	unsigned char *p = malloc(ps);
+	unsigned char *r = malloc(ps);
+	int			rc = 0;
+
+	client_attach(shm_name, ps);
+	for (uint32_t b = 0; b < 50; b++)
+	{
+		fill_page(p, ps, 1000 + b, (unsigned char) (id * 7 + b + 1));
+		op_write_one(rel, FORK0, b, p);
+	}
+	for (uint32_t b = 0; b < 50; b++)
+	{
+		op_read_one(rel, FORK0, b, r);
+		if (!page_has_tag(r, ps, (unsigned char) (id * 7 + b + 1)))
+			rc = 2;
+	}
+	client_detach();
+	free(p);
+	free(r);
+	return rc;
+}
+
+/*
+ * Concurrency: many clients, each claiming its own channel, hit the daemon at
+ * once on independent relations.  Exercises channel allocation and the
+ * multi-channel poll loop.
+ */
+static void
+run_concurrency_suite(const char *daemon_path, const char *tmpbase)
+{
+#define NKIDS 8
+	char		shm[64];
+	char		store[256];
+	pid_t		dpid;
+	pid_t		kids[NKIDS];
+	uint32_t	ps = 8192;
+
+	fprintf(stderr, "== concurrency (%d clients) ==\n", NKIDS);
+	snprintf(shm, sizeof(shm), "/pstest_%d_conc", (int) getpid());
+	snprintf(store, sizeof(store), "%s/store_conc", tmpbase);
+	rm_rf(store);
+	shm_unlink(shm);
+
+	dpid = spawn_daemon(daemon_path, shm, store, ps);
+	wait_ready(shm, ps);		/* parent does not claim a channel */
+
+	for (int i = 0; i < NKIDS; i++)
+	{
+		pid_t		pid = fork();
+
+		if (pid == 0)
+			_exit(conc_child(shm, ps, i));
+		kids[i] = pid;
+	}
+	for (int i = 0; i < NKIDS; i++)
+	{
+		int			st = 1;
+
+		waitpid(kids[i], &st, 0);
+		check(WIFEXITED(st) && WEXITSTATUS(st) == 0,
+			  "concurrent client %d completed correctly", i);
+	}
+
+	stop_daemon(dpid);
+	rm_rf(store);
+	shm_unlink(shm);
+#undef NKIDS
+}
+
 int
 main(int argc, char **argv)
 {
@@ -771,6 +929,12 @@ main(int argc, char **argv)
 
 	/* shipped-WAL durability */
 	run_wal_suite(daemon_path, tmpbase);
+
+	/* vectored multi-page I/O */
+	run_vectored_suite(daemon_path, tmpbase);
+
+	/* many concurrent clients */
+	run_concurrency_suite(daemon_path, tmpbase);
 
 	rmdir(tmpbase);
 

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -395,6 +395,21 @@ op_wal_size(uint32_t tl)
 	return ch->req_lsn;
 }
 
+/* Read len WAL bytes from start_lsn into out; returns bytes filled. */
+static uint32_t
+op_wal_read(uint32_t tl, uint64_t start_lsn, uint32_t len, void *out)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	ch->timeline = tl;
+	ch->opcode = PS_OP_WAL_READ;
+	ch->req_lsn = start_lsn;
+	ch->datalen = len;
+	cl_exec();
+	memcpy(out, ch->data, len);
+	return ch->result;
+}
+
 /* ===================== page helpers ==================================== */
 
 /* Encode lsn into the page's first 8 bytes (xlogid, xrecoff), tag the rest. */
@@ -728,10 +743,14 @@ run_wal_suite(const char *daemon_path, const char *tmpbase)
 	char		store[256];
 	pid_t		dpid;
 	uint32_t	ps = 8192;
-	unsigned char buf[512];
+	unsigned char bufa[500];
+	unsigned char bufb[500];
+	unsigned char rback[512];
+	int			ok;
 
 	fprintf(stderr, "== shipped WAL ==\n");
-	memset(buf, 0xAB, sizeof(buf));
+	memset(bufa, 0xAA, sizeof(bufa));	/* WAL [1000,1500) */
+	memset(bufb, 0xBB, sizeof(bufb));	/* WAL [1500,2000) */
 
 	snprintf(shm, sizeof(shm), "/pstest_%d_wal", (int) getpid());
 	snprintf(store, sizeof(store), "%s/store_wal", tmpbase);
@@ -743,14 +762,25 @@ run_wal_suite(const char *daemon_path, const char *tmpbase)
 	client_attach(shm, ps);
 
 	check(op_wal_size(0) == 0, "empty timeline has no WAL");
-	op_wal_append(0, 1000, buf, 500);
+	op_wal_append(0, 1000, bufa, 500);
 	check(op_wal_size(0) == 1500, "WAL end LSN advances after append");
-	op_wal_append(0, 1500, buf, 500);
+	op_wal_append(0, 1500, bufb, 500);
 	check(op_wal_size(0) == 2000, "WAL end LSN advances after second append");
+
+	/* read the WAL back, spanning the two records, and check positions */
+	check(op_wal_read(0, 1400, 200, rback) == 200, "WAL read returns the requested bytes");
+	ok = 1;
+	for (int i = 0; i < 100; i++)	/* [1400,1500) came from the 0xAA record */
+		if (rback[i] != 0xAA)
+			ok = 0;
+	for (int i = 100; i < 200; i++)	/* [1500,1600) from the 0xBB record */
+		if (rback[i] != 0xBB)
+			ok = 0;
+	check(ok, "WAL read assembles the right bytes across records (at their LSNs)");
 
 	/* a branch keeps its own WAL log */
 	op_create_branch(1, 0, 2000);
-	op_wal_append(1, 2000, buf, 300);
+	op_wal_append(1, 2000, bufa, 300);
 	check(op_wal_size(1) == 2300, "branch WAL advances independently");
 	check(op_wal_size(0) == 2000, "parent WAL unaffected by branch WAL");
 

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -410,6 +410,39 @@ op_wal_read(uint32_t tl, uint64_t start_lsn, uint32_t len, void *out)
 	return ch->result;
 }
 
+/* --- per-page WAL index operations --- */
+
+static void
+op_walidx_add(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block, uint64_t lsn)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	cl_setkey(ch, rel, fork);
+	ch->timeline = tl;
+	ch->opcode = PS_OP_WAL_INDEX_ADD;
+	ch->blocknum = block;
+	ch->req_lsn = lsn;
+	cl_exec();
+}
+
+/* Returns count; fills out[] with the record LSNs <= lsn_max. */
+static int
+op_walidx_get(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
+			  uint64_t lsn_max, uint64_t *out)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+	int			n;
+
+	cl_setkey(ch, rel, fork);
+	ch->timeline = tl;
+	ch->opcode = PS_OP_WAL_INDEX_GET;
+	ch->blocknum = block;
+	ch->req_lsn = lsn_max;
+	n = (int) cl_exec()->result;
+	memcpy(out, ch->data, (size_t) n * sizeof(uint64_t));
+	return n;
+}
+
 /* ===================== page helpers ==================================== */
 
 /* Encode lsn into the page's first 8 bytes (xlogid, xrecoff), tag the rest. */
@@ -801,6 +834,59 @@ run_wal_suite(const char *daemon_path, const char *tmpbase)
 }
 
 /*
+ * Per-page WAL index: record which WAL LSNs modify each page and query the ones
+ * visible as-of an LSN -- the lookup single-page materialization will use.
+ */
+static void
+run_walidx_suite(const char *daemon_path, const char *tmpbase)
+{
+	char		shm[64];
+	char		store[256];
+	pid_t		dpid;
+	uint32_t	ps = 8192;
+	uint64_t	out[16];
+	int		n;
+
+	fprintf(stderr, "== per-page WAL index ==\n");
+	snprintf(shm, sizeof(shm), "/pstest_%d_widx", (int) getpid());
+	snprintf(store, sizeof(store), "%s/store_widx", tmpbase);
+	rm_rf(store);
+	shm_unlink(shm);
+
+	dpid = spawn_daemon(daemon_path, shm, store, ps);
+	wait_ready(shm, ps);
+	client_attach(shm, ps);
+
+	/* block 0 changed by records at LSN 100, 200, 300; block 1 at 150 */
+	op_walidx_add(0, REL_A, FORK0, 0, 100);
+	op_walidx_add(0, REL_A, FORK0, 0, 200);
+	op_walidx_add(0, REL_A, FORK0, 0, 300);
+	op_walidx_add(0, REL_A, FORK0, 1, 150);
+
+	n = op_walidx_get(0, REL_A, FORK0, 0, 250, out);
+	check(n == 2 && out[0] == 100 && out[1] == 200,
+		  "index returns records <= lsn (block 0 as-of 250 -> [100,200])");
+	n = op_walidx_get(0, REL_A, FORK0, 0, 1000000, out);
+	check(n == 3 && out[2] == 300, "index returns all records up to a high lsn");
+	check(op_walidx_get(0, REL_A, FORK0, 0, 50, out) == 0, "no records below the first lsn");
+	n = op_walidx_get(0, REL_A, FORK0, 1, 200, out);
+	check(n == 1 && out[0] == 150, "per-block separation (block 1 -> [150])");
+	check(op_walidx_get(0, REL_A, FORK0, 9, 1000000, out) == 0, "unindexed block -> empty");
+
+	/* a branch sees its own records plus the parent's, capped at the fork LSN */
+	op_create_branch(1, 0, 250);
+	op_walidx_add(1, REL_A, FORK0, 0, 400);
+	n = op_walidx_get(1, REL_A, FORK0, 0, 1000000, out);
+	/* branch's 400, plus parent's <= branch_lsn 250 (100,200; not 300) */
+	check(n == 3, "branch index reads through to parent capped at the branch lsn");
+
+	client_detach();
+	stop_daemon(dpid);
+	rm_rf(store);
+	shm_unlink(shm);
+}
+
+/*
  * Vectored I/O: a single WRITEV/READV carrying many pages, exercising the
  * daemon's multi-block loop (the single-block suites never do nblocks > 1).
  */
@@ -959,6 +1045,9 @@ main(int argc, char **argv)
 
 	/* shipped-WAL durability */
 	run_wal_suite(daemon_path, tmpbase);
+
+	/* per-page WAL index */
+	run_walidx_suite(daemon_path, tmpbase);
 
 	/* vectored multi-page I/O */
 	run_vectored_suite(daemon_path, tmpbase);

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -337,6 +337,34 @@ op_read_at_tl(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
 	memcpy(out, ch->data, cl_page_size);
 }
 
+/* --- shipped-WAL operations --- */
+
+/* Append len WAL bytes at start_lsn on a timeline. */
+static void
+op_wal_append(uint32_t tl, uint64_t start_lsn, const void *data, uint32_t len)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	ch->timeline = tl;
+	ch->opcode = PS_OP_WAL_APPEND;
+	ch->req_lsn = start_lsn;
+	ch->datalen = len;
+	memcpy(ch->data, data, len);
+	cl_exec();
+}
+
+/* Return the end LSN of a timeline's shipped WAL. */
+static uint64_t
+op_wal_size(uint32_t tl)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	ch->timeline = tl;
+	ch->opcode = PS_OP_WAL_SIZE;
+	cl_exec();
+	return ch->req_lsn;
+}
+
 /* ===================== page helpers ==================================== */
 
 /* Encode lsn into the page's first 8 bytes (xlogid, xrecoff), tag the rest. */
@@ -658,6 +686,60 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 	free(rb);
 }
 
+/*
+ * Shipped WAL: the store persists a per-timeline WAL log durably, branches keep
+ * their own log, and the end LSN survives a daemon restart.  (This is the
+ * transport/durability layer; replaying it to pages -- redo -- is future work.)
+ */
+static void
+run_wal_suite(const char *daemon_path, const char *tmpbase)
+{
+	char		shm[64];
+	char		store[256];
+	pid_t		dpid;
+	uint32_t	ps = 8192;
+	unsigned char buf[512];
+
+	fprintf(stderr, "== shipped WAL ==\n");
+	memset(buf, 0xAB, sizeof(buf));
+
+	snprintf(shm, sizeof(shm), "/pstest_%d_wal", (int) getpid());
+	snprintf(store, sizeof(store), "%s/store_wal", tmpbase);
+	rm_rf(store);
+	shm_unlink(shm);
+
+	dpid = spawn_daemon(daemon_path, shm, store, ps);
+	wait_ready(shm, ps);
+	client_attach(shm, ps);
+
+	check(op_wal_size(0) == 0, "empty timeline has no WAL");
+	op_wal_append(0, 1000, buf, 500);
+	check(op_wal_size(0) == 1500, "WAL end LSN advances after append");
+	op_wal_append(0, 1500, buf, 500);
+	check(op_wal_size(0) == 2000, "WAL end LSN advances after second append");
+
+	/* a branch keeps its own WAL log */
+	op_create_branch(1, 0, 2000);
+	op_wal_append(1, 2000, buf, 300);
+	check(op_wal_size(1) == 2300, "branch WAL advances independently");
+	check(op_wal_size(0) == 2000, "parent WAL unaffected by branch WAL");
+
+	/* WAL end LSNs survive a daemon restart (recovered from the logs) */
+	client_detach();
+	stop_daemon(dpid);
+	shm_unlink(shm);
+	dpid = spawn_daemon(daemon_path, shm, store, ps);
+	wait_ready(shm, ps);
+	client_attach(shm, ps);
+	check(op_wal_size(0) == 2000, "main WAL end LSN survives daemon restart");
+	check(op_wal_size(1) == 2300, "branch WAL end LSN survives daemon restart");
+
+	client_detach();
+	stop_daemon(dpid);
+	rm_rf(store);
+	shm_unlink(shm);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -686,6 +768,9 @@ main(int argc, char **argv)
 
 	/* branch / snapshot isolation (page-size independent, run once) */
 	run_branch_suite(daemon_path, tmpbase);
+
+	/* shipped-WAL durability */
+	run_wal_suite(daemon_path, tmpbase);
 
 	rmdir(tmpbase);
 

--- a/contrib/pagestore/pagestore_walrestore.c
+++ b/contrib/pagestore/pagestore_walrestore.c
@@ -123,6 +123,20 @@ main(int argc, char **argv)
 		return 2;
 	}
 
+	/*
+	 * The WAL segment size must be a power of two in [1 MB, 1 GB] (PostgreSQL's
+	 * own constraint).  Reject anything else before dividing by it: a zero or
+	 * bogus --segsize would divide-by-zero / miscompute the LSN and break
+	 * recovery.
+	 */
+	if (segsize < 1024 * 1024 || segsize > 1024 * 1024 * 1024 ||
+		(segsize & (segsize - 1)) != 0)
+	{
+		fprintf(stderr, "invalid --segsize %llu (must be a power of two, "
+				"1MB..1GB)\n", (unsigned long long) segsize);
+		return 2;
+	}
+
 	/* segment file name is TLI(8 hex) + xlogid(8 hex) + segment-in-id(8 hex) */
 	if (sscanf(segname, "%8X%8X%8X", &tli, &hi, &lo) != 3)
 	{

--- a/contrib/pagestore/pagestore_walrestore.c
+++ b/contrib/pagestore/pagestore_walrestore.c
@@ -1,0 +1,174 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_walrestore.c
+ *	  Reconstruct a standard WAL segment file from the WAL a timeline shipped to
+ *	  the pagestore daemon.  Usable directly as a PostgreSQL restore_command, so
+ *	  a recovery instance can replay WAL that lives in the store (the bridge from
+ *	  shipped WAL to redo).
+ *
+ * Given a segment file name (e.g. 000000010000000000000005) it computes the
+ * segment's start LSN, reads wal_segment_size bytes from the store via
+ * PS_OP_WAL_READ (in io_unit chunks), and writes them to the output path.
+ * Exit 0 if the whole segment was available, non-zero otherwise (which tells
+ * recovery there is no more WAL) -- standard restore_command semantics.
+ *
+ * Freestanding: only pagestore_ipc.h and libc.
+ *
+ * Usage (as restore_command):
+ *   pagestore_walrestore --shm NAME --timeline N --segsize BYTES %f %p
+ *
+ * src/../contrib/pagestore/pagestore_walrestore.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "pagestore_ipc.h"
+
+static void *shm;
+static int	chan;
+
+static void
+client_attach(const char *shm_name, uint32_t page_size_unused)
+{
+	int			fd = shm_open(shm_name, O_RDWR, 0600);
+	PsShmHeader *hdr;
+
+	(void) page_size_unused;
+	if (fd < 0)
+	{
+		perror("shm_open (is the daemon running?)");
+		exit(2);
+	}
+	shm = mmap(NULL, PS_SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (shm == MAP_FAILED)
+	{
+		perror("mmap");
+		exit(2);
+	}
+	close(fd);
+	hdr = (PsShmHeader *) shm;
+	if (hdr->magic != PS_SHM_MAGIC)
+	{
+		fprintf(stderr, "bad shm header\n");
+		exit(2);
+	}
+	for (uint32_t i = 0; i < hdr->nchannels; i++)
+		if (ps_cas(&ps_channel(shm, i)->claimed, 0, 1))
+		{
+			chan = (int) i;
+			return;
+		}
+	fprintf(stderr, "no free channel\n");
+	exit(2);
+}
+
+/* Read up to len WAL bytes from start_lsn on a timeline; returns bytes read. */
+static uint32_t
+wal_read(uint32_t tl, uint64_t start_lsn, uint32_t len, void *out)
+{
+	PsChannel  *ch = ps_channel(shm, chan);
+
+	ch->timeline = tl;
+	ch->opcode = PS_OP_WAL_READ;
+	ch->req_lsn = start_lsn;
+	ch->datalen = len;
+	ps_store_release(&ch->state, PS_STATE_REQUEST);
+	while (ps_load_acquire(&ch->state) != PS_STATE_DONE)
+		;
+	memcpy(out, ch->data, len);
+	return ch->result;
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *shm_name = NULL;
+	uint32_t	timeline = 0;
+	uint64_t	segsize = 16 * 1024 * 1024;
+	const char *segname = NULL;
+	const char *outpath = NULL;
+	uint32_t	tli,
+				hi,
+				lo;
+	uint64_t	segs_per_id,
+				segno,
+				start_lsn,
+				off = 0;
+	int			outfd;
+	unsigned char *buf;
+
+	for (int i = 1; i < argc; i++)
+	{
+		if (strcmp(argv[i], "--shm") == 0 && i + 1 < argc)
+			shm_name = argv[++i];
+		else if (strcmp(argv[i], "--timeline") == 0 && i + 1 < argc)
+			timeline = (uint32_t) strtoul(argv[++i], NULL, 10);
+		else if (strcmp(argv[i], "--segsize") == 0 && i + 1 < argc)
+			segsize = strtoull(argv[++i], NULL, 10);
+		else if (!segname)
+			segname = argv[i];
+		else if (!outpath)
+			outpath = argv[i];
+	}
+	if (!shm_name || !segname || !outpath)
+	{
+		fprintf(stderr, "usage: %s --shm NAME [--timeline N] [--segsize B] <segfile> <outpath>\n",
+				argv[0]);
+		return 2;
+	}
+
+	/* segment file name is TLI(8 hex) + xlogid(8 hex) + segment-in-id(8 hex) */
+	if (sscanf(segname, "%8X%8X%8X", &tli, &hi, &lo) != 3)
+	{
+		fprintf(stderr, "bad segment name \"%s\"\n", segname);
+		return 2;
+	}
+	segs_per_id = 0x100000000ULL / segsize;
+	segno = (uint64_t) hi * segs_per_id + lo;
+	start_lsn = segno * segsize;
+
+	client_attach(shm_name, 0);
+
+	buf = malloc(PS_IO_UNIT);
+	outfd = open(outpath, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (outfd < 0)
+	{
+		perror("open outpath");
+		return 2;
+	}
+
+	while (off < segsize)
+	{
+		uint32_t	want = (uint32_t) ((segsize - off) < PS_IO_UNIT ?
+									   (segsize - off) : PS_IO_UNIT);
+		uint32_t	got = wal_read(timeline, start_lsn + off, want, buf);
+
+		if (got == 0)
+			break;				/* not in the store: segment unavailable */
+		if (write(outfd, buf, got) != (ssize_t) got)
+		{
+			perror("write");
+			close(outfd);
+			return 2;
+		}
+		off += got;
+		if (got < want)
+			break;
+	}
+	close(outfd);
+	free(buf);
+
+	if (off < segsize)
+	{
+		/* segment not (fully) available -> tell recovery there is no more WAL */
+		unlink(outpath);
+		return 1;
+	}
+	return 0;
+}

--- a/contrib/pagestore/redo_worker_demo.sh
+++ b/contrib/pagestore/redo_worker_demo.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# redo_worker_demo.sh -- demonstrate WAL redo in the store (milestone 3b).
+#
+# A PostgreSQL instance performs archive recovery with its WAL fetched entirely
+# from the page store (restore_command = pagestore_walrestore) and its relations
+# routed to the store (route_all).  Recovery's own rm_redo reads base pages from
+# the store, replays the shipped WAL, and writes the resulting pages back to the
+# store -- reusing PostgreSQL's redo wholesale, no rmgr reimplementation.
+#
+# Self-asserting; needs a full PostgreSQL build.  Pass the meson build dir as $1.
+#   contrib/pagestore/redo_worker_demo.sh /path/to/build
+#
+# Limitation: the redo instance runs with recovery_prefetch=off (the backend's
+# recovery-prefetch/AIO path is not wired yet).  See WAL_REDO.md.
+#
+set -uo pipefail
+
+BUILD=${1:?usage: redo_worker_demo.sh <meson-build-dir>}
+PGCTL=$(find "$BUILD/tmp_install" -path '*/bin/pg_ctl' -type f 2>/dev/null | head -1)
+[ -z "$PGCTL" ] && { echo "FAIL - no tmp_install (run: meson test -C $BUILD --suite setup)"; exit 1; }
+BIN=$(dirname "$PGCTL")
+ROOT=$(dirname "$BIN")
+export LD_LIBRARY_PATH="$ROOT/lib:$ROOT/lib64"
+DAEMON="$BUILD/contrib/pagestore/pagestore_daemon"
+IMPORT="$BUILD/contrib/pagestore/pagestore_import"
+WALRESTORE="$BUILD/contrib/pagestore/pagestore_walrestore"
+
+D=$(mktemp -d)/pgdata
+S=$(mktemp -d)/store
+SHM=/psredo_$$
+PORT=54470
+P="$BIN/psql -h 127.0.0.1 -p $PORT -U postgres -tA"
+
+cleanup() {
+	"$BIN/pg_ctl" -D "$D" -m immediate -w stop >/dev/null 2>&1 || true
+	[ -n "${DPID:-}" ] && kill "$DPID" 2>/dev/null || true
+	rm -rf "$(dirname "$D")" "$(dirname "$S")"
+	rm -f "/dev/shm$SHM"
+}
+trap cleanup EXIT
+
+mkdir -p "$S"
+"$BIN/initdb" -D "$D" -U postgres -A trust >/dev/null 2>&1
+"$DAEMON" --shm "$SHM" --store "$S" >/dev/null 2>&1 &
+DPID=$!
+sleep 0.5
+"$IMPORT" --shm "$SHM" --pgdata "$D" >/dev/null 2>&1
+
+cat >> "$D/postgresql.conf" <<EOF
+shared_preload_libraries = 'pagestore'
+pagestore.route_all = on
+pagestore.backend = 'localsvc'
+pagestore.localsvc_shm = '$SHM'
+io_method = sync
+recovery_prefetch = off
+archive_mode = on
+archive_library = 'pagestore'
+port = $PORT
+EOF
+
+# 1) writer: a row, a base backup (recovery start point), then a change shipped
+"$BIN/pg_ctl" -D "$D" -l "$D/w.log" -w start >/dev/null 2>&1
+$P -c "CREATE TABLE t(id int primary key, v text); INSERT INTO t VALUES (1,'base');" >/dev/null
+# write the backup label straight into PGDATA (unquoted heredoc expands $D)
+"$BIN/psql" -h 127.0.0.1 -p $PORT -U postgres >/dev/null <<SQL
+SELECT pg_backup_start('b', fast => true);
+\a
+\t on
+\o $D/backup_label
+SELECT labelfile FROM pg_backup_stop();
+\o
+SQL
+$P -c "UPDATE t SET v='changed' WHERE id=1;" >/dev/null
+
+# the segment holding the backup start point must reach the store; wait until
+# it (and the WAL after it) is archived, since archiving is asynchronous
+startseg=$(sed -n 's/.*(file \([0-9A-F]\{24\}\)).*/\1/p' "$D/backup_label")
+for _ in $(seq 1 50); do
+	$P -c "SELECT pg_switch_wal();" >/dev/null 2>&1
+	[ -f "$D/pg_wal/archive_status/$startseg.done" ] && break
+	sleep 0.2
+done
+"$BIN/pg_ctl" -D "$D" -m fast -w stop >/dev/null 2>&1
+
+# 2) turn the instance into a redo worker: recover from the store's WAL only
+# (backup_label is already in PGDATA from pg_backup_stop above)
+touch "$D/recovery.signal"
+echo "restore_command = '$WALRESTORE --shm $SHM --timeline 0 --segsize 16777216 %f %p'" >> "$D/postgresql.conf"
+rm -f "$D"/pg_wal/0000000*	# remove local WAL: recovery must fetch from the store
+
+if "$BIN/pg_ctl" -D "$D" -l "$D/r.log" -w start >/dev/null 2>&1; then
+	val=$($P -c "SELECT v FROM t WHERE id=1;")
+	if [ "$val" = "changed" ]; then
+		echo "ok   - redo worker recovered 'changed' from store-resident WAL"
+		grep -q "restored log file" "$D/r.log" && \
+			echo "ok   - WAL was fetched from the store via pagestore_walrestore" || \
+			{ echo "FAIL - restore_command was not used"; exit 1; }
+		echo "redo worker demo: PASS"
+		exit 0
+	fi
+	echo "FAIL - recovered value is '$val', expected 'changed'"
+else
+	echo "FAIL - redo worker did not start; recovery log:"
+	tail -5 "$D/r.log" 2>/dev/null
+fi
+exit 1

--- a/contrib/pagestore/wal_only_redo_demo.sh
+++ b/contrib/pagestore/wal_only_redo_demo.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# wal_only_redo_demo.sh -- non-redundant WAL redo (milestone 3d, step 1).
+#
+# Unlike redo_worker_demo.sh (where the writer page-ships via route_all, so the
+# store already has the pages and redo is redundant), here the writer ships
+# ONLY WAL (route_all OFF -> its relation pages stay local, never reach the
+# store).  A redo worker then materializes the relations into the store purely
+# by replaying the shipped WAL -- so the store's pages come from redo, not from
+# the compute.  This is the value of WAL redo: a stateless-ish write compute.
+#
+# Self-asserting; needs a full PostgreSQL build.  Pass the meson build dir as $1.
+#
+set -uo pipefail
+
+BUILD=${1:?usage: wal_only_redo_demo.sh <meson-build-dir>}
+PGCTL=$(find "$BUILD/tmp_install" -path '*/bin/pg_ctl' -type f 2>/dev/null | head -1)
+[ -z "$PGCTL" ] && { echo "FAIL - no tmp_install"; exit 1; }
+BIN=$(dirname "$PGCTL")
+ROOT=$(dirname "$BIN")
+export LD_LIBRARY_PATH="$ROOT/lib:$ROOT/lib64"
+DAEMON="$BUILD/contrib/pagestore/pagestore_daemon"
+IMPORT="$BUILD/contrib/pagestore/pagestore_import"
+WALRESTORE="$BUILD/contrib/pagestore/pagestore_walrestore"
+
+D=$(mktemp -d)/pgdata
+S=$(mktemp -d)/store
+SHM=/pswonly_$$
+PORT=54480
+P="$BIN/psql -h 127.0.0.1 -p $PORT -U postgres -tA"
+
+cleanup() {
+	"$BIN/pg_ctl" -D "$D" -m immediate -w stop >/dev/null 2>&1 || true
+	[ -n "${DPID:-}" ] && kill "$DPID" 2>/dev/null || true
+	rm -rf "$(dirname "$D")" "$(dirname "$S")"
+	rm -f "/dev/shm$SHM"
+}
+trap cleanup EXIT
+
+store_size() { du -sb "$S" 2>/dev/null | cut -f1; }
+
+mkdir -p "$S"
+"$BIN/initdb" -D "$D" -U postgres -A trust >/dev/null 2>&1
+"$DAEMON" --shm "$SHM" --store "$S" >/dev/null 2>&1 &
+DPID=$!
+sleep 0.5
+"$IMPORT" --shm "$SHM" --pgdata "$D" >/dev/null 2>&1   # base = empty cluster
+
+# writer: WAL-only.  route_all OFF -> relation pages stay local, only WAL ships.
+cat >> "$D/postgresql.conf" <<EOF
+shared_preload_libraries = 'pagestore'
+pagestore.backend = 'localsvc'
+pagestore.localsvc_shm = '$SHM'
+pagestore.route_all = off
+io_method = sync
+recovery_prefetch = off
+archive_mode = on
+archive_library = 'pagestore'
+port = $PORT
+EOF
+
+"$BIN/pg_ctl" -D "$D" -l "$D/w.log" -w start >/dev/null 2>&1
+# base backup right at the start (recovery start point), before any user table
+"$BIN/psql" -h 127.0.0.1 -p $PORT -U postgres >/dev/null <<SQL
+SELECT pg_backup_start('b', fast => true);
+\a
+\t on
+\o $D/backup_label
+SELECT labelfile FROM pg_backup_stop();
+\o
+SQL
+# create the table and change it; its pages are written LOCALLY, never shipped
+$P -c "CREATE TABLE t(id int primary key, v text); INSERT INTO t VALUES (1,'base');" >/dev/null
+$P -c "UPDATE t SET v='changed' WHERE id=1;" >/dev/null
+startseg=$(sed -n 's/.*(file \([0-9A-F]\{24\}\)).*/\1/p' "$D/backup_label")
+for _ in $(seq 1 50); do
+	$P -c "SELECT pg_switch_wal();" >/dev/null 2>&1
+	[ -f "$D/pg_wal/archive_status/$startseg.done" ] && break
+	sleep 0.2
+done
+# table t's relation file exists locally (the writer did not page-ship it)
+relfile=$($P -c "SELECT pg_relation_filepath('t');")
+[ -f "$D/$relfile" ] && echo "ok   - writer kept table pages local (no page-ship): $relfile" \
+	|| { echo "FAIL - expected local relation file $relfile"; }
+"$BIN/pg_ctl" -D "$D" -m fast -w stop >/dev/null 2>&1
+
+before=$(store_size)
+
+# redo worker: now route relations to the store and recover from shipped WAL.
+sed -i 's/^pagestore.route_all = off/pagestore.route_all = on/' "$D/postgresql.conf"
+touch "$D/recovery.signal"
+echo "restore_command = '$WALRESTORE --shm $SHM --timeline 0 --segsize 16777216 %f %p'" >> "$D/postgresql.conf"
+rm -f "$D"/pg_wal/0000000*
+
+if "$BIN/pg_ctl" -D "$D" -l "$D/r.log" -w start >/dev/null 2>&1; then
+	val=$($P -c "SELECT v FROM t WHERE id=1;" 2>/dev/null)
+	after=$(store_size)
+	if [ "$val" = "changed" ]; then
+		echo "ok   - redo materialized table t into the store from WAL alone (v=changed)"
+	else
+		echo "FAIL - recovered value '$val', expected 'changed'"; exit 1
+	fi
+	if [ "${after:-0}" -gt "${before:-0}" ]; then
+		echo "ok   - store grew via redo (${before} -> ${after} bytes; pages produced by redo, not the compute)"
+	else
+		echo "FAIL - store did not grow ($before -> $after); redo produced no pages"; exit 1
+	fi
+	echo "wal-only redo demo: PASS"
+	exit 0
+else
+	echo "FAIL - redo worker did not start; log:"; tail -5 "$D/r.log" 2>/dev/null
+fi
+exit 1

--- a/contrib/pagestore/wal_only_redo_demo.sh
+++ b/contrib/pagestore/wal_only_redo_demo.sh
@@ -37,8 +37,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-store_size() { du -sb "$S" 2>/dev/null | cut -f1; }
-
 mkdir -p "$S"
 "$BIN/initdb" -D "$D" -U postgres -A trust >/dev/null 2>&1
 "$DAEMON" --shm "$SHM" --store "$S" >/dev/null 2>&1 &
@@ -81,10 +79,12 @@ done
 # table t's relation file exists locally (the writer did not page-ship it)
 relfile=$($P -c "SELECT pg_relation_filepath('t');")
 [ -f "$D/$relfile" ] && echo "ok   - writer kept table pages local (no page-ship): $relfile" \
-	|| { echo "FAIL - expected local relation file $relfile"; }
+	|| { echo "FAIL - expected local relation file $relfile"; exit 1; }
 "$BIN/pg_ctl" -D "$D" -m fast -w stop >/dev/null 2>&1
 
-before=$(store_size)
+# Remove the local heap file so that any later read of table t can ONLY be
+# served from the store -- i.e. from pages the redo worker materialized.
+rm -f "$D/$relfile"*
 
 # redo worker: now route relations to the store and recover from shipped WAL.
 sed -i 's/^pagestore.route_all = off/pagestore.route_all = on/' "$D/postgresql.conf"
@@ -94,19 +94,12 @@ rm -f "$D"/pg_wal/0000000*
 
 if "$BIN/pg_ctl" -D "$D" -l "$D/r.log" -w start >/dev/null 2>&1; then
 	val=$($P -c "SELECT v FROM t WHERE id=1;" 2>/dev/null)
-	after=$(store_size)
 	if [ "$val" = "changed" ]; then
-		echo "ok   - redo materialized table t into the store from WAL alone (v=changed)"
-	else
-		echo "FAIL - recovered value '$val', expected 'changed'"; exit 1
+		echo "ok   - table read served from the store (local heap removed); redo built it from WAL"
+		echo "wal-only redo demo: PASS"
+		exit 0
 	fi
-	if [ "${after:-0}" -gt "${before:-0}" ]; then
-		echo "ok   - store grew via redo (${before} -> ${after} bytes; pages produced by redo, not the compute)"
-	else
-		echo "FAIL - store did not grow ($before -> $after); redo produced no pages"; exit 1
-	fi
-	echo "wal-only redo demo: PASS"
-	exit 0
+	echo "FAIL - read '$val', expected 'changed' (store should hold redo-built pages)"
 else
 	echo "FAIL - redo worker did not start; log:"; tail -5 "$D/r.log" 2>/dev/null
 fi


### PR DESCRIPTION
Stacked on #4 (compute-on-branch). Base retargets toward `branchdb_18` as the
stack merges.

## WAL shipping (transport + durability)
The compute's WAL is now persisted by the store, per timeline — the first two
of the three WAL-shipping layers.

- **Daemon**: each timeline has an append-only, self-describing WAL log
  `wal_<tl>`; the end LSN is tracked and rebuilt from the log at startup.
  IPC ops `WAL_APPEND` / `WAL_SIZE`; shm version → 4.
- **Compute**: `pagestore.so` also implements the `archive_library` API, so the
  archiver streams each completed WAL segment into the daemon's log at its true
  WAL positions. No core patch (official archive API); granularity is one
  completed segment.
- **Verified**: with `archive_mode=on` + `archive_library='pagestore'`,
  completed segments arrive in `wal_<tl>` (3 segments → ~48MB).

**Not in this PR**: replaying the shipped WAL to materialize pages (redo). That
is the third layer and would reuse PostgreSQL's rmgr redo; it's what would let
fully independent concurrent computes run on a branch.

## Broader tests (addressing thin coverage)
- Standalone (CI, no PostgreSQL): **vectored multi-page** WRITEV/READV (the
  daemon's multi-block loop was previously never exercised) and an **8-client
  concurrency** suite. 100 checks.
- **In-engine integration test** + a **second CI job** that builds PostgreSQL
  and runs it: asserts localsvc routing + restart round-trip, COW time-travel
  reads, and WAL shipping — so the real smgr-hijack path is covered in CI, not
  just by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)