### PR TITLE
contrib/pagestore: SPDK storage backend (high-performance option, ABI unchanged)

### DIFF
--- a/.github/workflows/pagestore-test.yml
+++ b/.github/workflows/pagestore-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Compile daemon and test harness
         working-directory: contrib/pagestore
         run: |
-          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c -lrt
+          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c storage_posix.c -lrt
           cc -O2 -Wall -Wextra -Werror -o pagestore_test   pagestore_test.c   -lrt
 
       - name: Run standalone test suite

--- a/.github/workflows/pagestore-test.yml
+++ b/.github/workflows/pagestore-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Compile daemon and test harness
         working-directory: contrib/pagestore
         run: |
-          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c storage_posix.c -lrt
+          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c pagestore_core.c storage_posix.c -lrt
           cc -O2 -Wall -Wextra -Werror -o pagestore_test   pagestore_test.c   -lrt
 
       - name: Run standalone test suite

--- a/contrib/pagestore/DESIGN_NOTES.md
+++ b/contrib/pagestore/DESIGN_NOTES.md
@@ -57,6 +57,46 @@ keep a per-core layer map, and run compaction/GC per shard.  In other words, the
 choice of data structure (item 1) must account for how it is owned and accessed
 across cores (item 2).
 
+## 3. The in-memory cache must be database-adapted, not an fs page cache
+
+SPDK bypasses the kernel, so it loses the OS page cache and readahead.  A
+benchmark made this concrete: on sequential reads POSIX (kernel readahead +
+page cache) does ~1574 MiB/s cold vs SPDK ~756; on *random* reads the kernel's
+advantage evaporates and the two tie (~750).  The naive fix -- a userspace
+block-address LRU -- is the wrong design: **you still fill it with the same I/O
+bandwidth**, so it merely re-implements the kernel cache we just bypassed, and a
+single big seqscan thrashes it.  You cannot out-bandwidth a cold/streaming
+workload, so don't try; be selective and cache at the level of database
+semantics, where the store knows things a block cache cannot:
+
+- **Cache materialized page versions, not blocks.**  Key by
+  `(timeline, key, block, LSN)`; the value is the reconstructed page image.  A
+  hit then skips both the device read *and* the WAL replay (single-page redo,
+  3c-4) that is the genuinely expensive work -- this is the page-server insight
+  (Neon's pageserver caches redo outputs).  Branches share a parent's cached
+  page by read-through instead of duplicating it.
+- **Value-aware admission/eviction, not pure LRU.**  Keep what is expensive to
+  reproduce and likely reused -- B-tree interior nodes, catalog/SLRU, pages with
+  long redo chains -- ranked by `reproduction-cost x reuse-probability`, not
+  recency alone.
+- **Scan-resistant.**  A bulk seqscan must not evict the hot set; use a
+  ring/probation policy (exactly what PostgreSQL's buffer access strategies,
+  e.g. `BAS_BULKREAD`, do).  Detect sequential block runs, or take a hint.
+- **Structure-aware prefetch, not blind readahead.**  Prefetch driven by access
+  type (index range scan, bitmap heap scan) -- ideally from hints the compute's
+  AIO prefetcher already computes -- rather than guessing from offsets.
+- **Unified with the LSM image layers (item 1).**  An image layer is a persisted
+  materialization of pages at an LSN over a key range; the RAM cache is just the
+  hot tier of that same materialization.  So cache, image-layer materialization,
+  and compaction are one system with one policy (what to materialize, keep hot,
+  persist, evict), not a bolt-on LRU.
+- **Per-shard and lock-free (item 2):** each core owns its cache slice.
+
+In short, the cache's job is not "read the disk less" (a block cache does that
+and still needs the bandwidth) but "do less of the work the database makes
+expensive" -- redo replay and repeated index traversal -- while staying
+disciplined about scans.  Items 1, 2 and 3 are co-designed.
+
 ## Other known simplifications (smaller)
 
 - Indexes are in-memory and rebuilt on restart; the per-page WAL index is not

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -218,14 +218,18 @@ per-core indexes single-owner (still lock-free).  This is #2's design.
     ready channels and serves replies from completion callbacks (per-channel
     in-flight tracking) instead of completing one request before the next, to lift
     effective queue depth past one request's worth and approach the S0 ceiling.
-  - **S1.2d — userspace page cache + readahead in the daemon (high priority).**
-    SPDK bypasses the kernel, so the daemon must do its own caching -- the
-    benchmark above shows the kernel page cache + readahead is exactly why POSIX
-    wins sequential reads.  A shared, sharded page cache (hot pages kept in
-    hugepage RAM, keyed by (timeline,key,block,lsn)) plus sequential readahead
-    turns most reads into memory hits and prefetches the rest.  This also moves us
-    toward serving reads with zero device I/O for the working set -- the page
-    server model -- and composes with the LSM layers (S4) and sharding (S3).
+  - **S1.2d — database-adapted materialization cache (high priority, NOT a
+    block cache).**  The benchmark shows the kernel page cache + readahead is why
+    POSIX wins sequential reads -- but a userspace block-address LRU is the wrong
+    answer: it is filled with the same I/O bandwidth (re-implementing the kernel
+    cache we bypassed) and a seqscan thrashes it.  Instead, cache database
+    *semantics* (see DESIGN_NOTES.md #3): materialized page versions keyed by
+    (timeline,key,block,LSN) so a hit skips device read *and* redo; value-aware
+    admission (keep index/catalog/long-redo-chain pages); scan-resistant
+    (BAS_BULKREAD-style ring); structure-aware prefetch from compute hints;
+    unified with the LSM image layers (the RAM cache is the hot tier of the same
+    materialization), per-shard and lock-free.  Co-designed with S3/S4, not a
+    bolt-on.
 - **S2 — blobstore for segments + WAL; persistent metadata.** Blob per segment /
   per timeline log; index persisted in blob xattrs or a metadata blob → drop the
   scan-on-restart.

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -152,10 +152,22 @@ per-core indexes single-owner (still lock-free).  This is #2's design.
     `read_version`.  Both compiled into `pagestore_daemon`.  Zero behaviour
     change: standalone 110/110, `integration_test.sh` PASS.  This sets up the
     two-binary split — the SPDK daemon will reuse `pagestore_core.c` verbatim.
-  - **S1.2b (next) — SPDK build wiring**: meson `-Dpagestore_spdk` option that
-    finds SPDK libs/headers; `storage_spdk.c` skeleton + `pagestore_daemon_spdk.c`
-    skeleton that links SPDK, inits the env in library mode, and enumerates the
-    control disk.  Compile/link path first, no real I/O yet.
+  - **S1.2b — SPDK build wiring (DONE).** `storage_spdk.c` (the SPDK PsStorage
+    backend) + `pagestore_daemon_spdk.c` (frontend skeleton) + `spdk_build.sh`.
+    Library-mode bring-up works: `ps_storage->open()` does `spdk_env_init` +
+    `spdk_nvme_probe` on the control disk's PCI address and grabs ns1 + an I/O
+    qpair; the frontend reuses `ps_core_open` (the shared brain) and reports
+    ready.  Verified: `sudo pagestore_daemon_spdk --pci 0000:06:00.0` attaches
+    the disk (sector=512, 976773168 sectors, ~466 GiB).  Byte I/O is stubbed.
+    - Build recipe (in `spdk_build.sh`): SPDK static libs need
+      `-Wl,--whole-archive ... pkg-config --libs spdk_nvme spdk_env_dpdk ...
+      --no-whole-archive` plus `pkg-config --libs --static spdk_syslibs`;
+      `PKG_CONFIG_PATH` must include both `$SPDK/build/lib/pkgconfig` and
+      `$SPDK/dpdk/build/lib/pkgconfig`; DPDK is shared, so rpath
+      `$SPDK/{build,dpdk/build}/lib` to avoid `LD_LIBRARY_PATH`.  The SPDK build
+      also links `storage_posix.c` (core's default `ps_storage` references
+      `PsStoragePosix`).  Not wired into PG's meson (SPDK is a local-only,
+      bound-disk artifact); the script is the compile switch.
   - **S1.2c — async SPDK I/O + dispatch**: implement `PsStorage` over async
     `spdk_bdev_*`; the SPDK frontend's loop polls channels + `spdk_thread_poll`,
     issues reads/writes with completions, tracks in-flight per channel.  Gate:

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -120,6 +120,18 @@ per-core indexes single-owner (still lock-free).  This is #2's design.
   `spdk_app`; channel poll becomes a poller; replace segment `pread`/`pwrite`
   with async `spdk_bdev_*`; make request handling in-flight/callback-driven.
   Gate: the existing `integration_test.sh` passes against an SPDK-backed store.
+  - **S1.1 — pluggable storage seam (DONE).** All raw byte movement and
+    enumeration now go through a `PsStorage` vtable (`pagestore_storage.h`); the
+    daemon's indexes, append cursor, timeline metadata and request handling stay
+    storage-agnostic.  `storage_posix.c` is the libc-only default backend
+    (the prior file layout, moved verbatim), selectable via `--storage posix`
+    (default).  A `--storage spdk` slot and `extern PsStorageSpdk` are stubbed
+    behind `#ifdef PAGESTORE_SPDK`.  Zero behaviour change: standalone suite
+    110/110, `integration_test.sh` PASS.  IPC ABI and compute side untouched —
+    SPDK will be a *second* `PsStorage` implementation, never an ABI change.
+  - **S1.2 (next) — the SPDK backend** (`storage_spdk.c`, opt-in compile): one
+    reactor, async `spdk_bdev_*` behind the same vtable, plus the daemon's
+    request loop made callback-driven for in-flight reads.
 - **S2 — blobstore for segments + WAL; persistent metadata.** Blob per segment /
   per timeline log; index persisted in blob xattrs or a metadata blob → drop the
   scan-on-restart.

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -1,0 +1,180 @@
+# SPDK storage backend — research & bring-up plan
+
+This is the production-storage track for the page-store daemon: replace its
+single-threaded, blocking-POSIX I/O with **SPDK** (userspace NVMe + per-core
+reactors + asynchronous I/O), on a dedicated NVMe "control disk".  It directly
+realizes the two big directions in `DESIGN_NOTES.md`:
+
+- **#1 LSM-like layered store** — SPDK gives us raw block access to build
+  image/delta layers, compaction and GC on, instead of flat `seg_*` files.
+- **#2 multi-core daemon** — SPDK's reactor model *is* the per-core, lock-free,
+  async-I/O architecture that doc asks for (and asks to be co-designed, not
+  retrofitted).
+
+This track lives on its own branch (`feat/pagestore-spdk`) because it is a large,
+self-contained rework of the daemon's storage and threading model.
+
+## Environment on this box (surveyed 2026-06-17)
+
+Disks are identified by **PCI address** (stable); the kernel `nvmeN` names are
+NOT stable across reboot — after the first reboot the system disk came back as
+`nvme2n1`, so never key on the kernel name.  `scripts/setup.sh` also refuses to
+bind any disk with active mounts, a second safety net.
+
+| PCI      | model / size                | role                         |
+|----------|-----------------------------|------------------------------|
+| 01:00.0  | WD SN770 500G               | **system** (`/`, ESP, swap) — do not touch |
+| 02:00.0  | WD_BLACK SN850X 1000G       | **`/home`** (xfs, repo lives here) — do not touch |
+| 06:00.0  | WD SN850 (WDS500G1X0E) 500G | **control disk** → SPDK target (bound to vfio-pci) |
+
+- CPU: i9-13900K, 32 logical CPUs, **single NUMA node** → clean per-core reactors.
+- Build deps present: gcc 15.2, meson 1.8, ninja 1.13, nasm 2.16, `libnuma`,
+  `libuuid`, `libaio` header, OpenSSL 3.5.  isa-l comes from SPDK's submodule.
+- Network OK (can clone github.com/spdk/spdk).
+- **Prerequisites still missing** (S0 work):
+  - SPDK not installed.
+  - Hugepages = 0 (SPDK needs hugepage-backed DMA memory).
+  - **IOMMU is not active** — `/sys/kernel/iommu_groups/` is empty and the
+    kernel cmdline has no `intel_iommu=on`.  For safe `vfio-pci` DMA we must add
+    `intel_iommu=on iommu=pt` to the cmdline and reboot.  Without it SPDK falls
+    back to `uio_pci_generic` (or vfio no-IOMMU mode) — works, but no DMA
+    protection (a daemon bug can scribble host memory).  **Decision needed:**
+    reboot-for-vfio vs unsafe-noiommu for the prototype.
+
+## SPDK primer (only the parts that matter here)
+
+Target version: **v26.01** (released 2026-01-30; bundles DPDK 25.11).  Pin a tag.
+
+- **Reactor / thread model.** One thread pinned per core runs a polled event
+  loop; there are *no blocking syscalls* in the data path.  Work is dispatched
+  to `spdk_thread`s; each gets its own `io_channel` to a device.  Data owned by a
+  single thread needs no locks — exactly the property the daemon relies on today
+  (single accessor) but extended to N cores.
+- **Memory.** DMA buffers come from hugepages (`spdk_dma_malloc` / `spdk_malloc`).
+  I/O buffers must be DMA-able; cannot just `pwrite` an arbitrary heap pointer.
+- **Device access.** The NVMe namespace is driven from userspace; the kernel
+  `nvme` driver is detached and the device bound to `vfio-pci`/`uio`. Hot path
+  has zero kernel involvement.
+- **Storage abstractions** (pick per stage below):
+  - **bdev** — raw async block layer: `spdk_bdev_read_blocks` /
+    `spdk_bdev_write_blocks` over LBAs.  *You* own allocation. Max control.
+  - **blobstore** — a lock-free allocator over a bdev: "blobs" are resizable
+    extents (thin-provisioned, growable).  Metadata ops are isolated to a single
+    metadata thread (its lock-free guarantee).  Can bind the NVMe driver
+    directly and skip bdev overhead.  A `seg_*` file maps cleanly to a blob.
+  - higher layers (lvol, blobfs, FTL) — not needed.
+
+## The daemon I/O surface to abstract (it is narrow)
+
+Everything the store persists goes through ~4 operations plus a startup scan —
+this narrowness is what makes the swap tractable. In `pagestore_daemon.c`:
+
+1. **append page-version** to the current 8 MB segment, returning `(seg, off)` —
+   `pwrite(hdr)` + `pwrite(page)` (~L725-746), segment roll-over at `segment_size`.
+2. **random read page** at `(seg, off)` — `pread` (~L759-763).
+3. **append WAL** to per-timeline `wal_<tl>` — `open(O_APPEND)` + write (~L510).
+4. **ranged WAL read** by byte range — `pread` loop (~L549-566).
+5. **startup recovery** — sequentially scan every `seg_*` to rebuild the
+   in-memory indexes (`recover()`, ~L771-815).  SPDK + persistent metadata
+   should eventually remove this scan.
+
+`seg_fd()`/`seg_path()` (~L92-121) are the fd cache to be replaced by
+blob handles / LBA ranges.
+
+## Architecture decisions
+
+**A. Who owns the main loop?**  The daemon is a standalone process (not a PG
+backend), so it can hand its threads to SPDK.
+- **A1 (recommended):** daemon *is* an SPDK app — `spdk_app_start()` owns the
+  reactors; the current IPC channel poll loop becomes an `spdk_poller`.
+- A2: run SPDK in a side thread, keep the existing loop — fights SPDK's
+  threading; only a stepping stone, not the target.
+
+**B. Storage layout.**
+- Start: **blobstore, one blob per segment** (and per `wal_<tl>`). Least code,
+  lock-free, thin-provisioned, persistent metadata for free.
+- Target: **raw bdev + our own LSM allocator** (image/delta layers), co-designed
+  with `DESIGN_NOTES.md` #1.  The blobstore stage validates the async plumbing;
+  the LSM stage is where the real layered store lives.
+
+**C. Synchronous→asynchronous request handling (the real work).**  Today a
+backend request is served synchronously on the poll loop (`pread` returns, reply
+goes back).  With async NVMe a read *completes in a callback*.  The daemon must
+track **in-flight requests** and send the reply from the I/O completion callback.
+This async refactor of request handling — not the device plumbing — is the bulk
+of the effort.
+
+**D. Sharding (multi-core).**  Partition the key space `(timeline, key)` across
+reactors; route a backend channel to the core that owns its relations; keep
+per-core indexes single-owner (still lock-free).  This is #2's design.
+
+## Staged plan
+
+- **S0 — bring up & validate the control disk.** Install SPDK (clone +
+  submodules + `pkgdep.sh` + `configure` + `make`), reserve hugepages, bind
+  `06:00.0` to vfio/uio (`scripts/setup.sh`), and benchmark raw nvme2 with
+  `examples/identify` and `examples/perf` (randread/randwrite 4 KiB) to get a
+  baseline ceiling.  Deliverable: a repeatable setup script + recorded baseline.
+  *Blocked on the IOMMU decision above.*
+- **S1 — minimal async bdev backend, single reactor.** Daemon becomes an
+  `spdk_app`; channel poll becomes a poller; replace segment `pread`/`pwrite`
+  with async `spdk_bdev_*`; make request handling in-flight/callback-driven.
+  Gate: the existing `integration_test.sh` passes against an SPDK-backed store.
+- **S2 — blobstore for segments + WAL; persistent metadata.** Blob per segment /
+  per timeline log; index persisted in blob xattrs or a metadata blob → drop the
+  scan-on-restart.
+- **S3 — per-core sharding.** N reactors, key-space partition, channel routing,
+  per-core lock-free indexes.
+- **S4 — LSM layers on raw bdev** (`DESIGN_NOTES.md` #1): image/delta layers,
+  per-shard compaction + GC, replacing flat segments.
+
+## S0 progress (2026-06-17)
+
+- **SPDK v26.01 cloned + built at `~/spdk`** (`make` exits 0; `build/bin/spdk_tgt`
+  present).  The bench tools are `build/bin/spdk_nvme_perf` and
+  `build/bin/spdk_nvme_identify` (the `examples/nvme/{perf,identify}` got renamed
+  to `spdk_nvme_*` in `build/bin/` — not `build/examples/`).
+- **`scripts/pkgdep.sh` fails on a pip `grpcio` step** under Python 3.14
+  ("No matching distribution found for grpcio").  Harmless: that installs the
+  Python RPC/test tooling, not C build deps (all the C deps were already on the
+  box).  The C build succeeds regardless.
+- **IOMMU cmdline applied**: `grubby --update-kernel=ALL --args="intel_iommu=on
+  iommu=pt"` — takes effect after a reboot (pending).
+- **Bind + benchmark script written**: `contrib/pagestore/spdk_setup.sh`
+  (`up`/`status`/`reset`; pins `PCI_ALLOWED=0000:06:00.0` so it only ever touches
+  the control disk).  Run it after the reboot to finish S0.
+
+- **S0 COMPLETE** (after the reboot).  IOMMU active (18 groups); `06:00.0` bound
+  to vfio-pci; 2048×2 MiB hugepages reserved; system/`/home` disks left on the
+  kernel driver.  Control disk = WD SN850 (WDS500G1X0E 500G, 64 I/O queues,
+  MDTS 512 KiB, 4 KiB page).
+  - **Raw baseline (the ceiling to chase):** 4 KiB randread, qd=128, single core
+    → **432 K IOPS, 1688 MiB/s, ~296 µs avg latency** (`spdk_nvme_perf`).
+
+## Concrete commands (reference)
+
+```sh
+# build SPDK (done): tools land in build/bin/spdk_nvme_{perf,identify}
+git clone --branch v26.01 https://github.com/spdk/spdk ~/spdk
+cd ~/spdk && git submodule update --init --recursive && ./configure && make -j
+
+# enable IOMMU for safe DMA (done), then REBOOT:
+sudo grubby --update-kernel=ALL --args="intel_iommu=on iommu=pt"
+
+# after reboot: reserve hugepages + bind ONLY the control disk, then bench
+contrib/pagestore/spdk_setup.sh
+```
+
+> Safety: `spdk_setup.sh` passes `PCI_ALLOWED="0000:06:00.0"` so `setup.sh` only
+> ever rebinds the control disk — never the system or `/home` NVMe.
+
+## Open questions
+
+- IOMMU: reboot-for-vfio vs unsafe-noiommu for the prototype.
+- SPDK build integration: vendor a tag vs system install; how `meson.build` finds
+  SPDK libs/headers (it currently builds a PG contrib module, not an SPDK app).
+- Does the daemon stay one `spdk_app`, or split (control-plane PG contrib +
+  data-plane SPDK app)?  Leaning single app for now.
+- Hugepage reservation persistence across reboot (sysctl `vm.nr_hugepages`).
+</content>
+</invoke>

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -194,16 +194,38 @@ per-core indexes single-owner (still lock-free).  This is #2's design.
     instead of one I/O at a time -- so a request uses real queue depth.  Reads of
     the current (buffered) append segment are still served from memory.  Still
     110/110.  `pagestore_bench.c` (forks a daemon, writes a dataset spanning many
-    segments, times reading it back) gives an indicative number on the control
-    disk: **read 754 MiB/s, 96 Kpages/s** at 8 KiB pages, combine=32, through the
-    full IPC + index + read path -- vs the S0 raw ceiling 1688 MiB/s / 432 KIOPS
-    (4 KiB, QD128).  ~45% of raw bandwidth at far lower effective QD.
-    (POSIX-vs-SPDK is not benchmarked here: the POSIX store lands on tmpfs / a
-    different disk and reads through the OS page cache, so it would be RAM-vs-NVMe.)
+    segments, times reading it back; supports a store dir, a `PS_BENCH_DROPCACHE`
+    cold-read mode, and `PS_BENCH_RANDOM` chunk shuffling) measured 256 MiB at
+    8 KiB pages, combine=32, through the full IPC + index + read path:
+
+    | daemon / store        | read pattern | MiB/s | note                         |
+    |-----------------------|--------------|-------|------------------------------|
+    | POSIX, /home (nvme1)  | seq, warm    | 3610  | OS page cache (RAM)          |
+    | POSIX, /home (nvme1)  | seq, cold    | 1574  | kernel readahead helps a lot |
+    | POSIX, /home (nvme1)  | random, cold |  748  | readahead defeated           |
+    | SPDK, nvme2           | sequential   |  756  | no readahead                 |
+    | SPDK, nvme2           | random       |  754  | order-insensitive            |
+
+    Key finding: **SPDK loses sequential reads to POSIX only because it gave up
+    the kernel page cache + readahead** (POSIX seq-cold 1574 vs SPDK 756); on
+    random reads the two tie (~750), and SPDK is order-insensitive.  Both hit
+    ~750 MiB/s at combine=32 -- the single-request-at-a-time loop caps effective
+    QD at one request's worth.  (S0 raw ceiling 1688 MiB/s / 432 KIOPS at QD128.)
+    This directly motivates a **userspace page cache + readahead in the daemon**
+    (SPDK bypasses the kernel, so the daemon must cache itself) and cross-channel
+    pipelining for QD -- the two levers to beat, not match, the kernel path.
   - **S1.2c-3 (next) — cross-channel pipelining**: the loop issues I/O for many
     ready channels and serves replies from completion callbacks (per-channel
     in-flight tracking) instead of completing one request before the next, to lift
     effective queue depth past one request's worth and approach the S0 ceiling.
+  - **S1.2d — userspace page cache + readahead in the daemon (high priority).**
+    SPDK bypasses the kernel, so the daemon must do its own caching -- the
+    benchmark above shows the kernel page cache + readahead is exactly why POSIX
+    wins sequential reads.  A shared, sharded page cache (hot pages kept in
+    hugepage RAM, keyed by (timeline,key,block,lsn)) plus sequential readahead
+    turns most reads into memory hits and prefetches the rest.  This also moves us
+    toward serving reads with zero device I/O for the working set -- the page
+    server model -- and composes with the LSM layers (S4) and sharding (S3).
 - **S2 — blobstore for segments + WAL; persistent metadata.** Blob per segment /
   per timeline log; index persisted in blob xattrs or a metadata blob → drop the
   scan-on-restart.

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -83,12 +83,27 @@ blob handles / LBA ranges.
 
 ## Architecture decisions
 
-**A. Who owns the main loop?**  The daemon is a standalone process (not a PG
-backend), so it can hand its threads to SPDK.
-- **A1 (recommended):** daemon *is* an SPDK app — `spdk_app_start()` owns the
-  reactors; the current IPC channel poll loop becomes an `spdk_poller`.
-- A2: run SPDK in a side thread, keep the existing loop — fights SPDK's
-  threading; only a stepping stone, not the target.
+**A. Packaging: two binaries, one shared brain (DECIDED).**  SPDK must be an
+*optional* higher-performance choice with the IPC ABI unchanged, because some
+machines cannot run SPDK.  So:
+- `pagestore_daemon` (POSIX) keeps its current synchronous poll loop, libc-only,
+  no SPDK dependency — the portable default, unchanged in behaviour.
+- `pagestore_daemon_spdk` (opt-in build) is a separate binary: its own loop that
+  also polls SPDK, async request handling, the SPDK storage backend.
+- The **brain is single-sourced** in `pagestore_core.{c,h}` and compiled into
+  both: the in-memory indexes, COW/`read_through`, timelines, per-page WAL index,
+  shipped-WAL metadata, recovery, and all the non-I/O request handling
+  (`ps_handle_meta`).  Only the request *loop* and the page **byte** I/O differ
+  per binary (sync vs async), and the byte I/O already goes through `PsStorage`.
+- Seam: the brain exposes `ps_locate` (read-through lookup → PsPageVer),
+  `ps_reserve` (advance the append cursor) and `ps_record` (index a written
+  page); a frontend does the actual `seg_read`/`seg_write` between them (inline
+  for POSIX, callback-driven for SPDK).  `ps_handle_meta(ch)` handles every op
+  except the four byte-I/O ops (EXTEND/WRITEV/READV/READ_AT), which each frontend
+  does itself.  Adding an op touches the shared switch once.
+- SPDK runs in **library mode** (`spdk_env_init` + `spdk_thread_poll` inside our
+  loop), so even the SPDK frontend keeps its own loop rather than surrendering it
+  to `spdk_app_start`.
 
 **B. Storage layout.**
 - Start: **blobstore, one blob per segment** (and per `wal_<tl>`). Least code,
@@ -129,9 +144,22 @@ per-core indexes single-owner (still lock-free).  This is #2's design.
     behind `#ifdef PAGESTORE_SPDK`.  Zero behaviour change: standalone suite
     110/110, `integration_test.sh` PASS.  IPC ABI and compute side untouched —
     SPDK will be a *second* `PsStorage` implementation, never an ABI change.
-  - **S1.2 (next) — the SPDK backend** (`storage_spdk.c`, opt-in compile): one
-    reactor, async `spdk_bdev_*` behind the same vtable, plus the daemon's
-    request loop made callback-driven for in-flight reads.
+  - **S1.2a — shared brain extracted (DONE).** The store's logic moved to
+    `pagestore_core.{c,h}` (indexes, COW/`read_through`, timelines, per-page WAL
+    index, shipped-WAL metadata, recovery, and `ps_handle_meta` for all non-I/O
+    ops).  `pagestore_daemon.c` is now a thin POSIX frontend: the synchronous
+    channel loop + the four byte-I/O ops via `append_page`/`read_through`/
+    `read_version`.  Both compiled into `pagestore_daemon`.  Zero behaviour
+    change: standalone 110/110, `integration_test.sh` PASS.  This sets up the
+    two-binary split — the SPDK daemon will reuse `pagestore_core.c` verbatim.
+  - **S1.2b (next) — SPDK build wiring**: meson `-Dpagestore_spdk` option that
+    finds SPDK libs/headers; `storage_spdk.c` skeleton + `pagestore_daemon_spdk.c`
+    skeleton that links SPDK, inits the env in library mode, and enumerates the
+    control disk.  Compile/link path first, no real I/O yet.
+  - **S1.2c — async SPDK I/O + dispatch**: implement `PsStorage` over async
+    `spdk_bdev_*`; the SPDK frontend's loop polls channels + `spdk_thread_poll`,
+    issues reads/writes with completions, tracks in-flight per channel.  Gate:
+    `integration_test.sh` PASS against the SPDK daemon; compare to the S0 ceiling.
 - **S2 — blobstore for segments + WAL; persistent metadata.** Blob per segment /
   per timeline log; index persisted in blob xattrs or a metadata blob → drop the
   scan-on-restart.

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -188,10 +188,22 @@ per-core indexes single-owner (still lock-free).  This is #2's design.
       recovery, all with pages on actual NVMe.
     - Gotcha: SPDK v26.01 needs `opts.opts_size = sizeof(opts)` set *before*
       `spdk_env_opts_init` (else "Invalid opts->opts_size 40 too small").
-  - **S1.2c-2 (next) — pipeline it**: loop issues I/O for many ready channels and
-    serves replies from completion callbacks (per-channel in-flight tracking),
-    instead of polling each op to completion, to approach the S0 ceiling
-    (432 K IOPS).  Then benchmark POSIX vs SPDK.
+  - **S1.2c-2 — batched (overlapped) reads (DONE).** A multi-block READV now
+    issues up to 64 page reads at once on the NVMe queue via `ps_spdk_readv`
+    (a DMA-buffer pool + `spdk_nvme_ns_cmd_read` per block, then one drain),
+    instead of one I/O at a time -- so a request uses real queue depth.  Reads of
+    the current (buffered) append segment are still served from memory.  Still
+    110/110.  `pagestore_bench.c` (forks a daemon, writes a dataset spanning many
+    segments, times reading it back) gives an indicative number on the control
+    disk: **read 754 MiB/s, 96 Kpages/s** at 8 KiB pages, combine=32, through the
+    full IPC + index + read path -- vs the S0 raw ceiling 1688 MiB/s / 432 KIOPS
+    (4 KiB, QD128).  ~45% of raw bandwidth at far lower effective QD.
+    (POSIX-vs-SPDK is not benchmarked here: the POSIX store lands on tmpfs / a
+    different disk and reads through the OS page cache, so it would be RAM-vs-NVMe.)
+  - **S1.2c-3 (next) — cross-channel pipelining**: the loop issues I/O for many
+    ready channels and serves replies from completion callbacks (per-channel
+    in-flight tracking) instead of completing one request before the next, to lift
+    effective queue depth past one request's worth and approach the S0 ceiling.
 - **S2 — blobstore for segments + WAL; persistent metadata.** Blob per segment /
   per timeline log; index persisted in blob xattrs or a metadata blob → drop the
   scan-on-restart.

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -214,10 +214,28 @@ per-core indexes single-owner (still lock-free).  This is #2's design.
     This directly motivates a **userspace page cache + readahead in the daemon**
     (SPDK bypasses the kernel, so the daemon must cache itself) and cross-channel
     pipelining for QD -- the two levers to beat, not match, the kernel path.
-  - **S1.2c-3 (next) — cross-channel pipelining**: the loop issues I/O for many
-    ready channels and serves replies from completion callbacks (per-channel
-    in-flight tracking) instead of completing one request before the next, to lift
-    effective queue depth past one request's worth and approach the S0 ceiling.
+  - **S1.2c-3 — cross-channel pipelining (DONE).** The SPDK daemon loop is now
+    asynchronous: `ps_spdk_read_async` + `ps_spdk_poll` (storage_spdk.h) with a
+    256-buffer DMA pool and free-list; the loop `begin()`s every ready channel
+    without blocking (metadata/buffered-write ops finish inline; read ops submit
+    their page reads and the reply is published from `read_done` when the last
+    lands), tracking per-channel in-flight state.  Index pointers from
+    `read_through` are dereferenced (seg/off taken) synchronously inside
+    `begin()`, never held across the async wait, so a concurrent write
+    reallocating a version array cannot dangle them.  Still 110/110 (the 8-client
+    phase now genuinely overlaps in flight).  `pagestore_bench.c` grew
+    `PS_BENCH_CLIENTS=N` (N reader processes, each its own channel); random reads
+    on the control disk scale with concurrency:
+
+    | clients | MiB/s | Kpages/s |
+    |---------|-------|----------|
+    | 1       |  671  |  86      |
+    | 4       | 2167  | 277      |
+    | 16      | 2443  | 313      |
+
+    3.6x from cross-channel queue depth; at 16 clients ~2.4 GiB/s, well past the
+    single-stream POSIX cold-random 748 MiB/s -- concurrency is the lever the
+    one-request-at-a-time loop was missing.
   - **S1.2d — database-adapted materialization cache (high priority, NOT a
     block cache).**  The benchmark shows the kernel page cache + readahead is why
     POSIX wins sequential reads -- but a userspace block-address LRU is the wrong

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -168,10 +168,30 @@ per-core indexes single-owner (still lock-free).  This is #2's design.
       also links `storage_posix.c` (core's default `ps_storage` references
       `PsStoragePosix`).  Not wired into PG's meson (SPDK is a local-only,
       bound-disk artifact); the script is the compile switch.
-  - **S1.2c — async SPDK I/O + dispatch**: implement `PsStorage` over async
-    `spdk_bdev_*`; the SPDK frontend's loop polls channels + `spdk_thread_poll`,
-    issues reads/writes with completions, tracks in-flight per channel.  Gate:
-    `integration_test.sh` PASS against the SPDK daemon; compare to the S0 ceiling.
+  - **S1.2c-1 — SPDK I/O on real NVMe (DONE).** `storage_spdk.c` now does real
+    I/O via the async `spdk_nvme_ns_cmd_read/write` API, polled to completion per
+    op (correct; cross-channel pipelining is S1.2c-2).  Layout: page **segments**
+    live on the raw namespace (segment S byte O -> device byte S*segsize+O), each
+    written as one sector-aligned zero-padded extent so recover() stops at the
+    zero tail (no per-segment length tracking); the current append segment is a
+    DMA buffer flushed on roll-over/sync, older segments read with an aligned
+    read + slice.  The shipped **WAL and timeline metadata** stay on the
+    filesystem under `--store` (delegated to the POSIX backend) -- small, not hot,
+    and awkward to lay out per-timeline on raw blocks; on-device is a later LSM
+    refinement.  Segment count persists in `<store>/spdk_super` so a fresh
+    `--store` dir is a fresh store and a restart continues.
+    - **Validated on the control disk**: the SPDK daemon is argument-compatible
+      with the standalone harness (PCI via `$PS_SPDK_PCI`), so
+      `sudo PS_SPDK_PCI=0000:06:00.0 ./pagestore_test ./pagestore_daemon_spdk`
+      runs the full suite -- **110/110**, exercising page I/O, COW, branches,
+      shipped WAL, vectored I/O, 8-client concurrency, and daemon-restart
+      recovery, all with pages on actual NVMe.
+    - Gotcha: SPDK v26.01 needs `opts.opts_size = sizeof(opts)` set *before*
+      `spdk_env_opts_init` (else "Invalid opts->opts_size 40 too small").
+  - **S1.2c-2 (next) — pipeline it**: loop issues I/O for many ready channels and
+    serves replies from completion callbacks (per-channel in-flight tracking),
+    instead of polling each op to completion, to approach the S0 ceiling
+    (432 K IOPS).  Then benchmark POSIX vs SPDK.
 - **S2 — blobstore for segments + WAL; persistent metadata.** Blob per segment /
   per timeline log; index persisted in blob xattrs or a metadata blob → drop the
   scan-on-restart.

--- a/contrib/pagestore/meson.build
+++ b/contrib/pagestore/meson.build
@@ -42,6 +42,14 @@ pagestore_walrestore = executable('pagestore_walrestore',
 )
 contrib_targets += pagestore_walrestore
 
+# Throughput probe: forks a daemon, writes a dataset, times reading it back.
+# Indicative only (see pagestore_bench.c); freestanding like the daemon.
+pagestore_bench = executable('pagestore_bench',
+  files('pagestore_bench.c'),
+  kwargs: default_bin_args,
+)
+contrib_targets += pagestore_bench
+
 # Standalone test harness: drives the daemon over the shared-memory protocol
 # with no PostgreSQL instance.  Run independently of the PG test suites with:
 #   meson test -C <build> --suite pagestore

--- a/contrib/pagestore/meson.build
+++ b/contrib/pagestore/meson.build
@@ -21,7 +21,7 @@ contrib_targets += pagestore
 # Standalone storage daemon for the "localsvc" backend.  Freestanding: it
 # includes only pagestore_ipc.h and libc, no PostgreSQL libraries.
 pagestore_daemon = executable('pagestore_daemon',
-  files('pagestore_daemon.c', 'storage_posix.c'),
+  files('pagestore_daemon.c', 'pagestore_core.c', 'storage_posix.c'),
   kwargs: default_bin_args,
 )
 contrib_targets += pagestore_daemon

--- a/contrib/pagestore/meson.build
+++ b/contrib/pagestore/meson.build
@@ -21,7 +21,7 @@ contrib_targets += pagestore
 # Standalone storage daemon for the "localsvc" backend.  Freestanding: it
 # includes only pagestore_ipc.h and libc, no PostgreSQL libraries.
 pagestore_daemon = executable('pagestore_daemon',
-  files('pagestore_daemon.c'),
+  files('pagestore_daemon.c', 'storage_posix.c'),
   kwargs: default_bin_args,
 )
 contrib_targets += pagestore_daemon

--- a/contrib/pagestore/pagestore_bench.c
+++ b/contrib/pagestore/pagestore_bench.c
@@ -1,0 +1,193 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_bench.c
+ *	  Tiny throughput probe for the page-store daemon (indicative, not rigorous).
+ *
+ * Forks the daemon given on the command line (POSIX or SPDK -- both accept the
+ * same --shm/--store/--page-size/--segment-size args; the SPDK one reads its PCI
+ * address from $PS_SPDK_PCI), writes a dataset large enough to span many
+ * segments, flushes, then times reading it all back in max-combine READVs.
+ *
+ * Caveats: the POSIX store reads through the OS page cache (and sits on a
+ * different disk than the SPDK control disk), so this is not a fair POSIX-vs-SPDK
+ * shootout -- it is mainly here to show the SPDK daemon's read path moving real
+ * bytes off NVMe and the effect of batched (overlapped) reads.
+ *
+ * Usage: [PS_SPDK_PCI=...] pagestore_bench <daemon-path> [total-MiB]
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "pagestore_ipc.h"
+
+#define PAGE	8192u
+#define SEGSZ	"4194304"		/* 4 MiB segments */
+#define REL		42u
+
+static void *g_shm;
+static int	g_chan = -1;
+
+static PsChannel *
+chp(void)
+{
+	return ps_channel(g_shm, g_chan);
+}
+
+static void
+exec1(void)
+{
+	PsChannel  *c = chp();
+
+	ps_store_release(&c->state, PS_STATE_REQUEST);
+	while (ps_load_acquire(&c->state) != PS_STATE_DONE)
+		;
+}
+
+static double
+now(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return ts.tv_sec + ts.tv_nsec / 1e9;
+}
+
+static pid_t
+spawn(const char *daemon, const char *shm, const char *store)
+{
+	pid_t		pid = fork();
+
+	if (pid == 0)
+	{
+		execl(daemon, daemon, "--shm", shm, "--store", store,
+			  "--page-size", "8192", "--segment-size", SEGSZ, (char *) NULL);
+		perror("execl");
+		_exit(127);
+	}
+	return pid;
+}
+
+static void
+attach(const char *shm)
+{
+	for (int i = 0; i < 1000; i++)
+	{
+		int			fd = shm_open(shm, O_RDWR, 0600);
+
+		if (fd >= 0)
+		{
+			PsShmHeader *h = mmap(NULL, PS_SHM_SIZE, PROT_READ | PROT_WRITE,
+								  MAP_SHARED, fd, 0);
+
+			close(fd);
+			if (h != MAP_FAILED && h->magic == PS_SHM_MAGIC &&
+				h->page_size == PAGE)
+			{
+				g_shm = h;
+				for (uint32_t c = 0; c < h->nchannels; c++)
+					if (ps_cas(&ps_channel(g_shm, c)->claimed, 0, 1))
+					{
+						g_chan = (int) c;
+						return;
+					}
+			}
+		}
+		usleep(10000);
+	}
+	fprintf(stderr, "bench: daemon not ready\n");
+	exit(2);
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *daemon = argc > 1 ? argv[1] : NULL;
+	uint64_t	total_mib = argc > 2 ? strtoull(argv[2], NULL, 10) : 256;
+	const char *shm = "/psbench";
+	char		store[] = "/tmp/psbenchstoreXXXXXX";
+	uint32_t	npages = (uint32_t) (total_mib * 1024 * 1024 / PAGE);
+	uint32_t	combine = PS_IO_UNIT / PAGE;
+	unsigned char *buf;
+	pid_t		pid;
+	double		t0,
+				wsec,
+				rsec;
+
+	if (!daemon || !mkdtemp(store))
+	{
+		fprintf(stderr, "usage: %s <daemon-path> [total-MiB]\n", argv[0]);
+		return 2;
+	}
+	shm_unlink(shm);
+	pid = spawn(daemon, shm, store);
+	attach(shm);
+
+	buf = malloc((size_t) combine * PAGE);
+	memset(buf, 0xab, (size_t) combine * PAGE);
+
+	/* write phase */
+	t0 = now();
+	for (uint32_t b = 0; b < npages; b += combine)
+	{
+		uint32_t	k = npages - b < combine ? npages - b : combine;
+		PsChannel  *c = chp();
+
+		for (uint32_t i = 0; i < k; i++)
+			memcpy(buf + (size_t) i * PAGE, &(uint64_t){b + i}, 8);	/* vary pd_lsn */
+		c->key.spcOid = 1;
+		c->key.dbOid = 1;
+		c->key.relNumber = REL;
+		c->key.forkNum = 0;
+		c->timeline = 0;
+		c->opcode = PS_OP_WRITEV;
+		c->blocknum = b;
+		c->nblocks = k;
+		memcpy(c->data, buf, (size_t) k * PAGE);
+		exec1();
+	}
+	chp()->opcode = PS_OP_IMMEDSYNC;
+	exec1();
+	wsec = now() - t0;
+
+	/* read phase */
+	t0 = now();
+	for (uint32_t b = 0; b < npages; b += combine)
+	{
+		uint32_t	k = npages - b < combine ? npages - b : combine;
+		PsChannel  *c = chp();
+
+		c->key.spcOid = 1;
+		c->key.dbOid = 1;
+		c->key.relNumber = REL;
+		c->key.forkNum = 0;
+		c->timeline = 0;
+		c->opcode = PS_OP_READV;
+		c->blocknum = b;
+		c->nblocks = k;
+		exec1();
+	}
+	rsec = now() - t0;
+
+	printf("daemon=%s  %llu MiB  page=%u  combine=%u\n", daemon,
+		   (unsigned long long) total_mib, PAGE, combine);
+	printf("  write: %.3fs  %.0f MiB/s  %.0f Kpages/s\n",
+		   wsec, total_mib / wsec, npages / wsec / 1000.0);
+	printf("  read : %.3fs  %.0f MiB/s  %.0f Kpages/s\n",
+		   rsec, total_mib / rsec, npages / rsec / 1000.0);
+
+	ps_store_release(&chp()->claimed, 0);
+	munmap(g_shm, PS_SHM_SIZE);
+	kill(pid, SIGTERM);
+	waitpid(pid, NULL, 0);
+	return 0;
+}

--- a/contrib/pagestore/pagestore_bench.c
+++ b/contrib/pagestore/pagestore_bench.c
@@ -49,13 +49,59 @@ chp(void)
 }
 
 static void
-exec1(void)
+exec_on(int chan)
 {
-	PsChannel  *c = chp();
+	PsChannel  *c = ps_channel(g_shm, chan);
 
 	ps_store_release(&c->state, PS_STATE_REQUEST);
 	while (ps_load_acquire(&c->state) != PS_STATE_DONE)
 		;
+}
+
+static void
+exec1(void)
+{
+	exec_on(g_chan);
+}
+
+/* claim any free channel for this (possibly forked) reader; -1 if none */
+static int
+claim_channel(void)
+{
+	PsShmHeader *h = g_shm;
+
+	for (uint32_t c = 0; c < h->nchannels; c++)
+		if (ps_cas(&ps_channel(g_shm, c)->claimed, 0, 1))
+			return (int) c;
+	return -1;
+}
+
+/* read chunks [from, to) of the shuffled order on our own channel */
+static void
+read_range(const uint32_t *starts, uint32_t from, uint32_t to,
+		   uint32_t npages, uint32_t combine)
+{
+	int			chan = claim_channel();
+
+	if (chan < 0)
+		_exit(3);
+	for (uint32_t ci = from; ci < to; ci++)
+	{
+		uint32_t	b = starts[ci];
+		uint32_t	k = npages - b < combine ? npages - b : combine;
+		PsChannel  *c = ps_channel(g_shm, chan);
+
+		c->key.spcOid = 1;
+		c->key.dbOid = 1;
+		c->key.relNumber = REL;
+		c->key.forkNum = 0;
+		c->timeline = 0;
+		c->opcode = PS_OP_READV;
+		c->blocknum = b;
+		c->nblocks = k;
+		exec_on(chan);
+	}
+	ps_store_release(&ps_channel(g_shm, chan)->claimed, 0);
 }
 
 static double
@@ -183,14 +229,20 @@ main(int argc, char **argv)
 			fprintf(stderr, "bench: could not drop caches (run as root)\n");
 	}
 
-	/* build the chunk order; shuffle it for a random read pattern (defeats the
-	 * OS readahead that favors POSIX on sequential reads) */
+	/* build the chunk order; shuffle for a random pattern (defeats the OS
+	 * readahead that favors POSIX on sequential reads); optionally split the
+	 * chunks across PS_BENCH_CLIENTS reader processes, each on its own channel,
+	 * to drive cross-channel queue depth on the daemon. */
 	{
 		uint32_t	nchunks = (npages + combine - 1) / combine;
 		uint32_t   *starts = malloc((size_t) nchunks * sizeof(uint32_t));
 		int			random = getenv("PS_BENCH_RANDOM") != NULL;
+		int			clients = getenv("PS_BENCH_CLIENTS") ?
+			atoi(getenv("PS_BENCH_CLIENTS")) : 1;
 		uint64_t	rng = 0x9e3779b97f4a7c15ull;
 
+		if (clients < 1)
+			clients = 1;
 		for (uint32_t i = 0; i < nchunks; i++)
 			starts[i] = i * combine;
 		if (random)
@@ -207,25 +259,28 @@ main(int argc, char **argv)
 			}
 
 		t0 = now();
-		for (uint32_t ci = 0; ci < nchunks; ci++)
+		if (clients == 1)
+			read_range(starts, 0, nchunks, npages, combine);
+		else
 		{
-			uint32_t	b = starts[ci];
-			uint32_t	k = npages - b < combine ? npages - b : combine;
-			PsChannel  *c = chp();
+			for (int c = 0; c < clients; c++)
+			{
+				uint32_t	from = (uint32_t) ((uint64_t) c * nchunks / clients);
+				uint32_t	to = (uint32_t) ((uint64_t) (c + 1) * nchunks / clients);
 
-			c->key.spcOid = 1;
-			c->key.dbOid = 1;
-			c->key.relNumber = REL;
-			c->key.forkNum = 0;
-			c->timeline = 0;
-			c->opcode = PS_OP_READV;
-			c->blocknum = b;
-			c->nblocks = k;
-			exec1();
+				if (fork() == 0)
+				{
+					read_range(starts, from, to, npages, combine);
+					_exit(0);
+				}
+			}
+			for (int c = 0; c < clients; c++)
+				wait(NULL);
 		}
 		rsec = now() - t0;
 		free(starts);
-		printf("  (read pattern: %s)\n", random ? "random chunk order" : "sequential");
+		printf("  (read pattern: %s, clients: %d)\n",
+			   random ? "random chunk order" : "sequential", clients);
 	}
 
 	printf("daemon=%s  %llu MiB  page=%u  combine=%u\n", daemon,

--- a/contrib/pagestore/pagestore_bench.c
+++ b/contrib/pagestore/pagestore_bench.c
@@ -13,7 +13,12 @@
  * shootout -- it is mainly here to show the SPDK daemon's read path moving real
  * bytes off NVMe and the effect of batched (overlapped) reads.
  *
- * Usage: [PS_SPDK_PCI=...] pagestore_bench <daemon-path> [total-MiB]
+ * For a fair cold-read POSIX comparison, set PS_BENCH_DROPCACHE=1 (needs root):
+ * the OS page cache is dropped between the write and read phases so POSIX reads
+ * hit the disk rather than RAM.  It is a no-op for SPDK (no OS cache).
+ *
+ * Usage: [PS_SPDK_PCI=...] [PS_BENCH_DROPCACHE=1] \
+ *            pagestore_bench <daemon-path> [total-MiB] [store-base-dir]
  *
  *-------------------------------------------------------------------------
  */
@@ -113,8 +118,9 @@ main(int argc, char **argv)
 {
 	const char *daemon = argc > 1 ? argv[1] : NULL;
 	uint64_t	total_mib = argc > 2 ? strtoull(argv[2], NULL, 10) : 256;
+	const char *base = argc > 3 ? argv[3] : "/tmp";
 	const char *shm = "/psbench";
-	char		store[] = "/tmp/psbenchstoreXXXXXX";
+	char		store[1024];
 	uint32_t	npages = (uint32_t) (total_mib * 1024 * 1024 / PAGE);
 	uint32_t	combine = PS_IO_UNIT / PAGE;
 	unsigned char *buf;
@@ -123,9 +129,11 @@ main(int argc, char **argv)
 				wsec,
 				rsec;
 
+	snprintf(store, sizeof(store), "%s/psbenchstoreXXXXXX", base);
 	if (!daemon || !mkdtemp(store))
 	{
-		fprintf(stderr, "usage: %s <daemon-path> [total-MiB]\n", argv[0]);
+		fprintf(stderr, "usage: %s <daemon-path> [total-MiB] [store-base-dir]\n",
+				argv[0]);
 		return 2;
 	}
 	shm_unlink(shm);
@@ -159,24 +167,66 @@ main(int argc, char **argv)
 	exec1();
 	wsec = now() - t0;
 
-	/* read phase */
-	t0 = now();
-	for (uint32_t b = 0; b < npages; b += combine)
+	/* optional: drop the OS page cache so POSIX reads hit the disk (root only) */
+	if (getenv("PS_BENCH_DROPCACHE"))
 	{
-		uint32_t	k = npages - b < combine ? npages - b : combine;
-		PsChannel  *c = chp();
+		FILE	   *f;
 
-		c->key.spcOid = 1;
-		c->key.dbOid = 1;
-		c->key.relNumber = REL;
-		c->key.forkNum = 0;
-		c->timeline = 0;
-		c->opcode = PS_OP_READV;
-		c->blocknum = b;
-		c->nblocks = k;
-		exec1();
+		sync();
+		f = fopen("/proc/sys/vm/drop_caches", "w");
+		if (f)
+		{
+			fputs("3\n", f);
+			fclose(f);
+		}
+		else
+			fprintf(stderr, "bench: could not drop caches (run as root)\n");
 	}
-	rsec = now() - t0;
+
+	/* build the chunk order; shuffle it for a random read pattern (defeats the
+	 * OS readahead that favors POSIX on sequential reads) */
+	{
+		uint32_t	nchunks = (npages + combine - 1) / combine;
+		uint32_t   *starts = malloc((size_t) nchunks * sizeof(uint32_t));
+		int			random = getenv("PS_BENCH_RANDOM") != NULL;
+		uint64_t	rng = 0x9e3779b97f4a7c15ull;
+
+		for (uint32_t i = 0; i < nchunks; i++)
+			starts[i] = i * combine;
+		if (random)
+			for (uint32_t i = nchunks; i > 1; i--)	/* Fisher-Yates, fixed seed */
+			{
+				uint32_t	j;
+				uint32_t	t;
+
+				rng = rng * 6364136223846793005ull + 1442695040888963407ull;
+				j = (uint32_t) ((rng >> 33) % i);
+				t = starts[i - 1];
+				starts[i - 1] = starts[j];
+				starts[j] = t;
+			}
+
+		t0 = now();
+		for (uint32_t ci = 0; ci < nchunks; ci++)
+		{
+			uint32_t	b = starts[ci];
+			uint32_t	k = npages - b < combine ? npages - b : combine;
+			PsChannel  *c = chp();
+
+			c->key.spcOid = 1;
+			c->key.dbOid = 1;
+			c->key.relNumber = REL;
+			c->key.forkNum = 0;
+			c->timeline = 0;
+			c->opcode = PS_OP_READV;
+			c->blocknum = b;
+			c->nblocks = k;
+			exec1();
+		}
+		rsec = now() - t0;
+		free(starts);
+		printf("  (read pattern: %s)\n", random ? "random chunk order" : "sequential");
+	}
 
 	printf("daemon=%s  %llu MiB  page=%u  combine=%u\n", daemon,
 		   (unsigned long long) total_mib, PAGE, combine);
@@ -189,5 +239,14 @@ main(int argc, char **argv)
 	munmap(g_shm, PS_SHM_SIZE);
 	kill(pid, SIGTERM);
 	waitpid(pid, NULL, 0);
+
+	/* best-effort cleanup of the store dir we created */
+	{
+		char		cmd[1100];
+
+		snprintf(cmd, sizeof(cmd), "rm -rf '%s'", store);
+		if (system(cmd) != 0)
+			fprintf(stderr, "bench: cleanup of %s failed\n", store);
+	}
 	return 0;
 }

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -426,9 +426,21 @@ load_timelines(void)
 	TimelineRec rec;
 	uint64_t	off = 0;
 
+	/*
+	 * Records are appended in creation order, so a record's parent is defined by
+	 * an earlier record (or is the root).  Re-validate each with the same check
+	 * used at creation, so a corrupt, truncated, or duplicated persisted record
+	 * cannot reintroduce an undefined parent or a cycle that the creation path
+	 * rejects -- which would otherwise hang read_through()'s ancestry walk after
+	 * a restart.  Invalid records are skipped, not applied.
+	 */
 	while (ps_storage->meta_read(off, &rec, sizeof(rec)) == (int) sizeof(rec))
 	{
-		timeline_define(rec.id, rec.parent, rec.branch_lsn);
+		if (branch_request_ok(rec.id, rec.parent))
+			timeline_define(rec.id, rec.parent, rec.branch_lsn);
+		else
+			fprintf(stderr, "pagestore: skipping invalid timeline record "
+					"(id=%u parent=%d)\n", rec.id, rec.parent);
 		off += sizeof(rec);
 	}
 }

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1,0 +1,827 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_core.c
+ *	  Shared "brain" of the page-store daemon (see pagestore_core.h).
+ *
+ * Design (see also pagestore_ipc.h):
+ *
+ *	- Page-size agnostic.  The logical page size is configured with --page-size
+ *	  (8192 for PostgreSQL, 16384 for InnoDB, ...) and published in the shm
+ *	  header; nothing about the on-disk format assumes a particular value.
+ *
+ *	- Log-structured storage.  Every page write is appended to a growing
+ *	  segment as a self-describing record [SegRecHdr | page bytes].  Writes are
+ *	  therefore large and sequential regardless of how small individual logical
+ *	  pages are.  Old versions are never overwritten, so the log is also the COW
+ *	  history.  How the segments are physically stored is the storage backend's
+ *	  business (pagestore_storage.h): files for POSIX, device regions for SPDK.
+ *
+ *	- Indirection map.  An in-memory index maps (timeline, key, block) -> a
+ *	  chain of versions {lsn, segment, offset}.  This lets a single small
+ *	  logical page be addressed inside a large physical segment (ranged read).
+ *	  The index is rebuilt by scanning segments at startup (recover()).
+ *
+ * This file holds everything backend- and loop-agnostic; each frontend (the
+ * POSIX daemon, the SPDK daemon) supplies its own request loop and page byte
+ * I/O.  Includes only pagestore_ipc.h/pagestore_storage.h and libc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pagestore_core.h"
+
+/* configuration, set by the frontend before ps_core_open() */
+uint32_t	page_size = PS_DEFAULT_PAGE_SIZE;
+uint64_t	segment_size = 8 * 1024 * 1024;
+
+/* the active storage backend (POSIX by default; the frontend may override) */
+const PsStorage *ps_storage = &PsStoragePosix;
+
+/* ===================== segment storage (log-structured) ================= */
+
+#define SEG_MAGIC	0x53454752	/* "SEGR" */
+
+/*
+ * On-disk layout of one appended page version: this header immediately
+ * followed by 'len' page bytes.  The header is self-describing (carries the
+ * full key/block/lsn), which is what lets recover() rebuild the entire
+ * in-memory index by scanning segments sequentially -- no separate index file
+ * to keep in sync.
+ */
+typedef struct SegRecHdr
+{
+	uint32_t	magic;			/* SEG_MAGIC; also the end-of-log sentinel */
+	uint32_t	timeline;		/* timeline the version belongs to */
+	PsKey		key;
+	uint32_t	block;
+	uint64_t	lsn;			/* the page's pd_lsn at write time */
+	uint32_t	len;			/* page bytes following the header */
+} SegRecHdr;
+
+/*
+ * Segments are addressed by (id, byte offset); how they are stored is the
+ * storage backend's business (see pagestore_storage.h).  Here we keep only the
+ * append cursor (cur_seg, cur_off) marking where the next record goes.
+ */
+static int	cur_seg = -1;		/* segment currently being appended (-1: none yet) */
+static uint64_t cur_off;		/* append cursor within cur_seg */
+
+/* ===================== in-memory indexes =============================== */
+
+/*
+ * Two chained hash tables form the indirection map that lets a single logical
+ * page be located inside the large append-only segments:
+ *
+ *	 page_idx: (timeline, key, block) -> chain of versions {lsn, seg, off}
+ *	 fork_idx: (timeline, key)        -> size of the fork on that timeline
+ *
+ * Entries are keyed by timeline so a branch's writes are isolated; reads that
+ * miss on a timeline fall through to its parent (see read_through()).  Both
+ * tables are in-memory state, rebuilt from the segments by recover().
+ * (Prototype: no GC/compaction, so the version chain only grows.)
+ */
+#define IDX_BUCKETS		(1 << 16)
+#define IDX_MASK		(IDX_BUCKETS - 1)
+
+/* PageVer (one stored version's location) is defined in pagestore_core.h. */
+
+/* Hash entry: all versions of one (timeline, key, block), in arrival order. */
+typedef struct PageEnt
+{
+	struct PageEnt *next;		/* bucket chain */
+	uint32_t	timeline;
+	PsKey		key;
+	uint32_t	block;
+	PageVer    *vers;			/* dynamic array, length nver, capacity cap */
+	int			nver;
+	int			cap;
+} PageEnt;
+
+/* Hash entry: the block count of one fork on one timeline. */
+typedef struct ForkEnt
+{
+	struct ForkEnt *next;		/* bucket chain */
+	uint32_t	timeline;
+	PsKey		key;
+	uint32_t	nblocks;
+} ForkEnt;
+
+static PageEnt *page_idx[IDX_BUCKETS];
+static ForkEnt *fork_idx[IDX_BUCKETS];
+
+/*
+ * Timeline metadata.  Timeline 0 is the root (no parent).  A branch records its
+ * parent and the LSN at which it forked; reads of pages the branch never wrote
+ * fall through to the parent as-of that branch LSN, so the branch is a stable
+ * copy-on-write snapshot.
+ */
+#define MAX_TIMELINES	1024
+typedef struct TimelineMeta
+{
+	int			defined;		/* 1 if this timeline exists */
+	int			parent;			/* parent timeline id, or -1 for the root */
+	uint64_t	branch_lsn;		/* parent LSN this timeline forked at */
+} TimelineMeta;
+
+static TimelineMeta timelines[MAX_TIMELINES];
+
+/* FNV-1a hash over a byte range (used to hash keys into buckets). */
+
+static uint32_t
+fnv(const void *p, size_t n)
+{
+	const unsigned char *b = p;
+	uint32_t	h = 2166136261u;
+
+	for (size_t i = 0; i < n; i++)
+	{
+		h ^= b[i];
+		h *= 16777619u;
+	}
+	return h;
+}
+
+static int
+key_eq(const PsKey *a, const PsKey *b)
+{
+	return a->spcOid == b->spcOid && a->dbOid == b->dbOid &&
+		a->relNumber == b->relNumber && a->forkNum == b->forkNum;
+}
+
+/* --- page index (keyed by timeline, key, block) --- */
+
+static uint32_t
+page_hash(uint32_t timeline, const PsKey *key, uint32_t block)
+{
+	return fnv(key, sizeof(*key)) ^ (block * 2654435761u) ^ (timeline * 40503u);
+}
+
+static PageEnt *
+page_find(uint32_t timeline, const PsKey *key, uint32_t block)
+{
+	uint32_t	h = page_hash(timeline, key, block);
+	PageEnt    *e;
+
+	for (e = page_idx[h & IDX_MASK]; e; e = e->next)
+		if (e->timeline == timeline && e->block == block && key_eq(&e->key, key))
+			return e;
+	return NULL;
+}
+
+/*
+ * Record a new version of (timeline, key, block).  Only ever appends to the
+ * version chain -- existing versions are never dropped -- which is what makes
+ * the store copy-on-write.  The version is tagged with the writing timeline, so
+ * a branch's writes never disturb its parent.  Called from append_page and from
+ * recover() while replaying segments.
+ */
+static void
+page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
+				 uint64_t lsn, int seg, uint64_t off)
+{
+	uint32_t	h = page_hash(timeline, key, block);
+	PageEnt    *e = page_find(timeline, key, block);
+
+	if (!e)
+	{
+		e = calloc(1, sizeof(*e));
+		e->timeline = timeline;
+		e->key = *key;
+		e->block = block;
+		e->next = page_idx[h & IDX_MASK];
+		page_idx[h & IDX_MASK] = e;
+	}
+	if (e->nver == e->cap)		/* grow the version array geometrically */
+	{
+		e->cap = e->cap ? e->cap * 2 : 2;
+		e->vers = realloc(e->vers, (size_t) e->cap * sizeof(PageVer));
+	}
+	e->vers[e->nver].lsn = lsn;
+	e->vers[e->nver].seg = seg;
+	e->vers[e->nver].off = off;
+	e->nver++;
+}
+
+/* Newest version on this entry with lsn <= read_lsn, or NULL if none. */
+static PageVer *
+page_visible(PageEnt *e, uint64_t read_lsn)
+{
+	PageVer    *best = NULL;
+
+	for (int i = 0; i < e->nver; i++)
+	{
+		PageVer    *v = &e->vers[i];
+
+		if (v->lsn <= read_lsn && (!best || v->lsn >= best->lsn))
+			best = v;
+	}
+	return best;
+}
+
+/* --- fork size index (keyed by timeline, key) --- */
+
+static ForkEnt *
+fork_find(uint32_t timeline, const PsKey *key)
+{
+	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
+	ForkEnt    *e;
+
+	for (e = fork_idx[h & IDX_MASK]; e; e = e->next)
+		if (e->timeline == timeline && key_eq(&e->key, key))
+			return e;
+	return NULL;
+}
+
+static ForkEnt *
+fork_get_or_create(uint32_t timeline, const PsKey *key)
+{
+	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
+	ForkEnt    *e = fork_find(timeline, key);
+
+	if (!e)
+	{
+		e = calloc(1, sizeof(*e));
+		e->timeline = timeline;
+		e->key = *key;
+		e->nblocks = 0;
+		e->next = fork_idx[h & IDX_MASK];
+		fork_idx[h & IDX_MASK] = e;
+	}
+	return e;
+}
+
+void
+fork_grow(uint32_t timeline, const PsKey *key, uint32_t to_nblocks)
+{
+	ForkEnt    *e = fork_get_or_create(timeline, key);
+
+	if (to_nblocks > e->nblocks)
+		e->nblocks = to_nblocks;
+}
+
+static void
+fork_remove(uint32_t timeline, const PsKey *key)
+{
+	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
+	ForkEnt   **pp = &fork_idx[h & IDX_MASK];
+
+	while (*pp)
+	{
+		if ((*pp)->timeline == timeline && key_eq(&(*pp)->key, key))
+		{
+			ForkEnt    *dead = *pp;
+
+			*pp = dead->next;
+			free(dead);
+			return;
+		}
+		pp = &(*pp)->next;
+	}
+}
+
+/* --- timeline metadata + read-through --- */
+
+static void
+timeline_define(uint32_t id, int parent, uint64_t branch_lsn)
+{
+	if (id >= MAX_TIMELINES)
+		return;
+	timelines[id].defined = 1;
+	timelines[id].parent = parent;
+	timelines[id].branch_lsn = branch_lsn;
+}
+
+static int
+timeline_has_parent(uint32_t timeline)
+{
+	return timeline < MAX_TIMELINES && timelines[timeline].defined &&
+		timelines[timeline].parent >= 0;
+}
+
+/*
+ * Resolve a read by walking the timeline ancestry: return the newest version of
+ * (key, block) visible at read_lsn on 'timeline'; if the timeline never wrote
+ * the page (or only after read_lsn), descend to the parent, capping read_lsn at
+ * the branch LSN so the branch sees a frozen snapshot of the parent.  Returns
+ * the chosen PageVer, or NULL if no ancestor has the page.
+ */
+PageVer *
+read_through(uint32_t timeline, const PsKey *key, uint32_t block,
+			 uint64_t read_lsn)
+{
+	for (;;)
+	{
+		PageEnt    *e = page_find(timeline, key, block);
+		PageVer    *v = e ? page_visible(e, read_lsn) : NULL;
+
+		if (v)
+			return v;
+		if (!timeline_has_parent(timeline))
+			return NULL;
+		if (timelines[timeline].branch_lsn < read_lsn)
+			read_lsn = timelines[timeline].branch_lsn;
+		timeline = (uint32_t) timelines[timeline].parent;
+	}
+}
+
+/*
+ * Fork size visible on 'timeline': the maximum block count across the timeline
+ * and all its ancestors.  A branch that has written only some blocks of a fork
+ * still inherits the parent's full size (the unwritten blocks are served by
+ * read_through), so we must take the max rather than the first entry found --
+ * otherwise the branch would under-report the size and reads of inherited
+ * blocks would look out of range.
+ *
+ * (Prototype limitation: nblocks is not itself versioned, so if the parent
+ * *grows* a fork after the branch point the branch sees the larger size; for a
+ * quiescent parent -- the usual branch case -- this is correct.)
+ */
+static uint32_t
+fork_nblocks_through(uint32_t timeline, const PsKey *key)
+{
+	uint32_t	maxnb = 0;
+
+	for (;;)
+	{
+		ForkEnt    *e = fork_find(timeline, key);
+
+		if (e && e->nblocks > maxnb)
+			maxnb = e->nblocks;
+		if (!timeline_has_parent(timeline))
+			return maxnb;
+		timeline = (uint32_t) timelines[timeline].parent;
+	}
+}
+
+/* Does the fork exist on 'timeline' or any ancestor? */
+static int
+fork_exists_through(uint32_t timeline, const PsKey *key)
+{
+	for (;;)
+	{
+		if (fork_find(timeline, key))
+			return 1;
+		if (!timeline_has_parent(timeline))
+			return 0;
+		timeline = (uint32_t) timelines[timeline].parent;
+	}
+}
+
+/*
+ * Timeline metadata is persisted as an append-only log of fixed records in
+ * "<store>/timelines", so branches survive a daemon restart.  (The page data
+ * itself is already durable in the segments.)
+ */
+typedef struct TimelineRec
+{
+	uint32_t	id;
+	int32_t		parent;
+	uint64_t	branch_lsn;
+} TimelineRec;
+
+static void
+timeline_persist(uint32_t id, int parent, uint64_t branch_lsn)
+{
+	TimelineRec rec = {id, (int32_t) parent, branch_lsn};
+
+	ps_storage->meta_append(&rec, sizeof(rec));		/* best-effort */
+}
+
+static void
+load_timelines(void)
+{
+	TimelineRec rec;
+	uint64_t	off = 0;
+
+	while (ps_storage->meta_read(off, &rec, sizeof(rec)) == (int) sizeof(rec))
+	{
+		timeline_define(rec.id, rec.parent, rec.branch_lsn);
+		off += sizeof(rec);
+	}
+}
+
+/* ===================== shipped WAL log (per timeline) ================== */
+
+/*
+ * Each timeline has an append-only WAL log "wal_<tl>" of self-describing
+ * records [WalRecHdr | bytes].  This is the durability/transport half of WAL
+ * shipping: the compute ships its WAL stream here so it is persisted by the
+ * store, per timeline.  (Replaying these records to materialize pages -- redo
+ * -- is a later milestone; it would reuse PostgreSQL's rmgr redo.)
+ */
+#define WAL_MAGIC	0x57414c52	/* "WALR" */
+
+typedef struct WalRecHdr
+{
+	uint32_t	magic;
+	uint32_t	len;			/* WAL bytes following the header */
+	uint64_t	start_lsn;		/* LSN of the first byte */
+} WalRecHdr;
+
+/* highest end LSN (start+len) received per timeline */
+static uint64_t wal_end[MAX_TIMELINES];
+
+static int
+wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,
+		   uint32_t len)
+{
+	WalRecHdr	h;
+
+	if (tl >= MAX_TIMELINES)
+		return -1;
+
+	h.magic = WAL_MAGIC;
+	h.len = len;
+	h.start_lsn = start_lsn;
+	if (ps_storage->wal_append(tl, &h, sizeof(h), data, len) != 0)
+		return -1;
+
+	if (start_lsn + len > wal_end[tl])
+		wal_end[tl] = start_lsn + len;
+	return 0;
+}
+
+/*
+ * Read up to 'len' WAL bytes starting at WAL position 'start' from a timeline's
+ * log into 'out'; returns the number of bytes filled.  Bytes not covered by any
+ * record are left as-is.  This is what a redo worker uses to pull WAL from the
+ * store for replay.  (Single timeline for now; reading a branch's WAL across
+ * its fork point is a refinement.)
+ */
+static uint32_t
+wal_read(uint32_t tl, uint64_t start, uint32_t len, unsigned char *out)
+{
+	uint64_t	off = 0;
+	WalRecHdr	h;
+	uint32_t	filled = 0;
+
+	if (tl >= MAX_TIMELINES)
+		return 0;
+
+	while (ps_storage->wal_read(tl, off, &h, sizeof(h)) == (int) sizeof(h) &&
+		   h.magic == WAL_MAGIC)
+	{
+		uint64_t	rs = h.start_lsn;
+		uint64_t	re = rs + h.len;
+		uint64_t	ws = start;
+		uint64_t	we = start + len;
+		uint64_t	os = rs > ws ? rs : ws;	/* overlap start */
+		uint64_t	oe = re < we ? re : we;	/* overlap end */
+
+		if (os < oe)
+		{
+			uint64_t	src = off + sizeof(h) + (os - rs);
+			int			n = ps_storage->wal_read(tl, src, out + (os - start),
+												 (uint32_t) (oe - os));
+
+			if (n > 0)
+				filled += (uint32_t) n;
+		}
+		off += sizeof(h) + h.len;
+	}
+	return filled;
+}
+
+/* Rebuild wal_end[tl] by scanning the timeline's WAL log at startup. */
+static void
+wal_recover_one(uint32_t tl)
+{
+	uint64_t	off = 0;
+	WalRecHdr	h;
+
+	if (tl >= MAX_TIMELINES)
+		return;
+	while (ps_storage->wal_read(tl, off, &h, sizeof(h)) == (int) sizeof(h) &&
+		   h.magic == WAL_MAGIC)
+	{
+		if (h.start_lsn + h.len > wal_end[tl])
+			wal_end[tl] = h.start_lsn + h.len;
+		off += sizeof(h) + h.len;
+	}
+}
+
+/* ===================== per-page WAL index ============================== */
+
+/*
+ * Maps (timeline, key, block) -> the LSNs of WAL records that modify that page,
+ * in ascending order.  This is the lookup single-page materialization needs: to
+ * rebuild page P as-of LSN L, take P's newest stored image and replay the WAL
+ * records whose LSNs fall after it and <= L.  Populated by decoding shipped WAL
+ * (next milestone); queried via PS_OP_WAL_INDEX_GET.
+ *
+ * In-memory only for now (rebuilt by re-decoding WAL after a restart).
+ */
+typedef struct WalIdxEnt
+{
+	struct WalIdxEnt *next;
+	uint32_t	timeline;
+	PsKey		key;
+	uint32_t	block;
+	uint64_t   *lsns;			/* ascending */
+	int			n;
+	int			cap;
+} WalIdxEnt;
+
+static WalIdxEnt *walidx[IDX_BUCKETS];
+
+static void
+walidx_add(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
+{
+	uint32_t	h = page_hash(tl, key, block);
+	WalIdxEnt  *e;
+
+	for (e = walidx[h & IDX_MASK]; e; e = e->next)
+		if (e->timeline == tl && e->block == block && key_eq(&e->key, key))
+			break;
+	if (!e)
+	{
+		e = calloc(1, sizeof(*e));
+		e->timeline = tl;
+		e->key = *key;
+		e->block = block;
+		e->next = walidx[h & IDX_MASK];
+		walidx[h & IDX_MASK] = e;
+	}
+	if (e->n == e->cap)
+	{
+		e->cap = e->cap ? e->cap * 2 : 4;
+		e->lsns = realloc(e->lsns, (size_t) e->cap * sizeof(uint64_t));
+	}
+	/* keep ascending; WAL is appended in LSN order, so usually just append */
+	if (e->n == 0 || lsn >= e->lsns[e->n - 1])
+		e->lsns[e->n++] = lsn;
+	else
+	{
+		int			i = e->n;
+
+		while (i > 0 && e->lsns[i - 1] > lsn)
+		{
+			e->lsns[i] = e->lsns[i - 1];
+			i--;
+		}
+		e->lsns[i] = lsn;
+		e->n++;
+	}
+}
+
+/* Copy the record LSNs for (tl,key,block) that are <= lsn_max into out (cap
+ * max_out); return how many.  Walks the timeline ancestry. */
+static int
+walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
+		   uint64_t *out, int max_out)
+{
+	int			got = 0;
+
+	for (;;)
+	{
+		uint32_t	h = page_hash(tl, key, block);
+		WalIdxEnt  *e;
+
+		for (e = walidx[h & IDX_MASK]; e; e = e->next)
+			if (e->timeline == tl && e->block == block && key_eq(&e->key, key))
+			{
+				for (int i = 0; i < e->n && got < max_out; i++)
+					if (e->lsns[i] <= lsn_max)
+						out[got++] = e->lsns[i];
+				break;
+			}
+		if (!timeline_has_parent(tl))
+			break;
+		if (timelines[tl].branch_lsn < lsn_max)
+			lsn_max = timelines[tl].branch_lsn;
+		tl = (uint32_t) timelines[tl].parent;
+	}
+	return got;
+}
+
+/* ===================== write / read primitives ========================= */
+
+/* The page's own pd_lsn lives in its first 8 bytes (xlogid, xrecoff). */
+static uint64_t
+page_lsn(const unsigned char *page)
+{
+	uint32_t	xlogid,
+				xrecoff;
+
+	memcpy(&xlogid, page, 4);
+	memcpy(&xrecoff, page + 4, 4);
+	return ((uint64_t) xlogid << 32) | xrecoff;
+}
+
+/*
+ * Append one page version at the log head and record it in the index.  Because
+ * every write lands at the moving append cursor, physical writes are large and
+ * sequential even though each logical page is small -- the property we want for
+ * NVMe/SPDK and network transports.
+ */
+int
+append_page(uint32_t timeline, const PsKey *key, uint32_t block,
+			const unsigned char *page)
+{
+	SegRecHdr	hdr;
+	uint64_t	reclen = sizeof(SegRecHdr) + page_size;
+	uint64_t	data_off;
+
+	/* roll over to a fresh segment when the current one would overflow */
+	if (cur_seg < 0 || cur_off + reclen > segment_size)
+	{
+		cur_seg = (cur_seg < 0) ? 0 : cur_seg + 1;
+		cur_off = 0;
+	}
+
+	hdr.magic = SEG_MAGIC;
+	hdr.timeline = timeline;
+	hdr.key = *key;
+	hdr.block = block;
+	hdr.lsn = page_lsn(page);	/* version key taken from the page itself */
+	hdr.len = page_size;
+
+	/* write header then page bytes contiguously at the append cursor */
+	if (ps_storage->seg_write(cur_seg, cur_off, &hdr, sizeof(hdr)) != 0)
+		return -1;
+	data_off = cur_off + sizeof(hdr);
+	if (ps_storage->seg_write(cur_seg, data_off, page, page_size) != 0)
+		return -1;
+
+	/* index points at the page bytes (data_off), so reads skip the header */
+	page_add_version(timeline, key, block, hdr.lsn, cur_seg, data_off);
+	cur_off += reclen;
+	return 0;
+}
+
+/* Read a specific version's page bytes into out (page_size bytes). */
+int
+read_version(const PageVer *v, unsigned char *out)
+{
+	if (ps_storage->seg_read(v->seg, v->off, out, page_size) != 0)
+		return -1;
+	return 0;
+}
+
+/* ===================== recovery (rebuild index from segments) ========== */
+
+/*
+ * Rebuild the entire in-memory index at startup by replaying the segments in
+ * order.  Each record is self-describing, so replaying append_page's effect
+ * (page_add_version + fork_grow) for every record reconstructs both indexes and
+ * leaves the append cursor positioned just past the last valid record.
+ *
+ * Caveat (prototype): TRUNCATE and UNLINK are not logged as records, so their
+ * effects are not reproduced on restart.  Also a partial/torn trailing record
+ * is simply treated as end-of-log (the magic/len check below stops the scan).
+ */
+static void
+recover(void)
+{
+	for (int id = 0;; id++)
+	{
+		uint64_t	off = 0;
+
+		if (ps_storage->seg_size(id) < 0)
+			break;				/* no more segments -> done */
+
+		/* replay records until one fails to validate (end of log) */
+		for (;;)
+		{
+			SegRecHdr	hdr;
+
+			if (ps_storage->seg_read(id, off, &hdr, sizeof(hdr)) != 0 ||
+				hdr.magic != SEG_MAGIC || hdr.len != page_size)
+				break;
+
+			page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn, id,
+							 off + sizeof(hdr));
+			fork_grow(hdr.timeline, &hdr.key, hdr.block + 1);
+			off += sizeof(hdr) + hdr.len;
+		}
+
+		/* this segment is the newest seen so far; append continues after it */
+		cur_seg = id;
+		cur_off = off;
+	}
+	if (cur_seg >= 0)
+		fprintf(stderr, "pagestore_daemon: recovered through segment %d (off %llu)\n",
+				cur_seg, (unsigned long long) cur_off);
+}
+
+/* ===================== request handling (non-I/O ops) ================== */
+
+/*
+ * Handle every request that needs no page byte I/O and return 1.  The four
+ * byte-I/O ops (EXTEND/WRITEV/READV/READ_AT) -- and any unknown op -- return 0,
+ * for the frontend to handle (synchronously for POSIX, async for SPDK).  The
+ * frontend sets ch->status = OK and ch->result = 0 before calling.
+ */
+int
+ps_handle_meta(PsChannel *ch)
+{
+	uint32_t	tl = ch->timeline;
+
+	switch ((PsOpcode) ch->opcode)
+	{
+		case PS_OP_CREATE:
+			fork_get_or_create(tl, &ch->key);
+			break;
+
+		case PS_OP_EXISTS:
+			ch->result = fork_exists_through(tl, &ch->key) ? 1 : 0;
+			break;
+
+		case PS_OP_UNLINK:
+			fork_remove(tl, &ch->key);
+			break;
+
+		case PS_OP_NBLOCKS:
+			ch->result = fork_nblocks_through(tl, &ch->key);
+			break;
+
+		case PS_OP_TRUNCATE:
+			fork_get_or_create(tl, &ch->key)->nblocks = ch->nblocks;
+			break;
+
+		case PS_OP_ZEROEXTEND:
+			/* allocation only: grow size, no page data stored (reads -> 0) */
+			fork_grow(tl, &ch->key, ch->blocknum + ch->nblocks);
+			break;
+
+		case PS_OP_CREATE_BRANCH:
+			/*
+			 * Instant clone: just record metadata.  Timeline ch->timeline forks
+			 * from ch->parent_timeline at LSN ch->req_lsn.  No page data is
+			 * copied -- the branch shares the parent's pages by read-through
+			 * until it writes (copy-on-write).
+			 */
+			if (ch->timeline == 0 || ch->timeline >= MAX_TIMELINES)
+				ch->status = PS_STATUS_ERROR;
+			else
+			{
+				timeline_define(ch->timeline, (int) ch->parent_timeline,
+								ch->req_lsn);
+				timeline_persist(ch->timeline, (int) ch->parent_timeline,
+								 ch->req_lsn);
+			}
+			break;
+
+		case PS_OP_WAL_APPEND:
+			if (wal_append(tl, ch->req_lsn, ch->data, ch->datalen) != 0)
+				ch->status = PS_STATUS_ERROR;
+			break;
+
+		case PS_OP_WAL_SIZE:
+			ch->req_lsn = wal_end[tl];	/* output: end LSN of this timeline's WAL */
+			break;
+
+		case PS_OP_WAL_READ:
+			ch->result = wal_read(tl, ch->req_lsn, ch->datalen, ch->data);
+			break;
+
+		case PS_OP_WAL_INDEX_ADD:
+			walidx_add(tl, &ch->key, ch->blocknum, ch->req_lsn);
+			break;
+
+		case PS_OP_WAL_INDEX_GET:
+			ch->result = (uint32_t) walidx_get(tl, &ch->key, ch->blocknum,
+											   ch->req_lsn, (uint64_t *) ch->data,
+											   (int) (PS_IO_UNIT / sizeof(uint64_t)));
+			break;
+
+		case PS_OP_IMMEDSYNC:
+			ps_storage->sync();
+			break;
+
+		default:
+			return 0;			/* a byte-I/O op (or unknown): frontend handles */
+	}
+	return 1;
+}
+
+/* ===================== lifecycle ====================================== */
+
+/*
+ * Open the store and rebuild all in-memory state from it: define the root
+ * timeline, load persisted branches, replay the segments to rebuild the page
+ * and fork indexes, and recompute each timeline's shipped-WAL end LSN.  The
+ * frontend must set page_size, segment_size and ps_storage beforehand.
+ */
+int
+ps_core_open(const char *store_dir)
+{
+	if (ps_storage->open(store_dir, segment_size) != 0)
+		return -1;
+
+	/* timeline 0 is the root; load any persisted branches, then replay data */
+	timeline_define(0, -1, 0);
+	load_timelines();
+	recover();
+
+	/* rebuild each timeline's shipped-WAL end LSN from its log */
+	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
+		if (tl == 0 || timelines[tl].defined)
+			wal_recover_one(tl);
+
+	return 0;
+}

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -303,6 +303,35 @@ timeline_has_parent(uint32_t timeline)
 }
 
 /*
+ * Validate a branch-creation request before it is recorded.  read_through() and
+ * the fork-size walks follow the parent chain assuming it is finite and well
+ * formed, so a bad CREATE_BRANCH must be rejected rather than persisted.  Refuse:
+ *	- a new id that is out of range, the root (0), or already defined (otherwise
+ *	  re-creating an id silently rewrites an existing branch's ancestry);
+ *	- a parent that is out of range or not yet defined (the requested parent must
+ *	  actually exist, else the branch silently inherits from nothing);
+ *	- a parent whose ancestry already reaches the new id, which would turn the
+ *	  parent walk into an infinite loop (e.g. new == parent, or A->B->A).
+ * Returns 1 if (new_tl, parent) is safe to define.
+ */
+static int
+branch_request_ok(uint32_t new_tl, int parent)
+{
+	if (new_tl == 0 || new_tl >= MAX_TIMELINES || timelines[new_tl].defined)
+		return 0;
+	if (parent < 0 || parent >= MAX_TIMELINES || !timelines[parent].defined)
+		return 0;
+	for (int t = parent; t >= 0 && t < MAX_TIMELINES; t = timelines[t].parent)
+	{
+		if ((uint32_t) t == new_tl)
+			return 0;			/* cycle */
+		if (!timelines[t].defined)
+			return 0;			/* broken chain: refuse rather than risk a loop */
+	}
+	return 1;
+}
+
+/*
  * Resolve a read by walking the timeline ancestry: return the newest version of
  * (key, block) visible at read_lsn on 'timeline'; if the timeline never wrote
  * the page (or only after read_lsn), descend to the parent, capping read_lsn at
@@ -755,15 +784,15 @@ ps_handle_meta(PsChannel *ch)
 			 * copied -- the branch shares the parent's pages by read-through
 			 * until it writes (copy-on-write).
 			 */
-			if (ch->timeline == 0 || ch->timeline >= MAX_TIMELINES)
-				ch->status = PS_STATUS_ERROR;
-			else
+			if (branch_request_ok(ch->timeline, (int) ch->parent_timeline))
 			{
 				timeline_define(ch->timeline, (int) ch->parent_timeline,
 								ch->req_lsn);
 				timeline_persist(ch->timeline, (int) ch->parent_timeline,
 								 ch->req_lsn);
 			}
+			else
+				ch->status = PS_STATUS_ERROR;
 			break;
 
 		case PS_OP_WAL_APPEND:

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -1,0 +1,58 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_core.h
+ *	  Shared "brain" of the page-store daemon.
+ *
+ * The in-memory indexes, copy-on-write read-through, timelines, per-page WAL
+ * index, shipped-WAL metadata and recovery live here and are compiled into both
+ * the POSIX daemon and the (optional) SPDK daemon, so the store's core logic is
+ * single-sourced.  Each frontend supplies only its request loop and the page
+ * byte I/O -- synchronous for POSIX, callback-driven for SPDK -- which goes
+ * through the PsStorage interface.  The IPC ABI is unaffected by any of this.
+ *
+ * Seam: ps_handle_meta() handles every request that is not page byte I/O; the
+ * four byte-I/O ops are done by each frontend using read_through()/read_version()
+ * (reads) and append_page()/fork_grow() (writes).
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PAGESTORE_CORE_H
+#define PAGESTORE_CORE_H
+
+#include <stdint.h>
+
+#include "pagestore_ipc.h"
+#include "pagestore_storage.h"
+
+/* One stored version of a page: its LSN and where the bytes live in the store. */
+typedef struct PageVer
+{
+	uint64_t	lsn;			/* the page's pd_lsn when it was written */
+	int			seg;			/* segment id holding the bytes */
+	uint64_t	off;			/* byte offset of the page within that segment */
+} PageVer;
+
+/* Configuration shared with the frontend; set by the frontend before open. */
+extern uint32_t page_size;
+extern uint64_t segment_size;
+extern const PsStorage *ps_storage;
+
+/* Open the store and rebuild all in-memory state (timelines, indexes, WAL). */
+extern int	ps_core_open(const char *store_dir);
+
+/*
+ * Handle every request that is NOT page byte I/O and return 1.  The four
+ * byte-I/O ops (EXTEND/WRITEV/READV/READ_AT) and unknown ops return 0 for the
+ * frontend to handle.  Sets ch->status/ch->result as appropriate.
+ */
+extern int	ps_handle_meta(PsChannel *ch);
+
+/* Page byte-I/O helpers used by the frontends' byte-op handlers. */
+extern int	append_page(uint32_t timeline, const PsKey *key, uint32_t block,
+						const unsigned char *page);
+extern PageVer *read_through(uint32_t timeline, const PsKey *key, uint32_t block,
+							 uint64_t read_lsn);
+extern int	read_version(const PageVer *v, unsigned char *out);
+extern void fork_grow(uint32_t timeline, const PsKey *key, uint32_t to_nblocks);
+
+#endif							/* PAGESTORE_CORE_H */

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -43,12 +43,16 @@
 #include <unistd.h>
 
 #include "pagestore_ipc.h"
+#include "pagestore_storage.h"
 
 static volatile sig_atomic_t stop_requested = 0;
 static const char *store_dir;
 static const char *shm_name;
 static uint32_t page_size = PS_DEFAULT_PAGE_SIZE;
 static uint64_t segment_size = 8 * 1024 * 1024;
+
+/* the active storage backend (POSIX by default; see --storage) */
+const PsStorage *ps_storage = &PsStoragePosix;
 
 static void
 on_signal(int sig)
@@ -79,48 +83,12 @@ typedef struct SegRecHdr
 } SegRecHdr;
 
 /*
- * Segments are plain append-only files seg_00000000, seg_00000001, ...  We keep
- * one OS fd open per segment (opened lazily, never closed during a run) and an
+ * Segments are addressed by (id, byte offset); how they are stored is the
+ * storage backend's business (see pagestore_storage.h).  Here we keep only the
  * append cursor (cur_seg, cur_off) marking where the next record goes.
  */
-static int *seg_fds;			/* open fd per segment id (-1 if not open) */
-static int	segs_cap;			/* allocated length of seg_fds[] */
 static int	cur_seg = -1;		/* segment currently being appended (-1: none yet) */
 static uint64_t cur_off;		/* append cursor within cur_seg */
-
-static void
-seg_path(char *buf, size_t buflen, int id)
-{
-	snprintf(buf, buflen, "%s/seg_%08d", store_dir, id);
-}
-
-/* Return a cached fd for segment 'id', opening (optionally creating) it once. */
-static int
-seg_fd(int id, int create)
-{
-	char		path[4096];
-	int			fd;
-
-	if (id < segs_cap && seg_fds[id] >= 0)
-		return seg_fds[id];
-
-	/* grow the fd cache to cover 'id', initializing new slots to -1 */
-	if (id >= segs_cap)
-	{
-		int			newcap = (id + 16) * 2;
-
-		seg_fds = realloc(seg_fds, (size_t) newcap * sizeof(int));
-		for (int i = segs_cap; i < newcap; i++)
-			seg_fds[i] = -1;
-		segs_cap = newcap;
-	}
-
-	seg_path(path, sizeof(path), id);
-	fd = open(path, O_RDWR | (create ? O_CREAT : 0), 0600);
-	if (fd >= 0)
-		seg_fds[id] = fd;
-	return fd;
-}
 
 /* ===================== in-memory indexes =============================== */
 
@@ -474,35 +442,22 @@ typedef struct TimelineRec
 static void
 timeline_persist(uint32_t id, int parent, uint64_t branch_lsn)
 {
-	char		path[4096];
-	int			fd;
 	TimelineRec rec = {id, (int32_t) parent, branch_lsn};
 
-	snprintf(path, sizeof(path), "%s/timelines", store_dir);
-	fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
-	if (fd < 0)
-		return;					/* best-effort */
-	if (write(fd, &rec, sizeof(rec)) != (ssize_t) sizeof(rec))
-	{
-		/* ignore: best-effort */
-	}
-	close(fd);
+	ps_storage->meta_append(&rec, sizeof(rec));		/* best-effort */
 }
 
 static void
 load_timelines(void)
 {
-	char		path[4096];
-	int			fd;
 	TimelineRec rec;
+	uint64_t	off = 0;
 
-	snprintf(path, sizeof(path), "%s/timelines", store_dir);
-	fd = open(path, O_RDONLY);
-	if (fd < 0)
-		return;					/* none yet */
-	while (read(fd, &rec, sizeof(rec)) == (ssize_t) sizeof(rec))
+	while (ps_storage->meta_read(off, &rec, sizeof(rec)) == (int) sizeof(rec))
+	{
 		timeline_define(rec.id, rec.parent, rec.branch_lsn);
-	close(fd);
+		off += sizeof(rec);
+	}
 }
 
 /* ===================== shipped WAL log (per timeline) ================== */
@@ -530,27 +485,16 @@ static int
 wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,
 		   uint32_t len)
 {
-	char		path[4096];
-	int			fd;
 	WalRecHdr	h;
 
 	if (tl >= MAX_TIMELINES)
-		return -1;
-	snprintf(path, sizeof(path), "%s/wal_%u", store_dir, tl);
-	fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
-	if (fd < 0)
 		return -1;
 
 	h.magic = WAL_MAGIC;
 	h.len = len;
 	h.start_lsn = start_lsn;
-	if (write(fd, &h, sizeof(h)) != (ssize_t) sizeof(h) ||
-		write(fd, data, len) != (ssize_t) len)
-	{
-		close(fd);
+	if (ps_storage->wal_append(tl, &h, sizeof(h), data, len) != 0)
 		return -1;
-	}
-	close(fd);
 
 	if (start_lsn + len > wal_end[tl])
 		wal_end[tl] = start_lsn + len;
@@ -567,20 +511,14 @@ wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,
 static uint32_t
 wal_read(uint32_t tl, uint64_t start, uint32_t len, unsigned char *out)
 {
-	char		path[4096];
-	int			fd;
-	off_t		off = 0;
+	uint64_t	off = 0;
 	WalRecHdr	h;
 	uint32_t	filled = 0;
 
 	if (tl >= MAX_TIMELINES)
 		return 0;
-	snprintf(path, sizeof(path), "%s/wal_%u", store_dir, tl);
-	fd = open(path, O_RDONLY);
-	if (fd < 0)
-		return 0;
 
-	while (pread(fd, &h, sizeof(h), off) == (ssize_t) sizeof(h) &&
+	while (ps_storage->wal_read(tl, off, &h, sizeof(h)) == (int) sizeof(h) &&
 		   h.magic == WAL_MAGIC)
 	{
 		uint64_t	rs = h.start_lsn;
@@ -592,15 +530,15 @@ wal_read(uint32_t tl, uint64_t start, uint32_t len, unsigned char *out)
 
 		if (os < oe)
 		{
-			off_t		src = off + sizeof(h) + (off_t) (os - rs);
-			ssize_t		n = pread(fd, out + (os - start), (size_t) (oe - os), src);
+			uint64_t	src = off + sizeof(h) + (os - rs);
+			int			n = ps_storage->wal_read(tl, src, out + (os - start),
+												 (uint32_t) (oe - os));
 
 			if (n > 0)
 				filled += (uint32_t) n;
 		}
 		off += sizeof(h) + h.len;
 	}
-	close(fd);
 	return filled;
 }
 
@@ -608,25 +546,18 @@ wal_read(uint32_t tl, uint64_t start, uint32_t len, unsigned char *out)
 static void
 wal_recover_one(uint32_t tl)
 {
-	char		path[4096];
-	int			fd;
-	off_t		off = 0;
+	uint64_t	off = 0;
 	WalRecHdr	h;
 
 	if (tl >= MAX_TIMELINES)
 		return;
-	snprintf(path, sizeof(path), "%s/wal_%u", store_dir, tl);
-	fd = open(path, O_RDONLY);
-	if (fd < 0)
-		return;
-	while (pread(fd, &h, sizeof(h), off) == (ssize_t) sizeof(h) &&
+	while (ps_storage->wal_read(tl, off, &h, sizeof(h)) == (int) sizeof(h) &&
 		   h.magic == WAL_MAGIC)
 	{
 		if (h.start_lsn + h.len > wal_end[tl])
 			wal_end[tl] = h.start_lsn + h.len;
 		off += sizeof(h) + h.len;
 	}
-	close(fd);
 }
 
 /* ===================== per-page WAL index ============================== */
@@ -749,7 +680,6 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 {
 	SegRecHdr	hdr;
 	uint64_t	reclen = sizeof(SegRecHdr) + page_size;
-	int			fd;
 	uint64_t	data_off;
 
 	/* roll over to a fresh segment when the current one would overflow */
@@ -758,9 +688,6 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 		cur_seg = (cur_seg < 0) ? 0 : cur_seg + 1;
 		cur_off = 0;
 	}
-	fd = seg_fd(cur_seg, 1);
-	if (fd < 0)
-		return -1;
 
 	hdr.magic = SEG_MAGIC;
 	hdr.timeline = timeline;
@@ -770,10 +697,10 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	hdr.len = page_size;
 
 	/* write header then page bytes contiguously at the append cursor */
-	if (pwrite(fd, &hdr, sizeof(hdr), cur_off) != (ssize_t) sizeof(hdr))
+	if (ps_storage->seg_write(cur_seg, cur_off, &hdr, sizeof(hdr)) != 0)
 		return -1;
 	data_off = cur_off + sizeof(hdr);
-	if (pwrite(fd, page, page_size, data_off) != (ssize_t) page_size)
+	if (ps_storage->seg_write(cur_seg, data_off, page, page_size) != 0)
 		return -1;
 
 	/* index points at the page bytes (data_off), so reads skip the header */
@@ -786,11 +713,7 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 static int
 read_version(const PageVer *v, unsigned char *out)
 {
-	int			fd = seg_fd(v->seg, 0);
-
-	if (fd < 0)
-		return -1;
-	if (pread(fd, out, page_size, v->off) != (ssize_t) page_size)
+	if (ps_storage->seg_read(v->seg, v->off, out, page_size) != 0)
 		return -1;
 	return 0;
 }
@@ -812,29 +735,18 @@ recover(void)
 {
 	for (int id = 0;; id++)
 	{
-		char		path[4096];
-		int			fd;
 		uint64_t	off = 0;
-		struct stat st;
 
-		seg_path(path, sizeof(path), id);
-		fd = open(path, O_RDONLY);
-		if (fd < 0)
+		if (ps_storage->seg_size(id) < 0)
 			break;				/* no more segments -> done */
-		if (fstat(fd, &st) != 0)
-		{
-			close(fd);
-			break;
-		}
 
 		/* replay records until one fails to validate (end of log) */
 		for (;;)
 		{
 			SegRecHdr	hdr;
-			ssize_t		n = pread(fd, &hdr, sizeof(hdr), off);
 
-			if (n != (ssize_t) sizeof(hdr) || hdr.magic != SEG_MAGIC ||
-				hdr.len != page_size)
+			if (ps_storage->seg_read(id, off, &hdr, sizeof(hdr)) != 0 ||
+				hdr.magic != SEG_MAGIC || hdr.len != page_size)
 				break;
 
 			page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn, id,
@@ -842,7 +754,6 @@ recover(void)
 			fork_grow(hdr.timeline, &hdr.key, hdr.block + 1);
 			off += sizeof(hdr) + hdr.len;
 		}
-		close(fd);
 
 		/* this segment is the newest seen so far; append continues after it */
 		cur_seg = id;
@@ -977,9 +888,7 @@ handle_request(PsChannel *ch)
 			break;
 
 		case PS_OP_IMMEDSYNC:
-			for (int id = 0; id < segs_cap; id++)
-				if (seg_fds[id] >= 0)
-					fsync(seg_fds[id]);
+			ps_storage->sync();
 			break;
 
 		default:
@@ -1006,23 +915,41 @@ main(int argc, char **argv)
 			page_size = (uint32_t) strtoul(argv[++i], NULL, 10);
 		else if (strcmp(argv[i], "--segment-size") == 0 && i + 1 < argc)
 			segment_size = strtoull(argv[++i], NULL, 10);
+		else if (strcmp(argv[i], "--storage") == 0 && i + 1 < argc)
+		{
+			const char *name = argv[++i];
+
+			if (strcmp(name, "posix") == 0)
+				ps_storage = &PsStoragePosix;
+#ifdef PAGESTORE_SPDK
+			else if (strcmp(name, "spdk") == 0)
+				ps_storage = &PsStorageSpdk;
+#endif
+			else
+			{
+				fprintf(stderr, "unknown --storage backend '%s'\n", name);
+				return 2;
+			}
+		}
 		else
 		{
 			fprintf(stderr, "usage: %s --shm NAME --store DIR "
-					"[--page-size N] [--segment-size N]\n", argv[0]);
+					"[--page-size N] [--segment-size N] [--storage NAME]\n",
+					argv[0]);
 			return 2;
 		}
 	}
 	if (!shm_name || !store_dir || page_size == 0 || page_size > PS_IO_UNIT)
 	{
 		fprintf(stderr, "usage: %s --shm NAME --store DIR "
-				"[--page-size N] [--segment-size N]\n", argv[0]);
+				"[--page-size N] [--segment-size N] [--storage NAME]\n",
+				argv[0]);
 		return 2;
 	}
 
-	if (mkdir(store_dir, 0700) != 0 && errno != EEXIST)
+	if (ps_storage->open(store_dir, segment_size) != 0)
 	{
-		perror("mkdir store");
+		perror("storage open");
 		return 1;
 	}
 
@@ -1077,9 +1004,10 @@ main(int argc, char **argv)
 	sigaction(SIGINT, &sa, NULL);
 	sigaction(SIGTERM, &sa, NULL);
 
-	fprintf(stderr, "pagestore_daemon: shm=%s store=%s page_size=%u io_unit=%u "
-			"channels=%d ready\n",
-			shm_name, store_dir, page_size, PS_IO_UNIT, PS_MAX_CHANNELS);
+	fprintf(stderr, "pagestore_daemon: shm=%s store=%s storage=%s page_size=%u "
+			"io_unit=%u channels=%d ready\n",
+			shm_name, store_dir, ps_storage->name, page_size, PS_IO_UNIT,
+			PS_MAX_CHANNELS);
 
 	while (!stop_requested)
 	{

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -1,58 +1,37 @@
 /*-------------------------------------------------------------------------
  *
  * pagestore_daemon.c
- *	  Standalone log-structured storage daemon for the pagestore "localsvc"
- *	  backend.
+ *	  POSIX frontend for the page-store daemon.
  *
- * Design (see also pagestore_ipc.h):
+ * The store's logic (indexes, COW, timelines, WAL, recovery) lives in the
+ * shared brain pagestore_core.c; this frontend is just the synchronous request
+ * loop over the shared-memory channels plus the page byte I/O, served through
+ * the POSIX storage backend (storage_posix.c).  It is libc-only and depends on
+ * nothing else -- the portable default daemon.  The SPDK daemon is a separate
+ * binary that reuses the same brain with an asynchronous loop.
  *
- *	- Page-size agnostic.  The logical page size is configured with --page-size
- *	  (8192 for PostgreSQL, 16384 for InnoDB, ...) and published in the shm
- *	  header; nothing about the on-disk format assumes a particular value.
+ * Includes only pagestore_ipc.h / pagestore_core.h and libc -- never
+ * PostgreSQL headers.
  *
- *	- Log-structured storage.  Every page write is appended to a growing
- *	  segment file (seg_NNNNNNNN) as a self-describing record
- *	  [SegRecHdr | page bytes].  Writes are therefore large and sequential
- *	  regardless of how small individual logical pages are -- which is what
- *	  makes the store friendly to NVMe/SPDK and network transports.  Old
- *	  versions are never overwritten, so the log is also the COW history.
- *
- *	- Indirection map.  An in-memory index maps (key, block) -> a chain of
- *	  versions {lsn, segment, offset}.  This lets a single small logical page
- *	  be addressed inside a large physical segment (ranged read), decoupling
- *	  "address by page" from "store/transfer in large units".  The index is
- *	  rebuilt by scanning segments at startup.
- *
- * Includes only pagestore_ipc.h and libc -- never PostgreSQL headers.
- *
- * Usage: pagestore_daemon --shm NAME --store DIR [--page-size N] [--segment-size N]
- *
- * src/../contrib/pagestore/pagestore_daemon.c
+ * Usage: pagestore_daemon --shm NAME --store DIR
+ *                         [--page-size N] [--segment-size N] [--storage NAME]
  *
  *-------------------------------------------------------------------------
  */
-#include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
 #include "pagestore_ipc.h"
-#include "pagestore_storage.h"
+#include "pagestore_core.h"
 
 static volatile sig_atomic_t stop_requested = 0;
-static const char *store_dir;
-static const char *shm_name;
-static uint32_t page_size = PS_DEFAULT_PAGE_SIZE;
-static uint64_t segment_size = 8 * 1024 * 1024;
-
-/* the active storage backend (POSIX by default; see --storage) */
-const PsStorage *ps_storage = &PsStoragePosix;
 
 static void
 on_signal(int sig)
@@ -61,711 +40,10 @@ on_signal(int sig)
 	stop_requested = 1;
 }
 
-/* ===================== segment storage (log-structured) ================= */
-
-#define SEG_MAGIC	0x53454752	/* "SEGR" */
-
 /*
- * On-disk layout of one appended page version: this header immediately
- * followed by 'len' page bytes.  The header is self-describing (carries the
- * full key/block/lsn), which is what lets recover() rebuild the entire
- * in-memory index by scanning segments sequentially -- no separate index file
- * to keep in sync.
+ * Serve one request.  The metadata ops are handled by the shared brain; the
+ * four byte-I/O ops are done here synchronously via the storage backend.
  */
-typedef struct SegRecHdr
-{
-	uint32_t	magic;			/* SEG_MAGIC; also the end-of-log sentinel */
-	uint32_t	timeline;		/* timeline the version belongs to */
-	PsKey		key;
-	uint32_t	block;
-	uint64_t	lsn;			/* the page's pd_lsn at write time */
-	uint32_t	len;			/* page bytes following the header */
-} SegRecHdr;
-
-/*
- * Segments are addressed by (id, byte offset); how they are stored is the
- * storage backend's business (see pagestore_storage.h).  Here we keep only the
- * append cursor (cur_seg, cur_off) marking where the next record goes.
- */
-static int	cur_seg = -1;		/* segment currently being appended (-1: none yet) */
-static uint64_t cur_off;		/* append cursor within cur_seg */
-
-/* ===================== in-memory indexes =============================== */
-
-/*
- * Two chained hash tables form the indirection map that lets a single logical
- * page be located inside the large append-only segments:
- *
- *	 page_idx: (timeline, key, block) -> chain of versions {lsn, seg, off}
- *	 fork_idx: (timeline, key)        -> size of the fork on that timeline
- *
- * Entries are keyed by timeline so a branch's writes are isolated; reads that
- * miss on a timeline fall through to its parent (see read_through()).  Both
- * tables are in-memory state, rebuilt from the segments by recover().
- * (Prototype: no GC/compaction, so the version chain only grows.)
- */
-#define IDX_BUCKETS		(1 << 16)
-#define IDX_MASK		(IDX_BUCKETS - 1)
-
-/* One stored version of a page: its LSN and where the bytes live on disk. */
-typedef struct PageVer
-{
-	uint64_t	lsn;			/* the page's pd_lsn when it was written */
-	int			seg;			/* segment id holding the bytes */
-	uint64_t	off;			/* byte offset of the page within that segment */
-} PageVer;
-
-/* Hash entry: all versions of one (timeline, key, block), in arrival order. */
-typedef struct PageEnt
-{
-	struct PageEnt *next;		/* bucket chain */
-	uint32_t	timeline;
-	PsKey		key;
-	uint32_t	block;
-	PageVer    *vers;			/* dynamic array, length nver, capacity cap */
-	int			nver;
-	int			cap;
-} PageEnt;
-
-/* Hash entry: the block count of one fork on one timeline. */
-typedef struct ForkEnt
-{
-	struct ForkEnt *next;		/* bucket chain */
-	uint32_t	timeline;
-	PsKey		key;
-	uint32_t	nblocks;
-} ForkEnt;
-
-static PageEnt *page_idx[IDX_BUCKETS];
-static ForkEnt *fork_idx[IDX_BUCKETS];
-
-/*
- * Timeline metadata.  Timeline 0 is the root (no parent).  A branch records its
- * parent and the LSN at which it forked; reads of pages the branch never wrote
- * fall through to the parent as-of that branch LSN, so the branch is a stable
- * copy-on-write snapshot.
- */
-#define MAX_TIMELINES	1024
-typedef struct TimelineMeta
-{
-	int			defined;		/* 1 if this timeline exists */
-	int			parent;			/* parent timeline id, or -1 for the root */
-	uint64_t	branch_lsn;		/* parent LSN this timeline forked at */
-} TimelineMeta;
-
-static TimelineMeta timelines[MAX_TIMELINES];
-
-/* FNV-1a hash over a byte range (used to hash keys into buckets). */
-
-static uint32_t
-fnv(const void *p, size_t n)
-{
-	const unsigned char *b = p;
-	uint32_t	h = 2166136261u;
-
-	for (size_t i = 0; i < n; i++)
-	{
-		h ^= b[i];
-		h *= 16777619u;
-	}
-	return h;
-}
-
-static int
-key_eq(const PsKey *a, const PsKey *b)
-{
-	return a->spcOid == b->spcOid && a->dbOid == b->dbOid &&
-		a->relNumber == b->relNumber && a->forkNum == b->forkNum;
-}
-
-/* --- page index (keyed by timeline, key, block) --- */
-
-static uint32_t
-page_hash(uint32_t timeline, const PsKey *key, uint32_t block)
-{
-	return fnv(key, sizeof(*key)) ^ (block * 2654435761u) ^ (timeline * 40503u);
-}
-
-static PageEnt *
-page_find(uint32_t timeline, const PsKey *key, uint32_t block)
-{
-	uint32_t	h = page_hash(timeline, key, block);
-	PageEnt    *e;
-
-	for (e = page_idx[h & IDX_MASK]; e; e = e->next)
-		if (e->timeline == timeline && e->block == block && key_eq(&e->key, key))
-			return e;
-	return NULL;
-}
-
-/*
- * Record a new version of (timeline, key, block).  Only ever appends to the
- * version chain -- existing versions are never dropped -- which is what makes
- * the store copy-on-write.  The version is tagged with the writing timeline, so
- * a branch's writes never disturb its parent.  Called from append_page and from
- * recover() while replaying segments.
- */
-static void
-page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
-				 uint64_t lsn, int seg, uint64_t off)
-{
-	uint32_t	h = page_hash(timeline, key, block);
-	PageEnt    *e = page_find(timeline, key, block);
-
-	if (!e)
-	{
-		e = calloc(1, sizeof(*e));
-		e->timeline = timeline;
-		e->key = *key;
-		e->block = block;
-		e->next = page_idx[h & IDX_MASK];
-		page_idx[h & IDX_MASK] = e;
-	}
-	if (e->nver == e->cap)		/* grow the version array geometrically */
-	{
-		e->cap = e->cap ? e->cap * 2 : 2;
-		e->vers = realloc(e->vers, (size_t) e->cap * sizeof(PageVer));
-	}
-	e->vers[e->nver].lsn = lsn;
-	e->vers[e->nver].seg = seg;
-	e->vers[e->nver].off = off;
-	e->nver++;
-}
-
-/* Newest version on this entry with lsn <= read_lsn, or NULL if none. */
-static PageVer *
-page_visible(PageEnt *e, uint64_t read_lsn)
-{
-	PageVer    *best = NULL;
-
-	for (int i = 0; i < e->nver; i++)
-	{
-		PageVer    *v = &e->vers[i];
-
-		if (v->lsn <= read_lsn && (!best || v->lsn >= best->lsn))
-			best = v;
-	}
-	return best;
-}
-
-/* --- fork size index (keyed by timeline, key) --- */
-
-static ForkEnt *
-fork_find(uint32_t timeline, const PsKey *key)
-{
-	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
-	ForkEnt    *e;
-
-	for (e = fork_idx[h & IDX_MASK]; e; e = e->next)
-		if (e->timeline == timeline && key_eq(&e->key, key))
-			return e;
-	return NULL;
-}
-
-static ForkEnt *
-fork_get_or_create(uint32_t timeline, const PsKey *key)
-{
-	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
-	ForkEnt    *e = fork_find(timeline, key);
-
-	if (!e)
-	{
-		e = calloc(1, sizeof(*e));
-		e->timeline = timeline;
-		e->key = *key;
-		e->nblocks = 0;
-		e->next = fork_idx[h & IDX_MASK];
-		fork_idx[h & IDX_MASK] = e;
-	}
-	return e;
-}
-
-static void
-fork_grow(uint32_t timeline, const PsKey *key, uint32_t to_nblocks)
-{
-	ForkEnt    *e = fork_get_or_create(timeline, key);
-
-	if (to_nblocks > e->nblocks)
-		e->nblocks = to_nblocks;
-}
-
-static void
-fork_remove(uint32_t timeline, const PsKey *key)
-{
-	uint32_t	h = fnv(key, sizeof(*key)) ^ (timeline * 40503u);
-	ForkEnt   **pp = &fork_idx[h & IDX_MASK];
-
-	while (*pp)
-	{
-		if ((*pp)->timeline == timeline && key_eq(&(*pp)->key, key))
-		{
-			ForkEnt    *dead = *pp;
-
-			*pp = dead->next;
-			free(dead);
-			return;
-		}
-		pp = &(*pp)->next;
-	}
-}
-
-/* --- timeline metadata + read-through --- */
-
-static void
-timeline_define(uint32_t id, int parent, uint64_t branch_lsn)
-{
-	if (id >= MAX_TIMELINES)
-		return;
-	timelines[id].defined = 1;
-	timelines[id].parent = parent;
-	timelines[id].branch_lsn = branch_lsn;
-}
-
-static int
-timeline_has_parent(uint32_t timeline)
-{
-	return timeline < MAX_TIMELINES && timelines[timeline].defined &&
-		timelines[timeline].parent >= 0;
-}
-
-/*
- * Validate a branch-creation request before it is recorded.  read_through() and
- * the fork-size / per-page WAL ancestry walks follow the parent chain assuming
- * it is finite and well formed, so a bad CREATE_BRANCH must be rejected rather
- * than persisted.  Refuse:
- *	- a new id that is out of range, the root (0), or already defined (otherwise
- *	  re-creating an id silently rewrites an existing branch's ancestry);
- *	- a parent that is out of range or not yet defined (the requested parent must
- *	  actually exist, else the branch silently inherits from nothing);
- *	- a parent whose ancestry already reaches the new id, which would turn the
- *	  parent walk into an infinite loop (e.g. new == parent, or A->B->A).
- * Returns 1 if (new_tl, parent) is safe to define.
- */
-static int
-branch_request_ok(uint32_t new_tl, int parent)
-{
-	if (new_tl == 0 || new_tl >= MAX_TIMELINES || timelines[new_tl].defined)
-		return 0;
-	if (parent < 0 || parent >= MAX_TIMELINES || !timelines[parent].defined)
-		return 0;
-	for (int t = parent; t >= 0 && t < MAX_TIMELINES; t = timelines[t].parent)
-	{
-		if ((uint32_t) t == new_tl)
-			return 0;			/* cycle */
-		if (!timelines[t].defined)
-			return 0;			/* broken chain: refuse rather than risk a loop */
-	}
-	return 1;
-}
-
-/*
- * Resolve a read by walking the timeline ancestry: return the newest version of
- * (key, block) visible at read_lsn on 'timeline'; if the timeline never wrote
- * the page (or only after read_lsn), descend to the parent, capping read_lsn at
- * the branch LSN so the branch sees a frozen snapshot of the parent.  Returns
- * the chosen PageVer, or NULL if no ancestor has the page.
- */
-static PageVer *
-read_through(uint32_t timeline, const PsKey *key, uint32_t block,
-			 uint64_t read_lsn)
-{
-	for (;;)
-	{
-		PageEnt    *e = page_find(timeline, key, block);
-		PageVer    *v = e ? page_visible(e, read_lsn) : NULL;
-
-		if (v)
-			return v;
-		if (!timeline_has_parent(timeline))
-			return NULL;
-		if (timelines[timeline].branch_lsn < read_lsn)
-			read_lsn = timelines[timeline].branch_lsn;
-		timeline = (uint32_t) timelines[timeline].parent;
-	}
-}
-
-/*
- * Fork size visible on 'timeline': the maximum block count across the timeline
- * and all its ancestors.  A branch that has written only some blocks of a fork
- * still inherits the parent's full size (the unwritten blocks are served by
- * read_through), so we must take the max rather than the first entry found --
- * otherwise the branch would under-report the size and reads of inherited
- * blocks would look out of range.
- *
- * (Prototype limitation: nblocks is not itself versioned, so if the parent
- * *grows* a fork after the branch point the branch sees the larger size; for a
- * quiescent parent -- the usual branch case -- this is correct.)
- */
-static uint32_t
-fork_nblocks_through(uint32_t timeline, const PsKey *key)
-{
-	uint32_t	maxnb = 0;
-
-	for (;;)
-	{
-		ForkEnt    *e = fork_find(timeline, key);
-
-		if (e && e->nblocks > maxnb)
-			maxnb = e->nblocks;
-		if (!timeline_has_parent(timeline))
-			return maxnb;
-		timeline = (uint32_t) timelines[timeline].parent;
-	}
-}
-
-/* Does the fork exist on 'timeline' or any ancestor? */
-static int
-fork_exists_through(uint32_t timeline, const PsKey *key)
-{
-	for (;;)
-	{
-		if (fork_find(timeline, key))
-			return 1;
-		if (!timeline_has_parent(timeline))
-			return 0;
-		timeline = (uint32_t) timelines[timeline].parent;
-	}
-}
-
-/*
- * Timeline metadata is persisted as an append-only log of fixed records in
- * "<store>/timelines", so branches survive a daemon restart.  (The page data
- * itself is already durable in the segments.)
- */
-typedef struct TimelineRec
-{
-	uint32_t	id;
-	int32_t		parent;
-	uint64_t	branch_lsn;
-} TimelineRec;
-
-static void
-timeline_persist(uint32_t id, int parent, uint64_t branch_lsn)
-{
-	TimelineRec rec = {id, (int32_t) parent, branch_lsn};
-
-	ps_storage->meta_append(&rec, sizeof(rec));		/* best-effort */
-}
-
-static void
-load_timelines(void)
-{
-	TimelineRec rec;
-	uint64_t	off = 0;
-
-	while (ps_storage->meta_read(off, &rec, sizeof(rec)) == (int) sizeof(rec))
-	{
-		timeline_define(rec.id, rec.parent, rec.branch_lsn);
-		off += sizeof(rec);
-	}
-}
-
-/* ===================== shipped WAL log (per timeline) ================== */
-
-/*
- * Each timeline has an append-only WAL log "wal_<tl>" of self-describing
- * records [WalRecHdr | bytes].  This is the durability/transport half of WAL
- * shipping: the compute ships its WAL stream here so it is persisted by the
- * store, per timeline.  (Replaying these records to materialize pages -- redo
- * -- is a later milestone; it would reuse PostgreSQL's rmgr redo.)
- */
-#define WAL_MAGIC	0x57414c52	/* "WALR" */
-
-typedef struct WalRecHdr
-{
-	uint32_t	magic;
-	uint32_t	len;			/* WAL bytes following the header */
-	uint64_t	start_lsn;		/* LSN of the first byte */
-} WalRecHdr;
-
-/* highest end LSN (start+len) received per timeline */
-static uint64_t wal_end[MAX_TIMELINES];
-
-static int
-wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,
-		   uint32_t len)
-{
-	WalRecHdr	h;
-
-	if (tl >= MAX_TIMELINES)
-		return -1;
-
-	h.magic = WAL_MAGIC;
-	h.len = len;
-	h.start_lsn = start_lsn;
-	if (ps_storage->wal_append(tl, &h, sizeof(h), data, len) != 0)
-		return -1;
-
-	if (start_lsn + len > wal_end[tl])
-		wal_end[tl] = start_lsn + len;
-	return 0;
-}
-
-/*
- * Read up to 'len' WAL bytes starting at WAL position 'start' from a timeline's
- * log into 'out'; returns the number of bytes filled.  Bytes not covered by any
- * record are left as-is.  This is what a redo worker uses to pull WAL from the
- * store for replay.  (Single timeline for now; reading a branch's WAL across
- * its fork point is a refinement.)
- */
-static uint32_t
-wal_read(uint32_t tl, uint64_t start, uint32_t len, unsigned char *out)
-{
-	uint64_t	off = 0;
-	WalRecHdr	h;
-	uint32_t	filled = 0;
-
-	if (tl >= MAX_TIMELINES)
-		return 0;
-
-	while (ps_storage->wal_read(tl, off, &h, sizeof(h)) == (int) sizeof(h) &&
-		   h.magic == WAL_MAGIC)
-	{
-		uint64_t	rs = h.start_lsn;
-		uint64_t	re = rs + h.len;
-		uint64_t	ws = start;
-		uint64_t	we = start + len;
-		uint64_t	os = rs > ws ? rs : ws;	/* overlap start */
-		uint64_t	oe = re < we ? re : we;	/* overlap end */
-
-		if (os < oe)
-		{
-			uint64_t	src = off + sizeof(h) + (os - rs);
-			int			n = ps_storage->wal_read(tl, src, out + (os - start),
-												 (uint32_t) (oe - os));
-
-			if (n > 0)
-				filled += (uint32_t) n;
-		}
-		off += sizeof(h) + h.len;
-	}
-	return filled;
-}
-
-/* Rebuild wal_end[tl] by scanning the timeline's WAL log at startup. */
-static void
-wal_recover_one(uint32_t tl)
-{
-	uint64_t	off = 0;
-	WalRecHdr	h;
-
-	if (tl >= MAX_TIMELINES)
-		return;
-	while (ps_storage->wal_read(tl, off, &h, sizeof(h)) == (int) sizeof(h) &&
-		   h.magic == WAL_MAGIC)
-	{
-		if (h.start_lsn + h.len > wal_end[tl])
-			wal_end[tl] = h.start_lsn + h.len;
-		off += sizeof(h) + h.len;
-	}
-}
-
-/* ===================== per-page WAL index ============================== */
-
-/*
- * Maps (timeline, key, block) -> the LSNs of WAL records that modify that page,
- * in ascending order.  This is the lookup single-page materialization needs: to
- * rebuild page P as-of LSN L, take P's newest stored image and replay the WAL
- * records whose LSNs fall after it and <= L.  Populated by decoding shipped WAL
- * (next milestone); queried via PS_OP_WAL_INDEX_GET.
- *
- * In-memory only for now (rebuilt by re-decoding WAL after a restart).
- */
-typedef struct WalIdxEnt
-{
-	struct WalIdxEnt *next;
-	uint32_t	timeline;
-	PsKey		key;
-	uint32_t	block;
-	uint64_t   *lsns;			/* ascending */
-	int			n;
-	int			cap;
-} WalIdxEnt;
-
-static WalIdxEnt *walidx[IDX_BUCKETS];
-
-static void
-walidx_add(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
-{
-	uint32_t	h = page_hash(tl, key, block);
-	WalIdxEnt  *e;
-
-	for (e = walidx[h & IDX_MASK]; e; e = e->next)
-		if (e->timeline == tl && e->block == block && key_eq(&e->key, key))
-			break;
-	if (!e)
-	{
-		e = calloc(1, sizeof(*e));
-		e->timeline = tl;
-		e->key = *key;
-		e->block = block;
-		e->next = walidx[h & IDX_MASK];
-		walidx[h & IDX_MASK] = e;
-	}
-	if (e->n == e->cap)
-	{
-		e->cap = e->cap ? e->cap * 2 : 4;
-		e->lsns = realloc(e->lsns, (size_t) e->cap * sizeof(uint64_t));
-	}
-	/* keep ascending; WAL is appended in LSN order, so usually just append */
-	if (e->n == 0 || lsn >= e->lsns[e->n - 1])
-		e->lsns[e->n++] = lsn;
-	else
-	{
-		int			i = e->n;
-
-		while (i > 0 && e->lsns[i - 1] > lsn)
-		{
-			e->lsns[i] = e->lsns[i - 1];
-			i--;
-		}
-		e->lsns[i] = lsn;
-		e->n++;
-	}
-}
-
-/* Copy the record LSNs for (tl,key,block) that are <= lsn_max into out (cap
- * max_out); return how many.  Walks the timeline ancestry. */
-static int
-walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
-		   uint64_t *out, int max_out)
-{
-	int			got = 0;
-
-	for (;;)
-	{
-		uint32_t	h = page_hash(tl, key, block);
-		WalIdxEnt  *e;
-
-		for (e = walidx[h & IDX_MASK]; e; e = e->next)
-			if (e->timeline == tl && e->block == block && key_eq(&e->key, key))
-			{
-				for (int i = 0; i < e->n && got < max_out; i++)
-					if (e->lsns[i] <= lsn_max)
-						out[got++] = e->lsns[i];
-				break;
-			}
-		if (!timeline_has_parent(tl))
-			break;
-		if (timelines[tl].branch_lsn < lsn_max)
-			lsn_max = timelines[tl].branch_lsn;
-		tl = (uint32_t) timelines[tl].parent;
-	}
-	return got;
-}
-
-/* ===================== write / read primitives ========================= */
-
-/* The page's own pd_lsn lives in its first 8 bytes (xlogid, xrecoff). */
-static uint64_t
-page_lsn(const unsigned char *page)
-{
-	uint32_t	xlogid,
-				xrecoff;
-
-	memcpy(&xlogid, page, 4);
-	memcpy(&xrecoff, page + 4, 4);
-	return ((uint64_t) xlogid << 32) | xrecoff;
-}
-
-/*
- * Append one page version at the log head and record it in the index.  Because
- * every write lands at the moving append cursor, physical writes are large and
- * sequential even though each logical page is small -- the property we want for
- * NVMe/SPDK and network transports.
- */
-static int
-append_page(uint32_t timeline, const PsKey *key, uint32_t block,
-			const unsigned char *page)
-{
-	SegRecHdr	hdr;
-	uint64_t	reclen = sizeof(SegRecHdr) + page_size;
-	uint64_t	data_off;
-
-	/* roll over to a fresh segment when the current one would overflow */
-	if (cur_seg < 0 || cur_off + reclen > segment_size)
-	{
-		cur_seg = (cur_seg < 0) ? 0 : cur_seg + 1;
-		cur_off = 0;
-	}
-
-	hdr.magic = SEG_MAGIC;
-	hdr.timeline = timeline;
-	hdr.key = *key;
-	hdr.block = block;
-	hdr.lsn = page_lsn(page);	/* version key taken from the page itself */
-	hdr.len = page_size;
-
-	/* write header then page bytes contiguously at the append cursor */
-	if (ps_storage->seg_write(cur_seg, cur_off, &hdr, sizeof(hdr)) != 0)
-		return -1;
-	data_off = cur_off + sizeof(hdr);
-	if (ps_storage->seg_write(cur_seg, data_off, page, page_size) != 0)
-		return -1;
-
-	/* index points at the page bytes (data_off), so reads skip the header */
-	page_add_version(timeline, key, block, hdr.lsn, cur_seg, data_off);
-	cur_off += reclen;
-	return 0;
-}
-
-/* Read a specific version's page bytes into out (page_size bytes). */
-static int
-read_version(const PageVer *v, unsigned char *out)
-{
-	if (ps_storage->seg_read(v->seg, v->off, out, page_size) != 0)
-		return -1;
-	return 0;
-}
-
-/* ===================== recovery (rebuild index from segments) ========== */
-
-/*
- * Rebuild the entire in-memory index at startup by replaying the segments in
- * order.  Each record is self-describing, so replaying append_page's effect
- * (page_add_version + fork_grow) for every record reconstructs both indexes and
- * leaves the append cursor positioned just past the last valid record.
- *
- * Caveat (prototype): TRUNCATE and UNLINK are not logged as records, so their
- * effects are not reproduced on restart.  Also a partial/torn trailing record
- * is simply treated as end-of-log (the magic/len check below stops the scan).
- */
-static void
-recover(void)
-{
-	for (int id = 0;; id++)
-	{
-		uint64_t	off = 0;
-
-		if (ps_storage->seg_size(id) < 0)
-			break;				/* no more segments -> done */
-
-		/* replay records until one fails to validate (end of log) */
-		for (;;)
-		{
-			SegRecHdr	hdr;
-
-			if (ps_storage->seg_read(id, off, &hdr, sizeof(hdr)) != 0 ||
-				hdr.magic != SEG_MAGIC || hdr.len != page_size)
-				break;
-
-			page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn, id,
-							 off + sizeof(hdr));
-			fork_grow(hdr.timeline, &hdr.key, hdr.block + 1);
-			off += sizeof(hdr) + hdr.len;
-		}
-
-		/* this segment is the newest seen so far; append continues after it */
-		cur_seg = id;
-		cur_off = off;
-	}
-	if (cur_seg >= 0)
-		fprintf(stderr, "pagestore_daemon: recovered through segment %d (off %llu)\n",
-				cur_seg, (unsigned long long) cur_off);
-}
-
-/* ===================== request handling ================================ */
-
 static void
 handle_request(PsChannel *ch)
 {
@@ -774,38 +52,16 @@ handle_request(PsChannel *ch)
 	ch->status = PS_STATUS_OK;
 	ch->result = 0;
 
+	if (ps_handle_meta(ch))
+		return;
+
 	switch ((PsOpcode) ch->opcode)
 	{
-		case PS_OP_CREATE:
-			fork_get_or_create(tl, &ch->key);
-			break;
-
-		case PS_OP_EXISTS:
-			ch->result = fork_exists_through(tl, &ch->key) ? 1 : 0;
-			break;
-
-		case PS_OP_UNLINK:
-			fork_remove(tl, &ch->key);
-			break;
-
-		case PS_OP_NBLOCKS:
-			ch->result = fork_nblocks_through(tl, &ch->key);
-			break;
-
-		case PS_OP_TRUNCATE:
-			fork_get_or_create(tl, &ch->key)->nblocks = ch->nblocks;
-			break;
-
 		case PS_OP_EXTEND:
 			if (append_page(tl, &ch->key, ch->blocknum, ch->data) != 0)
 				ch->status = PS_STATUS_ERROR;
 			else
 				fork_grow(tl, &ch->key, ch->blocknum + 1);
-			break;
-
-		case PS_OP_ZEROEXTEND:
-			/* allocation only: grow size, no page data stored (reads -> 0) */
-			fork_grow(tl, &ch->key, ch->blocknum + ch->nblocks);
 			break;
 
 		case PS_OP_WRITEV:
@@ -846,51 +102,6 @@ handle_request(PsChannel *ch)
 				break;
 			}
 
-		case PS_OP_CREATE_BRANCH:
-			/*
-			 * Instant clone: just record metadata.  Timeline ch->timeline forks
-			 * from ch->parent_timeline at LSN ch->req_lsn.  No page data is
-			 * copied -- the branch shares the parent's pages by read-through
-			 * until it writes (copy-on-write).
-			 */
-			if (branch_request_ok(ch->timeline, (int) ch->parent_timeline))
-			{
-				timeline_define(ch->timeline, (int) ch->parent_timeline,
-								ch->req_lsn);
-				timeline_persist(ch->timeline, (int) ch->parent_timeline,
-								 ch->req_lsn);
-			}
-			else
-				ch->status = PS_STATUS_ERROR;
-			break;
-
-		case PS_OP_WAL_APPEND:
-			if (wal_append(tl, ch->req_lsn, ch->data, ch->datalen) != 0)
-				ch->status = PS_STATUS_ERROR;
-			break;
-
-		case PS_OP_WAL_SIZE:
-			ch->req_lsn = wal_end[tl];	/* output: end LSN of this timeline's WAL */
-			break;
-
-		case PS_OP_WAL_READ:
-			ch->result = wal_read(tl, ch->req_lsn, ch->datalen, ch->data);
-			break;
-
-		case PS_OP_WAL_INDEX_ADD:
-			walidx_add(tl, &ch->key, ch->blocknum, ch->req_lsn);
-			break;
-
-		case PS_OP_WAL_INDEX_GET:
-			ch->result = (uint32_t) walidx_get(tl, &ch->key, ch->blocknum,
-											   ch->req_lsn, (uint64_t *) ch->data,
-											   (int) (PS_IO_UNIT / sizeof(uint64_t)));
-			break;
-
-		case PS_OP_IMMEDSYNC:
-			ps_storage->sync();
-			break;
-
 		default:
 			ch->status = PS_STATUS_ERROR;
 			break;
@@ -904,6 +115,8 @@ main(int argc, char **argv)
 	void	   *shm;
 	PsShmHeader *hdr;
 	struct sigaction sa;
+	const char *store_dir = NULL;
+	const char *shm_name = NULL;
 
 	for (int i = 1; i < argc; i++)
 	{
@@ -947,21 +160,11 @@ main(int argc, char **argv)
 		return 2;
 	}
 
-	if (ps_storage->open(store_dir, segment_size) != 0)
+	if (ps_core_open(store_dir) != 0)
 	{
 		perror("storage open");
 		return 1;
 	}
-
-	/* timeline 0 is the root; load any persisted branches, then replay data */
-	timeline_define(0, -1, 0);
-	load_timelines();
-	recover();
-
-	/* rebuild each timeline's shipped-WAL end LSN from its log */
-	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
-		if (tl == 0 || timelines[tl].defined)
-			wal_recover_one(tl);
 
 	fd = shm_open(shm_name, O_CREAT | O_RDWR, 0600);
 	if (fd < 0)

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -1,0 +1,77 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_daemon_spdk.c
+ *	  SPDK frontend for the page-store daemon (optional, higher performance).
+ *
+ * Reuses the shared brain pagestore_core.c verbatim; this file supplies the
+ * SPDK-specific bring-up and (in S1.2c) an asynchronous request loop.  SPDK is
+ * used in *library mode*: we own the main loop and call spdk_thread_poll() to
+ * drive completions, rather than handing the loop to spdk_app_start().  The
+ * portable POSIX daemon (pagestore_daemon.c) is unaffected and remains the
+ * default; this binary is built separately (spdk_build.sh) and links SPDK.
+ *
+ * Status: S1.2b -- brings up the SPDK environment and the control disk through
+ * the PsStorage interface and reports readiness.  The shared-memory channel
+ * loop with asynchronous spdk_nvme I/O is S1.2c.
+ *
+ * Usage: pagestore_daemon_spdk --pci 0000:06:00.0
+ *                              [--page-size N] [--segment-size N]
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pagestore_ipc.h"
+#include "pagestore_core.h"
+
+int
+main(int argc, char **argv)
+{
+	const char *pci_addr = NULL;
+
+	ps_storage = &PsStorageSpdk;
+
+	for (int i = 1; i < argc; i++)
+	{
+		if (strcmp(argv[i], "--pci") == 0 && i + 1 < argc)
+			pci_addr = argv[++i];
+		else if (strcmp(argv[i], "--page-size") == 0 && i + 1 < argc)
+			page_size = (uint32_t) strtoul(argv[++i], NULL, 10);
+		else if (strcmp(argv[i], "--segment-size") == 0 && i + 1 < argc)
+			segment_size = strtoull(argv[++i], NULL, 10);
+		else
+		{
+			fprintf(stderr, "usage: %s --pci ADDR "
+					"[--page-size N] [--segment-size N]\n", argv[0]);
+			return 2;
+		}
+	}
+	if (!pci_addr || page_size == 0 || page_size > PS_IO_UNIT)
+	{
+		fprintf(stderr, "usage: %s --pci ADDR "
+				"[--page-size N] [--segment-size N]\n", argv[0]);
+		return 2;
+	}
+
+	/* open the control disk via SPDK and rebuild in-memory state */
+	if (ps_core_open(pci_addr) != 0)
+	{
+		fprintf(stderr, "pagestore_daemon_spdk: bring-up failed\n");
+		return 1;
+	}
+
+	fprintf(stderr, "pagestore_daemon_spdk: storage=%s page_size=%u ready "
+			"(channel loop + async I/O: S1.2c)\n", ps_storage->name, page_size);
+
+	/*
+	 * S1.2c: shm_open the channel region, then loop polling channels and
+	 * spdk_thread_poll(); serve metadata via ps_handle_meta and the four
+	 * byte-I/O ops via asynchronous spdk_nvme reads/writes with per-channel
+	 * in-flight tracking.  For now bring-up is the deliverable.
+	 */
+	ps_storage->close();
+	return 0;
+}

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -4,18 +4,18 @@
  *	  SPDK frontend for the page-store daemon (optional, higher performance).
  *
  * Reuses the shared brain pagestore_core.c verbatim; this file supplies the
- * SPDK-specific bring-up and the request loop.  SPDK is used in *library mode*:
- * we own the loop, and the SPDK storage backend's byte ops poll the NVMe qpair
- * to completion internally (S1.2c-1).  Pipelining many requests in flight across
- * channels is S1.2c-2.  The portable POSIX daemon is unaffected and remains the
+ * SPDK-specific bring-up and an *asynchronous, cross-channel* request loop.
+ * SPDK is used in library mode (we own the loop).  The loop scans the channels
+ * and begins each ready request without blocking: metadata and (buffered) write
+ * ops complete synchronously, while read ops submit their page reads to the NVMe
+ * queue and the channel's reply is published from the read completions.  So many
+ * requests are in flight at once -- effective queue depth is no longer one
+ * request's worth.  The portable POSIX daemon is unaffected and remains the
  * default; this binary is built separately (spdk_build.sh) and links SPDK.
  *
- * Argument-compatible with pagestore_daemon (so the standalone test harness can
- * drive it): --shm/--store/--page-size/--segment-size.  The control disk's PCI
- * address is taken from --pci or $PS_SPDK_PCI (so the test, which only passes
- * the common args, can set it via the environment).  --store is the dir for the
- * spdk_super file and the delegated WAL/timeline metadata; page segments live on
- * the NVMe device.
+ * Argument-compatible with pagestore_daemon so the standalone test harness can
+ * drive it: --shm/--store/--page-size/--segment-size; the control disk's PCI
+ * address is --pci or $PS_SPDK_PCI.
  *
  *-------------------------------------------------------------------------
  */
@@ -33,6 +33,9 @@
 #include "pagestore_core.h"
 #include "storage_spdk.h"
 
+/* most page reads a single request can carry (nblocks * page_size <= io_unit) */
+#define MAX_BLOCKS	128
+
 static volatile sig_atomic_t stop_requested = 0;
 
 static void
@@ -42,12 +45,39 @@ on_signal(int sig)
 	stop_requested = 1;
 }
 
+/* per-channel in-flight read request */
+typedef struct ReqState
+{
+	PsChannel  *ch;
+	int			active;			/* a read request is in flight on this channel */
+	int			pending;		/* page reads not yet completed */
+} ReqState;
+
+static ReqState reqstate[PS_MAX_CHANNELS];
+
+/* one page read finished; when the last of a request lands, publish the reply */
+static void
+read_done(void *arg, int ok)
+{
+	ReqState   *rs = arg;
+
+	(void) ok;					/* the engine already delivered/zeroed the page */
+	if (--rs->pending == 0)
+	{
+		rs->active = 0;			/* clear before publishing DONE */
+		ps_store_release(&rs->ch->state, PS_STATE_DONE);
+	}
+}
+
 /*
- * Serve one request.  Metadata ops go to the shared brain; the four byte-I/O
- * ops use the SPDK storage backend (which polls NVMe completions internally).
+ * Begin serving the request on channel 'i'.  Synchronous ops (metadata, buffered
+ * writes) finish and publish DONE here; read ops submit their page reads and
+ * return, leaving DONE to read_done().  Index pointers from read_through() are
+ * dereferenced (seg/off taken) synchronously here, never held across the async
+ * wait, so a concurrent write reallocating a version array cannot dangle them.
  */
 static void
-handle_request(PsChannel *ch)
+begin(uint32_t i, PsChannel *ch)
 {
 	uint32_t	tl = ch->timeline;
 
@@ -55,7 +85,10 @@ handle_request(PsChannel *ch)
 	ch->result = 0;
 
 	if (ps_handle_meta(ch))
+	{
+		ps_store_release(&ch->state, PS_STATE_DONE);
 		return;
+	}
 
 	switch ((PsOpcode) ch->opcode)
 	{
@@ -64,13 +97,14 @@ handle_request(PsChannel *ch)
 				ch->status = PS_STATUS_ERROR;
 			else
 				fork_grow(tl, &ch->key, ch->blocknum + 1);
-			break;
+			ps_store_release(&ch->state, PS_STATE_DONE);
+			return;
 
 		case PS_OP_WRITEV:
-			for (uint32_t i = 0; i < ch->nblocks; i++)
+			for (uint32_t b = 0; b < ch->nblocks; b++)
 			{
-				if (append_page(tl, &ch->key, ch->blocknum + i,
-								 ch->data + (size_t) i * page_size) != 0)
+				if (append_page(tl, &ch->key, ch->blocknum + b,
+								 ch->data + (size_t) b * page_size) != 0)
 				{
 					ch->status = PS_STATUS_ERROR;
 					break;
@@ -78,61 +112,74 @@ handle_request(PsChannel *ch)
 			}
 			if (ch->status == PS_STATUS_OK)
 				fork_grow(tl, &ch->key, ch->blocknum + ch->nblocks);
-			break;
+			ps_store_release(&ch->state, PS_STATE_DONE);
+			return;
 
 		case PS_OP_READV:
 			{
-				/* batch up to 64 page reads at a time so the device reads
-				 * overlap on the NVMe queue (see ps_spdk_readv) */
-				PsSpdkRead	reqs[64];
-				uint32_t	i = 0;
+				PageVer    *locs[MAX_BLOCKS];
+				uint32_t	nb = ch->nblocks;
+				ReqState   *rs = &reqstate[i];
 
-				while (i < ch->nblocks)
+				if (nb > MAX_BLOCKS || (uint64_t) nb * page_size > PS_IO_UNIT)
 				{
-					int			nr = 0;
-
-					while (i < ch->nblocks && nr < 64)
-					{
-						unsigned char *dst = ch->data + (size_t) i * page_size;
-						PageVer    *v = read_through(tl, &ch->key,
-													 ch->blocknum + i, UINT64_MAX);
-
-						if (!v)
-							memset(dst, 0, page_size);	/* unwritten -> zeros */
-						else
-						{
-							reqs[nr].seg = v->seg;
-							reqs[nr].off = v->off;
-							reqs[nr].dst = dst;
-							reqs[nr].len = page_size;
-							nr++;
-						}
-						i++;
-					}
-					ps_spdk_readv(reqs, nr);
+					ch->status = PS_STATUS_ERROR;
+					ps_store_release(&ch->state, PS_STATE_DONE);
+					return;
 				}
-				break;
+				rs->ch = ch;
+				rs->pending = 0;
+				for (uint32_t b = 0; b < nb; b++)
+				{
+					locs[b] = read_through(tl, &ch->key, ch->blocknum + b,
+										   UINT64_MAX);
+					if (locs[b])
+						rs->pending++;
+				}
+				if (rs->pending == 0)	/* all unwritten -> zeros */
+				{
+					memset(ch->data, 0, (size_t) nb * page_size);
+					ps_store_release(&ch->state, PS_STATE_DONE);
+					return;
+				}
+				rs->active = 1;
+				for (uint32_t b = 0; b < nb; b++)
+				{
+					unsigned char *dst = ch->data + (size_t) b * page_size;
+
+					if (!locs[b])
+						memset(dst, 0, page_size);
+					else
+						ps_spdk_read_async(locs[b]->seg, locs[b]->off, dst,
+										   page_size, read_done, rs);
+				}
+				return;			/* DONE published by read_done */
 			}
 
 		case PS_OP_READ_AT:
 			{
 				PageVer    *v = read_through(tl, &ch->key, ch->blocknum,
 											 ch->req_lsn);
+				ReqState   *rs = &reqstate[i];
 
 				if (!v)
-					memset(ch->data, 0, page_size);
-				else
 				{
-					PsSpdkRead	r = {v->seg, v->off, ch->data, page_size};
-
-					ps_spdk_readv(&r, 1);
+					memset(ch->data, 0, page_size);
+					ps_store_release(&ch->state, PS_STATE_DONE);
+					return;
 				}
-				break;
+				rs->ch = ch;
+				rs->pending = 1;
+				rs->active = 1;
+				ps_spdk_read_async(v->seg, v->off, ch->data, page_size,
+								   read_done, rs);
+				return;
 			}
 
 		default:
 			ch->status = PS_STATUS_ERROR;
-			break;
+			ps_store_release(&ch->state, PS_STATE_DONE);
+			return;
 	}
 }
 
@@ -174,7 +221,6 @@ main(int argc, char **argv)
 				"[--page-size N] [--segment-size N]\n", argv[0]);
 		return 2;
 	}
-	/* the PCI address reaches the storage backend through $PS_SPDK_PCI */
 	if (pci_addr)
 		setenv("PS_SPDK_PCI", pci_addr, 1);
 
@@ -223,23 +269,31 @@ main(int argc, char **argv)
 			shm_name, store_dir, ps_storage->name, page_size, PS_IO_UNIT,
 			PS_MAX_CHANNELS);
 
+	/*
+	 * Cross-channel async loop: start every ready request that is not already in
+	 * flight, then drive NVMe completions.  Read requests stay "active" until
+	 * their completions publish DONE, so many overlap on the queue.
+	 */
 	while (!stop_requested)
 	{
-		int			did_work = 0;
+		int			work = 0;
 
 		for (uint32_t i = 0; i < PS_MAX_CHANNELS; i++)
 		{
 			PsChannel  *ch = ps_channel(shm, i);
 
-			if (ps_load_acquire(&ch->state) != PS_STATE_REQUEST)
-				continue;
-
-			handle_request(ch);
-			ps_store_release(&ch->state, PS_STATE_DONE);
-			did_work = 1;
+			if (!reqstate[i].active &&
+				ps_load_acquire(&ch->state) == PS_STATE_REQUEST)
+			{
+				begin(i, ch);
+				work = 1;
+			}
 		}
 
-		if (!did_work)
+		if (ps_spdk_poll() > 0)
+			work = 1;
+
+		if (!work)
 		{
 			struct timespec ts = {0, 20000};	/* 20us */
 

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -31,6 +31,7 @@
 
 #include "pagestore_ipc.h"
 #include "pagestore_core.h"
+#include "storage_spdk.h"
 
 static volatile sig_atomic_t stop_requested = 0;
 
@@ -80,24 +81,52 @@ handle_request(PsChannel *ch)
 			break;
 
 		case PS_OP_READV:
-			for (uint32_t i = 0; i < ch->nblocks; i++)
 			{
-				unsigned char *dst = ch->data + (size_t) i * page_size;
-				PageVer    *v = read_through(tl, &ch->key, ch->blocknum + i,
-											 UINT64_MAX);
+				/* batch up to 64 page reads at a time so the device reads
+				 * overlap on the NVMe queue (see ps_spdk_readv) */
+				PsSpdkRead	reqs[64];
+				uint32_t	i = 0;
 
-				if (!v || read_version(v, dst) != 0)
-					memset(dst, 0, page_size);
+				while (i < ch->nblocks)
+				{
+					int			nr = 0;
+
+					while (i < ch->nblocks && nr < 64)
+					{
+						unsigned char *dst = ch->data + (size_t) i * page_size;
+						PageVer    *v = read_through(tl, &ch->key,
+													 ch->blocknum + i, UINT64_MAX);
+
+						if (!v)
+							memset(dst, 0, page_size);	/* unwritten -> zeros */
+						else
+						{
+							reqs[nr].seg = v->seg;
+							reqs[nr].off = v->off;
+							reqs[nr].dst = dst;
+							reqs[nr].len = page_size;
+							nr++;
+						}
+						i++;
+					}
+					ps_spdk_readv(reqs, nr);
+				}
+				break;
 			}
-			break;
 
 		case PS_OP_READ_AT:
 			{
 				PageVer    *v = read_through(tl, &ch->key, ch->blocknum,
 											 ch->req_lsn);
 
-				if (!v || read_version(v, ch->data) != 0)
+				if (!v)
 					memset(ch->data, 0, page_size);
+				else
+				{
+					PsSpdkRead	r = {v->seg, v->off, ch->data, page_size};
+
+					ps_spdk_readv(&r, 1);
+				}
 				break;
 			}
 

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -4,39 +4,129 @@
  *	  SPDK frontend for the page-store daemon (optional, higher performance).
  *
  * Reuses the shared brain pagestore_core.c verbatim; this file supplies the
- * SPDK-specific bring-up and (in S1.2c) an asynchronous request loop.  SPDK is
- * used in *library mode*: we own the main loop and call spdk_thread_poll() to
- * drive completions, rather than handing the loop to spdk_app_start().  The
- * portable POSIX daemon (pagestore_daemon.c) is unaffected and remains the
+ * SPDK-specific bring-up and the request loop.  SPDK is used in *library mode*:
+ * we own the loop, and the SPDK storage backend's byte ops poll the NVMe qpair
+ * to completion internally (S1.2c-1).  Pipelining many requests in flight across
+ * channels is S1.2c-2.  The portable POSIX daemon is unaffected and remains the
  * default; this binary is built separately (spdk_build.sh) and links SPDK.
  *
- * Status: S1.2b -- brings up the SPDK environment and the control disk through
- * the PsStorage interface and reports readiness.  The shared-memory channel
- * loop with asynchronous spdk_nvme I/O is S1.2c.
- *
- * Usage: pagestore_daemon_spdk --pci 0000:06:00.0
- *                              [--page-size N] [--segment-size N]
+ * Argument-compatible with pagestore_daemon (so the standalone test harness can
+ * drive it): --shm/--store/--page-size/--segment-size.  The control disk's PCI
+ * address is taken from --pci or $PS_SPDK_PCI (so the test, which only passes
+ * the common args, can set it via the environment).  --store is the dir for the
+ * spdk_super file and the delegated WAL/timeline metadata; page segments live on
+ * the NVMe device.
  *
  *-------------------------------------------------------------------------
  */
+#include <fcntl.h>
+#include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
 
 #include "pagestore_ipc.h"
 #include "pagestore_core.h"
 
+static volatile sig_atomic_t stop_requested = 0;
+
+static void
+on_signal(int sig)
+{
+	(void) sig;
+	stop_requested = 1;
+}
+
+/*
+ * Serve one request.  Metadata ops go to the shared brain; the four byte-I/O
+ * ops use the SPDK storage backend (which polls NVMe completions internally).
+ */
+static void
+handle_request(PsChannel *ch)
+{
+	uint32_t	tl = ch->timeline;
+
+	ch->status = PS_STATUS_OK;
+	ch->result = 0;
+
+	if (ps_handle_meta(ch))
+		return;
+
+	switch ((PsOpcode) ch->opcode)
+	{
+		case PS_OP_EXTEND:
+			if (append_page(tl, &ch->key, ch->blocknum, ch->data) != 0)
+				ch->status = PS_STATUS_ERROR;
+			else
+				fork_grow(tl, &ch->key, ch->blocknum + 1);
+			break;
+
+		case PS_OP_WRITEV:
+			for (uint32_t i = 0; i < ch->nblocks; i++)
+			{
+				if (append_page(tl, &ch->key, ch->blocknum + i,
+								 ch->data + (size_t) i * page_size) != 0)
+				{
+					ch->status = PS_STATUS_ERROR;
+					break;
+				}
+			}
+			if (ch->status == PS_STATUS_OK)
+				fork_grow(tl, &ch->key, ch->blocknum + ch->nblocks);
+			break;
+
+		case PS_OP_READV:
+			for (uint32_t i = 0; i < ch->nblocks; i++)
+			{
+				unsigned char *dst = ch->data + (size_t) i * page_size;
+				PageVer    *v = read_through(tl, &ch->key, ch->blocknum + i,
+											 UINT64_MAX);
+
+				if (!v || read_version(v, dst) != 0)
+					memset(dst, 0, page_size);
+			}
+			break;
+
+		case PS_OP_READ_AT:
+			{
+				PageVer    *v = read_through(tl, &ch->key, ch->blocknum,
+											 ch->req_lsn);
+
+				if (!v || read_version(v, ch->data) != 0)
+					memset(ch->data, 0, page_size);
+				break;
+			}
+
+		default:
+			ch->status = PS_STATUS_ERROR;
+			break;
+	}
+}
+
 int
 main(int argc, char **argv)
 {
+	int			fd;
+	void	   *shm;
+	PsShmHeader *hdr;
+	struct sigaction sa;
+	const char *store_dir = NULL;
+	const char *shm_name = NULL;
 	const char *pci_addr = NULL;
 
 	ps_storage = &PsStorageSpdk;
 
 	for (int i = 1; i < argc; i++)
 	{
-		if (strcmp(argv[i], "--pci") == 0 && i + 1 < argc)
+		if (strcmp(argv[i], "--shm") == 0 && i + 1 < argc)
+			shm_name = argv[++i];
+		else if (strcmp(argv[i], "--store") == 0 && i + 1 < argc)
+			store_dir = argv[++i];
+		else if (strcmp(argv[i], "--pci") == 0 && i + 1 < argc)
 			pci_addr = argv[++i];
 		else if (strcmp(argv[i], "--page-size") == 0 && i + 1 < argc)
 			page_size = (uint32_t) strtoul(argv[++i], NULL, 10);
@@ -44,34 +134,92 @@ main(int argc, char **argv)
 			segment_size = strtoull(argv[++i], NULL, 10);
 		else
 		{
-			fprintf(stderr, "usage: %s --pci ADDR "
+			fprintf(stderr, "usage: %s --shm NAME --store DIR --pci ADDR "
 					"[--page-size N] [--segment-size N]\n", argv[0]);
 			return 2;
 		}
 	}
-	if (!pci_addr || page_size == 0 || page_size > PS_IO_UNIT)
+	if (!shm_name || !store_dir || page_size == 0 || page_size > PS_IO_UNIT)
 	{
-		fprintf(stderr, "usage: %s --pci ADDR "
+		fprintf(stderr, "usage: %s --shm NAME --store DIR --pci ADDR "
 				"[--page-size N] [--segment-size N]\n", argv[0]);
 		return 2;
 	}
+	/* the PCI address reaches the storage backend through $PS_SPDK_PCI */
+	if (pci_addr)
+		setenv("PS_SPDK_PCI", pci_addr, 1);
 
-	/* open the control disk via SPDK and rebuild in-memory state */
-	if (ps_core_open(pci_addr) != 0)
+	if (ps_core_open(store_dir) != 0)
 	{
 		fprintf(stderr, "pagestore_daemon_spdk: bring-up failed\n");
 		return 1;
 	}
 
-	fprintf(stderr, "pagestore_daemon_spdk: storage=%s page_size=%u ready "
-			"(channel loop + async I/O: S1.2c)\n", ps_storage->name, page_size);
+	fd = shm_open(shm_name, O_CREAT | O_RDWR, 0600);
+	if (fd < 0)
+	{
+		perror("shm_open");
+		return 1;
+	}
+	if (ftruncate(fd, PS_SHM_SIZE) != 0)
+	{
+		perror("ftruncate shm");
+		return 1;
+	}
+	shm = mmap(NULL, PS_SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (shm == MAP_FAILED)
+	{
+		perror("mmap");
+		return 1;
+	}
+	close(fd);
 
-	/*
-	 * S1.2c: shm_open the channel region, then loop polling channels and
-	 * spdk_thread_poll(); serve metadata via ps_handle_meta and the four
-	 * byte-I/O ops via asynchronous spdk_nvme reads/writes with per-channel
-	 * in-flight tracking.  For now bring-up is the deliverable.
-	 */
+	hdr = (PsShmHeader *) shm;
+	memset(shm, 0, PS_SHM_SIZE);
+	hdr->magic = PS_SHM_MAGIC;
+	hdr->version = PS_SHM_VERSION;
+	hdr->page_size = page_size;
+	hdr->io_unit = PS_IO_UNIT;
+	hdr->nchannels = PS_MAX_CHANNELS;
+	hdr->channel_stride = PS_CHANNEL_STRIDE;
+	hdr->channels_off = PS_CHANNELS_OFF;
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = on_signal;
+	sigaction(SIGINT, &sa, NULL);
+	sigaction(SIGTERM, &sa, NULL);
+
+	fprintf(stderr, "pagestore_daemon_spdk: shm=%s store=%s storage=%s "
+			"page_size=%u io_unit=%u channels=%d ready\n",
+			shm_name, store_dir, ps_storage->name, page_size, PS_IO_UNIT,
+			PS_MAX_CHANNELS);
+
+	while (!stop_requested)
+	{
+		int			did_work = 0;
+
+		for (uint32_t i = 0; i < PS_MAX_CHANNELS; i++)
+		{
+			PsChannel  *ch = ps_channel(shm, i);
+
+			if (ps_load_acquire(&ch->state) != PS_STATE_REQUEST)
+				continue;
+
+			handle_request(ch);
+			ps_store_release(&ch->state, PS_STATE_DONE);
+			did_work = 1;
+		}
+
+		if (!did_work)
+		{
+			struct timespec ts = {0, 20000};	/* 20us */
+
+			nanosleep(&ts, NULL);
+		}
+	}
+
+	fprintf(stderr, "pagestore_daemon_spdk: shutting down\n");
 	ps_storage->close();
+	munmap(shm, PS_SHM_SIZE);
 	return 0;
 }

--- a/contrib/pagestore/pagestore_storage.h
+++ b/contrib/pagestore/pagestore_storage.h
@@ -1,0 +1,74 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_storage.h
+ *	  Byte-log storage abstraction for the page-store daemon.
+ *
+ * The daemon's indexes, append cursor, timeline metadata and request handling
+ * are all storage-agnostic in-memory logic; only raw byte movement and
+ * enumeration go through this interface.  Making the storage layer pluggable
+ * lets a portable POSIX backend (the default -- libc only, runs anywhere) and
+ * an optional, higher-performance SPDK backend coexist behind one interface,
+ * WITHOUT changing the IPC ABI: a machine that cannot run SPDK simply uses the
+ * POSIX backend, transparently to the compute side.
+ *
+ * The store is three append-only logs:
+ *	 - segments: page-version records, addressed by (segment id, byte offset);
+ *	 - per-timeline shipped WAL, one log per timeline;
+ *	 - timeline metadata, a single log.
+ * A backend maps these onto its medium (files for POSIX; device regions or
+ * blobs for SPDK).
+ *
+ * Conventions:
+ *	 - read ops return the number of bytes read (>= 0, possibly short at EOF)
+ *	   or -1 on error;
+ *	 - write/append/sync/open ops return 0 on success or -1 on error;
+ *	 - seg_size returns a segment's byte length, or -1 if it does not exist.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PAGESTORE_STORAGE_H
+#define PAGESTORE_STORAGE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct PsStorage
+{
+	const char *name;
+
+	/* lifecycle */
+	int			(*open) (const char *path, uint64_t segment_size);
+	void		(*close) (void);
+	int			(*sync) (void);
+
+	/* segment log (page-version data); seg_write creates the segment lazily */
+	int			(*seg_write) (int seg, uint64_t off, const void *buf, uint32_t len);
+	int			(*seg_read) (int seg, uint64_t off, void *buf, uint32_t len);
+	int64_t		(*seg_size) (int seg);
+
+	/*
+	 * Per-timeline shipped-WAL log.  wal_append takes the record header (a) and
+	 * its payload (b) so the backend can land them contiguously in one append;
+	 * b may be NULL with blen 0.
+	 */
+	int			(*wal_append) (uint32_t tl, const void *a, uint32_t alen,
+							   const void *b, uint32_t blen);
+	int			(*wal_read) (uint32_t tl, uint64_t off, void *buf, uint32_t len);
+
+	/* timeline metadata log */
+	int			(*meta_append) (const void *buf, uint32_t len);
+	int			(*meta_read) (uint64_t off, void *buf, uint32_t len);
+} PsStorage;
+
+/* the active backend, selected at startup */
+extern const PsStorage *ps_storage;
+
+/* always available: portable, libc-only */
+extern const PsStorage PsStoragePosix;
+
+#ifdef PAGESTORE_SPDK
+/* optional: userspace NVMe via SPDK, compiled in only when enabled */
+extern const PsStorage PsStorageSpdk;
+#endif
+
+#endif							/* PAGESTORE_STORAGE_H */

--- a/contrib/pagestore/redo_worker_demo.sh
+++ b/contrib/pagestore/redo_worker_demo.sh
@@ -80,9 +80,10 @@ $P -c "UPDATE t SET v='changed' WHERE id=1;" >/dev/null
 # only for the backup-start segment races: the UPDATE is in a later segment that
 # may not be shipped yet (this is what intermittently failed in CI).
 updseg=$($P -c "SELECT pg_walfile_name(pg_current_wal_lsn());")
-for _ in $(seq 1 100); do
+for _ in $(seq 1 150); do
 	$P -c "SELECT pg_switch_wal();" >/dev/null 2>&1
-	[ -f "$D/pg_wal/archive_status/$updseg.done" ] && break
+	last=$($P -c "SELECT last_archived_wal FROM pg_stat_archiver;" 2>/dev/null)
+	[[ -n "$last" && ! "$last" < "$updseg" ]] && break	# archived through updseg
 	sleep 0.2
 done
 "$BIN/pg_ctl" -D "$D" -m fast -w stop >/dev/null 2>&1

--- a/contrib/pagestore/redo_worker_demo.sh
+++ b/contrib/pagestore/redo_worker_demo.sh
@@ -73,12 +73,16 @@ SELECT labelfile FROM pg_backup_stop();
 SQL
 $P -c "UPDATE t SET v='changed' WHERE id=1;" >/dev/null
 
-# the segment holding the backup start point must reach the store; wait until
-# it (and the WAL after it) is archived, since archiving is asynchronous
-startseg=$(sed -n 's/.*(file \([0-9A-F]\{24\}\)).*/\1/p' "$D/backup_label")
-for _ in $(seq 1 50); do
+# The UPDATE's WAL must reach the store before recovery, and archiving is
+# asynchronous.  Capture the segment the UPDATE landed in, force it to complete,
+# and wait until *that* segment is archived -- which implies the backup-start
+# segment and everything between are too (the archiver ships in order).  Waiting
+# only for the backup-start segment races: the UPDATE is in a later segment that
+# may not be shipped yet (this is what intermittently failed in CI).
+updseg=$($P -c "SELECT pg_walfile_name(pg_current_wal_lsn());")
+for _ in $(seq 1 100); do
 	$P -c "SELECT pg_switch_wal();" >/dev/null 2>&1
-	[ -f "$D/pg_wal/archive_status/$startseg.done" ] && break
+	[ -f "$D/pg_wal/archive_status/$updseg.done" ] && break
 	sleep 0.2
 done
 "$BIN/pg_ctl" -D "$D" -m fast -w stop >/dev/null 2>&1

--- a/contrib/pagestore/redo_worker_demo.sh
+++ b/contrib/pagestore/redo_worker_demo.sh
@@ -95,7 +95,15 @@ echo "restore_command = '$WALRESTORE --shm $SHM --timeline 0 --segsize 16777216 
 rm -f "$D"/pg_wal/0000000*	# remove local WAL: recovery must fetch from the store
 
 if "$BIN/pg_ctl" -D "$D" -l "$D/r.log" -w start >/dev/null 2>&1; then
-	val=$($P -c "SELECT v FROM t WHERE id=1;")
+	# pg_ctl -w returns once the server accepts connections, which (with hot
+	# standby) is during recovery -- so retry the read until replay has caught up
+	# to the shipped UPDATE rather than racing ahead of it.
+	val=
+	for _ in $(seq 1 100); do
+		val=$($P -c "SELECT v FROM t WHERE id=1;" 2>/dev/null)
+		[ "$val" = "changed" ] && break
+		sleep 0.2
+	done
 	if [ "$val" = "changed" ]; then
 		echo "ok   - redo worker recovered 'changed' from store-resident WAL"
 		grep -q "restored log file" "$D/r.log" && \

--- a/contrib/pagestore/spdk_build.sh
+++ b/contrib/pagestore/spdk_build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Build pagestore_daemon_spdk: the optional SPDK frontend.  It reuses the shared
+# brain (pagestore_core.c) and the SPDK storage backend (storage_spdk.c), and
+# links against a local SPDK build.  The portable POSIX daemon is built by meson
+# / the plain cc line and needs none of this.
+#
+# SPDK's static libraries must be wrapped in --whole-archive so the env and NVMe
+# driver constructors register; DPDK ships as shared libs, so we rpath them in to
+# avoid needing LD_LIBRARY_PATH at runtime.
+#
+# Usage:   contrib/pagestore/spdk_build.sh [output-path]
+# Env:     SPDK_DIR (default ~/spdk)
+#
+set -euo pipefail
+
+SPDK_DIR="${SPDK_DIR:-$HOME/spdk}"
+out="${1:-pagestore_daemon_spdk}"
+here="$(cd "$(dirname "$0")" && pwd)"
+
+if [ ! -d "$SPDK_DIR/build/lib/pkgconfig" ]; then
+	echo "SPDK build not found at $SPDK_DIR (set SPDK_DIR)."
+	echo "Build it first: see contrib/pagestore/SPDK_NOTES.md"
+	exit 1
+fi
+
+export PKG_CONFIG_PATH="$SPDK_DIR/build/lib/pkgconfig:$SPDK_DIR/dpdk/build/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+
+cflags="$(pkg-config --cflags spdk_nvme spdk_env_dpdk)"
+# SPDK libs need --whole-archive; spdk_syslibs carries the static system deps.
+spdk_libs="-Wl,--whole-archive -Wl,--no-as-needed \
+$(pkg-config --libs spdk_nvme spdk_env_dpdk) \
+-Wl,--no-whole-archive $(pkg-config --libs --static spdk_syslibs)"
+rpath="-Wl,-rpath,$SPDK_DIR/build/lib -Wl,-rpath,$SPDK_DIR/dpdk/build/lib"
+
+set -x
+cc -O2 -Wall -Wextra -DPAGESTORE_SPDK -I"$here" $cflags \
+	-o "$out" \
+	"$here/pagestore_daemon_spdk.c" "$here/pagestore_core.c" \
+	"$here/storage_spdk.c" "$here/storage_posix.c" \
+	$rpath $spdk_libs -lrt
+set +x
+echo "built $out"

--- a/contrib/pagestore/spdk_setup.sh
+++ b/contrib/pagestore/spdk_setup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# S0 bring-up: bind the dedicated control disk to SPDK and benchmark it.
+#
+# This realizes step S0 of SPDK_NOTES.md.  It reserves hugepages, binds the
+# control NVMe to vfio-pci (userspace), and runs a raw throughput baseline.
+#
+# SAFETY: PCI_ALLOWED restricts SPDK's setup.sh to the control disk ONLY, so the
+# system disk and the /home NVMe are never rebound.  Always keep CTRL_PCI correct
+# for the box you run on.
+#
+# Usage:
+#   contrib/pagestore/spdk_setup.sh            # reserve hugepages + bind + bench
+#   contrib/pagestore/spdk_setup.sh status     # show current binding
+#   contrib/pagestore/spdk_setup.sh reset      # give the disk back to the kernel
+#
+set -euo pipefail
+
+SPDK_DIR="${SPDK_DIR:-$HOME/spdk}"
+CTRL_PCI="${CTRL_PCI:-0000:06:00.0}"   # WD SN850 465.8G -- the bare control disk
+HUGEMEM="${HUGEMEM:-4096}"             # MiB of hugepages to reserve
+
+mode="${1:-up}"
+
+if [ ! -x "$SPDK_DIR/scripts/setup.sh" ]; then
+	echo "SPDK not found at $SPDK_DIR (set SPDK_DIR). Build it first:"
+	echo "  git clone --branch v26.01 https://github.com/spdk/spdk ~/spdk"
+	echo "  cd ~/spdk && git submodule update --init && ./configure && make -j"
+	exit 1
+fi
+
+case "$mode" in
+status)
+	sudo PCI_ALLOWED="$CTRL_PCI" "$SPDK_DIR/scripts/setup.sh" status
+	exit 0
+	;;
+reset)
+	# hand the control disk back to the kernel nvme driver
+	sudo PCI_ALLOWED="$CTRL_PCI" "$SPDK_DIR/scripts/setup.sh" reset
+	exit 0
+	;;
+up) ;;
+*)
+	echo "usage: $0 [up|status|reset]"; exit 2
+	;;
+esac
+
+# 0. IOMMU must be active for safe vfio-pci DMA (else SPDK uses unsafe uio).
+if [ -z "$(ls -A /sys/kernel/iommu_groups 2>/dev/null)" ]; then
+	echo "WARNING: IOMMU is not active (empty /sys/kernel/iommu_groups)."
+	echo "  Add 'intel_iommu=on iommu=pt' to the kernel cmdline and reboot for"
+	echo "  safe DMA; otherwise SPDK falls back to unsafe uio/no-IOMMU mode."
+	echo
+fi
+
+# 1. reserve hugepages + bind ONLY the control disk to vfio-pci.
+echo "=== setup: hugepages=${HUGEMEM}MiB, bind $CTRL_PCI to vfio-pci ==="
+sudo HUGEMEM="$HUGEMEM" PCI_ALLOWED="$CTRL_PCI" "$SPDK_DIR/scripts/setup.sh"
+
+# 2. confirm.
+echo "=== status ==="
+sudo PCI_ALLOWED="$CTRL_PCI" "$SPDK_DIR/scripts/setup.sh" status
+grep -i hugepages_total /proc/meminfo
+
+# 3. validate the disk under SPDK: enumerate then a 4 KiB randread baseline.
+#    (In SPDK v26.01 these tools install as build/bin/spdk_nvme_{identify,perf}.)
+echo "=== identify ==="
+sudo "$SPDK_DIR/build/bin/spdk_nvme_identify" -r "trtype:PCIe traddr:$CTRL_PCI" 2>&1 | head -40
+echo "=== perf: 4 KiB randread, qd=128, 20s (raw ceiling) ==="
+sudo "$SPDK_DIR/build/bin/spdk_nvme_perf" -q 128 -o 4096 -w randread -t 20 \
+	-r "trtype:PCIe traddr:$CTRL_PCI"
+
+echo
+echo "S0 done. To return the disk to the kernel: $0 reset"

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -1,0 +1,221 @@
+/*-------------------------------------------------------------------------
+ *
+ * storage_posix.c
+ *	  Portable, libc-only storage backend for the page-store daemon.
+ *
+ * Implements the PsStorage interface over plain files, exactly the on-disk
+ * layout the daemon used before storage was made pluggable: one append-only
+ * file per segment (seg_NNNNNNNN), one per-timeline shipped-WAL log (wal_<tl>),
+ * and a single timeline metadata log (timelines), all under the store dir.
+ *
+ * This backend has no external dependencies and is the default everywhere; the
+ * SPDK backend is an optional, higher-performance alternative behind the same
+ * interface.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "pagestore_storage.h"
+
+/* bounded well under the 4096-byte path buffers so suffixes never truncate */
+static char posix_dir[2048];
+
+/*
+ * One cached OS fd per segment id (opened lazily, never closed during a run).
+ * Only the segment log keeps fds; the WAL and metadata logs open per call,
+ * matching the original daemon (they are not on the hot path).
+ */
+static int *seg_fds;
+static int	segs_cap;
+
+static void
+seg_path(char *buf, size_t buflen, int id)
+{
+	snprintf(buf, buflen, "%s/seg_%08d", posix_dir, id);
+}
+
+/* Return a cached fd for segment 'id', opening (optionally creating) it once. */
+static int
+seg_fd(int id, int create)
+{
+	char		path[4096];
+	int			fd;
+
+	if (id < segs_cap && seg_fds[id] >= 0)
+		return seg_fds[id];
+
+	if (id >= segs_cap)
+	{
+		int			newcap = (id + 16) * 2;
+
+		seg_fds = realloc(seg_fds, (size_t) newcap * sizeof(int));
+		for (int i = segs_cap; i < newcap; i++)
+			seg_fds[i] = -1;
+		segs_cap = newcap;
+	}
+
+	seg_path(path, sizeof(path), id);
+	fd = open(path, O_RDWR | (create ? O_CREAT : 0), 0600);
+	if (fd >= 0)
+		seg_fds[id] = fd;
+	return fd;
+}
+
+static int
+posix_open(const char *path, uint64_t segment_size)
+{
+	(void) segment_size;		/* the file backend has no fixed-region layout */
+	if (mkdir(path, 0700) != 0 && errno != EEXIST)
+		return -1;
+	snprintf(posix_dir, sizeof(posix_dir), "%s", path);
+	return 0;
+}
+
+static void
+posix_close(void)
+{
+	for (int id = 0; id < segs_cap; id++)
+		if (seg_fds[id] >= 0)
+			close(seg_fds[id]);
+	free(seg_fds);
+	seg_fds = NULL;
+	segs_cap = 0;
+}
+
+static int
+posix_sync(void)
+{
+	for (int id = 0; id < segs_cap; id++)
+		if (seg_fds[id] >= 0 && fsync(seg_fds[id]) != 0)
+			return -1;
+	return 0;
+}
+
+static int
+posix_seg_write(int seg, uint64_t off, const void *buf, uint32_t len)
+{
+	int			fd = seg_fd(seg, 1);
+
+	if (fd < 0)
+		return -1;
+	if (pwrite(fd, buf, len, (off_t) off) != (ssize_t) len)
+		return -1;
+	return 0;
+}
+
+static int
+posix_seg_read(int seg, uint64_t off, void *buf, uint32_t len)
+{
+	int			fd = seg_fd(seg, 0);
+
+	if (fd < 0)
+		return -1;
+	if (pread(fd, buf, len, (off_t) off) != (ssize_t) len)
+		return -1;
+	return 0;
+}
+
+static int64_t
+posix_seg_size(int seg)
+{
+	char		path[4096];
+	struct stat st;
+
+	seg_path(path, sizeof(path), seg);
+	if (stat(path, &st) != 0)
+		return -1;
+	return (int64_t) st.st_size;
+}
+
+static int
+posix_wal_append(uint32_t tl, const void *a, uint32_t alen,
+				 const void *b, uint32_t blen)
+{
+	char		path[4096];
+	int			fd;
+
+	snprintf(path, sizeof(path), "%s/wal_%u", posix_dir, tl);
+	fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
+	if (fd < 0)
+		return -1;
+	if (write(fd, a, alen) != (ssize_t) alen ||
+		(blen > 0 && write(fd, b, blen) != (ssize_t) blen))
+	{
+		close(fd);
+		return -1;
+	}
+	close(fd);
+	return 0;
+}
+
+static int
+posix_wal_read(uint32_t tl, uint64_t off, void *buf, uint32_t len)
+{
+	char		path[4096];
+	int			fd;
+	ssize_t		n;
+
+	snprintf(path, sizeof(path), "%s/wal_%u", posix_dir, tl);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	n = pread(fd, buf, len, (off_t) off);
+	close(fd);
+	return (int) n;
+}
+
+static int
+posix_meta_append(const void *buf, uint32_t len)
+{
+	char		path[4096];
+	int			fd;
+
+	snprintf(path, sizeof(path), "%s/timelines", posix_dir);
+	fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
+	if (fd < 0)
+		return -1;
+	if (write(fd, buf, len) != (ssize_t) len)
+	{
+		close(fd);
+		return -1;
+	}
+	close(fd);
+	return 0;
+}
+
+static int
+posix_meta_read(uint64_t off, void *buf, uint32_t len)
+{
+	char		path[4096];
+	int			fd;
+	ssize_t		n;
+
+	snprintf(path, sizeof(path), "%s/timelines", posix_dir);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	n = pread(fd, buf, len, (off_t) off);
+	close(fd);
+	return (int) n;
+}
+
+const PsStorage PsStoragePosix = {
+	.name = "posix",
+	.open = posix_open,
+	.close = posix_close,
+	.sync = posix_sync,
+	.seg_write = posix_seg_write,
+	.seg_read = posix_seg_read,
+	.seg_size = posix_seg_size,
+	.wal_append = posix_wal_append,
+	.wal_read = posix_wal_read,
+	.meta_append = posix_meta_append,
+	.meta_read = posix_meta_read,
+};

--- a/contrib/pagestore/storage_spdk.c
+++ b/contrib/pagestore/storage_spdk.c
@@ -41,12 +41,29 @@
 #include "pagestore_storage.h"
 #include "storage_spdk.h"
 
-/* Async read engine: a pool of DMA buffers to overlap page reads of one request
- * on the NVMe queue (see ps_spdk_readv).  Each buffer holds one aligned page
- * read; 64 KiB covers any page size we use plus the alignment slack. */
-#define PS_SPDK_POOL	64
+/*
+ * Async read engine (see storage_spdk.h): a pool of DMA buffers lets many page
+ * reads -- across many request channels -- be in flight on the NVMe queue at
+ * once.  Each buffer holds one aligned page read; 64 KiB covers any page size we
+ * use plus the alignment slack.  Buffer index == its completion context; a
+ * free-list hands them out.
+ */
+#define PS_SPDK_POOL	256
 #define PS_SPDK_BUFSZ	65536
-static char *g_pool[PS_SPDK_POOL];
+
+typedef struct PsSpdkRd
+{
+	void	   *dst;			/* caller's destination (shared memory) */
+	uint64_t	slice;			/* byte offset of the page within the DMA buffer */
+	uint32_t	len;
+	PsSpdkDone	done;
+	void	   *arg;
+} PsSpdkRd;
+
+static char *g_pool[PS_SPDK_POOL];	/* DMA buffers */
+static PsSpdkRd g_rd[PS_SPDK_POOL]; /* one in-flight read context per buffer */
+static int	g_free[PS_SPDK_POOL];	/* free-list of buffer indices */
+static int	g_nfree;
 
 #define SPDK_SUPER_MAGIC	0x53504b53	/* "SPKS" */
 
@@ -282,7 +299,9 @@ spdk_open(const char *path, uint64_t segment_size)
 			fprintf(stderr, "storage_spdk: read-pool DMA allocation failed\n");
 			return -1;
 		}
+		g_free[j] = j;
 	}
+	g_nfree = PS_SPDK_POOL;
 
 	super_read();				/* segment count: fresh dir -> 0 */
 
@@ -388,87 +407,87 @@ spdk_seg_size(int seg)
 }
 
 /*
- * Batched asynchronous reads (the hot read path; see storage_spdk.h).  Reads of
- * the current append segment are served from the DMA buffer; every other read is
- * submitted to the NVMe queue, and a chunk of up to PS_SPDK_POOL of them is
- * overlapped before we wait, so a multi-block request uses real queue depth
- * instead of one I/O at a time.  A failed read leaves its dst zero-filled.
+ * Completion of one queued device read: deliver the page (zero-fill on error),
+ * return the buffer to the free-list, and notify the caller.  Runs inside
+ * spdk_nvme_qpair_process_completions, i.e. single-threaded with the loop.
  */
-int
-ps_spdk_readv(const PsSpdkRead *reqs, int n)
+static void
+rd_cb(void *arg, const struct spdk_nvme_cpl *cpl)
 {
-	int			i = 0;
+	int			b = (int) (intptr_t) arg;	/* buffer/context index */
+	PsSpdkRd   *rd = &g_rd[b];
+	int			ok = !spdk_nvme_cpl_is_error(cpl);
 
-	while (i < n)
+	if (ok)
+		memcpy(rd->dst, g_pool[b] + rd->slice, rd->len);
+	else
+		memset(rd->dst, 0, rd->len);
+	g_free[g_nfree++] = b;		/* free the buffer before notifying */
+	rd->done(rd->arg, ok);
+}
+
+int
+ps_spdk_read_async(int seg, uint64_t off, void *dst, uint32_t len,
+				   PsSpdkDone done, void *arg)
+{
+	uint64_t	byte0,
+				start,
+				end;
+	uint32_t	sectors;
+	int			b;
+	PsSpdkRd   *rd;
+
+	/* current append segment is authoritative in memory */
+	if (seg == g_curseg)
 	{
-		struct io_ctx ctx[PS_SPDK_POOL];
-		uint64_t	slice[PS_SPDK_POOL];	/* byte offset of the page in g_pool[k] */
-		const PsSpdkRead *r[PS_SPDK_POOL];	/* the request served by slot k */
-		int			chunk = 0;
-		int			done;
+		memcpy(dst, g_curbuf + off, len);
+		done(arg, 1);
+		return 0;
+	}
+	if ((uint32_t) seg >= g_num_segments)
+	{
+		memset(dst, 0, len);	/* no such segment */
+		done(arg, 1);
+		return 0;
+	}
 
-		/* fill a chunk: buffered/missing reads served inline, device reads queued */
-		while (i < n && chunk < PS_SPDK_POOL)
-		{
-			const PsSpdkRead *q = &reqs[i++];
-			uint64_t	byte0,
-						start,
-						end;
-			uint32_t	sectors;
+	byte0 = (uint64_t) seg * g_segsize + off;
+	start = byte0 - (byte0 % g_sector);
+	end = byte0 + len;
+	if (end % g_sector)
+		end += g_sector - (end % g_sector);
+	sectors = (uint32_t) ((end - start) / g_sector);
+	if ((uint64_t) sectors * g_sector > PS_SPDK_BUFSZ)
+	{
+		memset(dst, 0, len);	/* read too large for a pool buffer */
+		done(arg, 0);
+		return 0;
+	}
 
-			if (q->seg == g_curseg)
-			{
-				memcpy(q->dst, g_curbuf + q->off, q->len);
-				continue;
-			}
-			if ((uint32_t) q->seg >= g_num_segments)
-			{
-				memset(q->dst, 0, q->len);
-				continue;
-			}
-			byte0 = (uint64_t) q->seg * g_segsize + q->off;
-			start = byte0 - (byte0 % g_sector);
-			end = byte0 + q->len;
-			if (end % g_sector)
-				end += g_sector - (end % g_sector);
-			sectors = (uint32_t) ((end - start) / g_sector);
-			if ((uint64_t) sectors * g_sector > PS_SPDK_BUFSZ)
-			{
-				memset(q->dst, 0, q->len);	/* read too large for a pool buffer */
-				continue;
-			}
-			ctx[chunk].done = 0;
-			ctx[chunk].err = 0;
-			slice[chunk] = byte0 - start;
-			r[chunk] = q;
-			if (spdk_nvme_ns_cmd_read(g_ns, g_qpair, g_pool[chunk], start / g_sector,
-									  sectors, io_cb, &ctx[chunk], 0) != 0)
-			{
-				memset(q->dst, 0, q->len);	/* submission failed */
-				continue;
-			}
-			chunk++;
-		}
-
-		/* wait for this chunk's overlapped reads, then deliver the pages */
-		done = 0;
-		while (done < chunk)
-		{
-			spdk_nvme_qpair_process_completions(g_qpair, 0);
-			done = 0;
-			for (int k = 0; k < chunk; k++)
-				if (ctx[k].done)
-					done++;
-		}
-		for (int k = 0; k < chunk; k++)
-		{
-			if (ctx[k].err)
-				memset(r[k]->dst, 0, r[k]->len);
-			else
-				memcpy(r[k]->dst, g_pool[k] + slice[k], r[k]->len);
-		}
+	/* take a free DMA buffer, polling completions until one frees if needed */
+	while (g_nfree == 0)
+		spdk_nvme_qpair_process_completions(g_qpair, 0);
+	b = g_free[--g_nfree];
+	rd = &g_rd[b];
+	rd->dst = dst;
+	rd->slice = byte0 - start;
+	rd->len = len;
+	rd->done = done;
+	rd->arg = arg;
+	if (spdk_nvme_ns_cmd_read(g_ns, g_qpair, g_pool[b], start / g_sector,
+							  sectors, rd_cb, (void *) (intptr_t) b, 0) != 0)
+	{
+		g_free[g_nfree++] = b;	/* submission failed: give the buffer back */
+		memset(dst, 0, len);
+		done(arg, 0);
 	}
 	return 0;
+}
+
+int
+ps_spdk_poll(void)
+{
+	return spdk_nvme_qpair_process_completions(g_qpair, 0);
 }
 
 /* --- WAL + timeline metadata: delegated to the POSIX backend ------------- */

--- a/contrib/pagestore/storage_spdk.c
+++ b/contrib/pagestore/storage_spdk.c
@@ -4,20 +4,35 @@
  *	  SPDK (userspace NVMe) storage backend for the page-store daemon.
  *
  * Optional, higher-performance alternative to storage_posix.c behind the same
- * PsStorage interface (so the IPC ABI is unchanged and a machine without SPDK
- * just uses the POSIX backend).  Built only when PAGESTORE_SPDK is defined and
+ * PsStorage interface, so the IPC ABI is unchanged and a machine without SPDK
+ * just uses the POSIX backend.  Built only when PAGESTORE_SPDK is defined and
  * linked against SPDK; see spdk_build.sh.
  *
- * Status: S1.2b -- this brings up SPDK in *library mode* (spdk_env_init, no
- * spdk_app_start) and attaches the dedicated control NVMe by PCI address,
- * grabbing its namespace and an I/O qpair.  The actual byte movement
- * (seg/wal/meta) is stubbed and lands in S1.2c, where it becomes asynchronous
- * spdk_nvme_ns_cmd_* with completions driven by the daemon loop.
+ * What lives where (S1.2c):
+ *   - The page *segments* -- the bulk and the hot path -- live on the raw NVMe
+ *     namespace.  Segment id S, byte offset O maps to device byte S*segsize+O.
+ *     A segment is written as one sector-aligned, zero-padded extent; the unused
+ *     tail reads back as zeros so recover() stops at the first non-magic record
+ *     (no per-segment length bookkeeping needed).  The current append segment is
+ *     held in a DMA buffer and flushed on roll-over / sync; older segments are
+ *     read back with an aligned read + slice.
+ *   - The shipped WAL and the timeline metadata are small and not hot, so for
+ *     now they stay on the filesystem, delegated to the POSIX backend under the
+ *     same --store dir.  (Putting them on-device is a later LSM-layer refinement.)
+ *   - The segment count is persisted in <store>/spdk_super, so a fresh --store
+ *     dir means a fresh store (matching POSIX semantics) and a restart with the
+ *     same dir continues.
+ *
+ * I/O uses the asynchronous spdk_nvme_ns_cmd_* API; for now each op polls the
+ * qpair to completion before returning (correct, not yet pipelined across
+ * channels -- that is S1.2c-2).  Library mode: no spdk_app_start.
  *
  *-------------------------------------------------------------------------
  */
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "spdk/env.h"
@@ -25,47 +40,188 @@
 
 #include "pagestore_storage.h"
 
-/* The single control device this daemon owns. */
+#define SPDK_SUPER_MAGIC	0x53504b53	/* "SPKS" */
+
+typedef struct SpdkSuper
+{
+	uint32_t	magic;
+	uint32_t	sector_size;
+	uint64_t	segment_size;
+	uint32_t	num_segments;
+} SpdkSuper;
+
+/* the single control device this daemon owns */
 static struct spdk_nvme_ctrlr *g_ctrlr;
 static struct spdk_nvme_ns *g_ns;
 static struct spdk_nvme_qpair *g_qpair;
-static uint32_t g_sector_size;	/* device LBA size (e.g. 512 or 4096) */
-static uint64_t g_num_sectors;	/* namespace capacity in sectors */
+static uint32_t g_sector;		/* device LBA size (e.g. 512) */
+static uint64_t g_segsize;		/* bytes per segment */
+static uint32_t g_secs_per_seg; /* sectors per segment */
+static uint32_t g_num_segments; /* segments that hold data */
+static char g_store[2048];		/* --store dir (for spdk_super + WAL/meta) */
+
+/* DMA buffers: the current append segment, and a scratch buffer for reads */
+static char *g_curbuf;			/* segment_size bytes, DMA-able */
+static int	g_curseg = -1;		/* which segment g_curbuf holds (-1: none) */
+static int	g_dirty;			/* g_curbuf has unflushed writes */
+static char *g_iobuf;			/* segment_size scratch for aligned reads */
+
+/* --- low-level synchronous-but-polled NVMe I/O --------------------------- */
+
+struct io_ctx
+{
+	volatile int done;
+	volatile int err;
+};
+
+static void
+io_cb(void *arg, const struct spdk_nvme_cpl *cpl)
+{
+	struct io_ctx *c = arg;
+
+	c->err = spdk_nvme_cpl_is_error(cpl) ? -1 : 0;
+	c->done = 1;
+}
+
+/* read/write 'sectors' LBAs at 'lba' to/from DMA buffer 'buf'; poll to done. */
+static int
+do_io(void *buf, uint64_t lba, uint32_t sectors, int is_write)
+{
+	struct io_ctx c = {0, 0};
+	int			rc;
+
+	rc = is_write
+		? spdk_nvme_ns_cmd_write(g_ns, g_qpair, buf, lba, sectors, io_cb, &c, 0)
+		: spdk_nvme_ns_cmd_read(g_ns, g_qpair, buf, lba, sectors, io_cb, &c, 0);
+	if (rc != 0)
+		return -1;
+	while (!c.done)
+		spdk_nvme_qpair_process_completions(g_qpair, 0);
+	return c.err;
+}
+
+static uint64_t
+seg_lba(int seg)
+{
+	return (uint64_t) seg * g_secs_per_seg;
+}
+
+/* --- spdk_super (segment count) in the store dir ------------------------- */
+
+static void
+super_path(char *buf, size_t buflen)
+{
+	snprintf(buf, buflen, "%s/spdk_super", g_store);
+}
+
+static void
+super_write(void)
+{
+	char		path[2300];
+	SpdkSuper	s = {SPDK_SUPER_MAGIC, g_sector, g_segsize, g_num_segments};
+	FILE	   *f;
+
+	super_path(path, sizeof(path));
+	f = fopen(path, "wb");
+	if (!f)
+		return;					/* best-effort */
+	fwrite(&s, sizeof(s), 1, f);
+	fclose(f);
+}
+
+static void
+super_read(void)
+{
+	char		path[2300];
+	SpdkSuper	s;
+	FILE	   *f;
+
+	g_num_segments = 0;			/* default: fresh store */
+	super_path(path, sizeof(path));
+	f = fopen(path, "rb");
+	if (!f)
+		return;
+	if (fread(&s, sizeof(s), 1, f) == 1 && s.magic == SPDK_SUPER_MAGIC &&
+		s.sector_size == g_sector && s.segment_size == g_segsize)
+		g_num_segments = s.num_segments;
+	fclose(f);
+}
+
+/* --- current-segment buffer management ----------------------------------- */
+
+static int
+flush_curbuf(void)
+{
+	if (g_curseg < 0 || !g_dirty)
+		return 0;
+	if (do_io(g_curbuf, seg_lba(g_curseg), g_secs_per_seg, 1) != 0)
+		return -1;
+	g_dirty = 0;
+	return 0;
+}
+
+/* Make g_curbuf hold segment 'seg' (loading it from the device if it exists). */
+static int
+load_curbuf(int seg)
+{
+	if (flush_curbuf() != 0)
+		return -1;
+	if ((uint32_t) seg < g_num_segments)
+	{
+		if (do_io(g_curbuf, seg_lba(seg), g_secs_per_seg, 0) != 0)
+			return -1;
+	}
+	else
+		memset(g_curbuf, 0, g_segsize);		/* fresh segment: zero tail */
+	g_curseg = seg;
+	g_dirty = 0;
+	return 0;
+}
+
+/* --- SPDK bring-up ------------------------------------------------------- */
 
 static bool
 probe_cb(void *ctx, const struct spdk_nvme_transport_id *trid,
 		 struct spdk_nvme_ctrlr_opts *opts)
 {
-	(void) ctx;
-	(void) trid;
-	(void) opts;
-	return true;				/* attach every controller we probed for */
+	(void) ctx; (void) trid; (void) opts;
+	return true;
 }
 
 static void
 attach_cb(void *ctx, const struct spdk_nvme_transport_id *trid,
 		  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
-	(void) ctx;
-	(void) trid;
-	(void) opts;
-	if (!g_ctrlr)				/* we probe a single PCI addr; take the first */
+	(void) ctx; (void) trid; (void) opts;
+	if (!g_ctrlr)
 		g_ctrlr = ctrlr;
 }
 
 /*
- * open(): 'path' is the control disk's PCI address (e.g. "0000:06:00.0").
- * Initialize the SPDK environment in library mode, attach the controller, and
- * grab namespace 1 plus an I/O qpair.
+ * open(): 'path' is the --store dir (for spdk_super and the delegated WAL/meta
+ * files); the control disk's PCI address comes from $PS_SPDK_PCI.
  */
 static int
 spdk_open(const char *path, uint64_t segment_size)
 {
 	struct spdk_env_opts opts;
 	struct spdk_nvme_transport_id trid;
+	const char *pci = getenv("PS_SPDK_PCI");
 
-	(void) segment_size;
+	if (!pci)
+	{
+		fprintf(stderr, "storage_spdk: PS_SPDK_PCI not set "
+				"(control disk PCI address, e.g. 0000:06:00.0)\n");
+		return -1;
+	}
 
+	/* WAL + timeline metadata are delegated to the POSIX backend under store */
+	if (PsStoragePosix.open(path, segment_size) != 0)
+		return -1;
+	snprintf(g_store, sizeof(g_store), "%s", path);
+	g_segsize = segment_size;
+
+	opts.opts_size = sizeof(opts);	/* required by spdk_env_opts_init in v26.01 */
 	spdk_env_opts_init(&opts);
 	opts.name = "pagestore_daemon_spdk";
 	if (spdk_env_init(&opts) < 0)
@@ -76,118 +232,162 @@ spdk_open(const char *path, uint64_t segment_size)
 
 	memset(&trid, 0, sizeof(trid));
 	spdk_nvme_trid_populate_transport(&trid, SPDK_NVME_TRANSPORT_PCIE);
-	snprintf(trid.traddr, sizeof(trid.traddr), "%s", path);
-
+	snprintf(trid.traddr, sizeof(trid.traddr), "%s", pci);
 	if (spdk_nvme_probe(&trid, NULL, probe_cb, attach_cb, NULL) != 0 || !g_ctrlr)
 	{
 		fprintf(stderr, "storage_spdk: could not attach NVMe at %s "
-				"(bound to vfio-pci? see spdk_setup.sh)\n", path);
+				"(bound to vfio-pci? see spdk_setup.sh)\n", pci);
 		return -1;
 	}
 
 	g_ns = spdk_nvme_ctrlr_get_ns(g_ctrlr, 1);
 	if (!g_ns || !spdk_nvme_ns_is_active(g_ns))
 	{
-		fprintf(stderr, "storage_spdk: namespace 1 not active on %s\n", path);
+		fprintf(stderr, "storage_spdk: namespace 1 not active\n");
 		return -1;
 	}
-	g_sector_size = spdk_nvme_ns_get_sector_size(g_ns);
-	g_num_sectors = spdk_nvme_ns_get_num_sectors(g_ns);
+	g_sector = spdk_nvme_ns_get_sector_size(g_ns);
+	if (g_segsize % g_sector != 0)
+	{
+		fprintf(stderr, "storage_spdk: segment size %llu not a multiple of "
+				"sector %u\n", (unsigned long long) g_segsize, g_sector);
+		return -1;
+	}
+	g_secs_per_seg = (uint32_t) (g_segsize / g_sector);
 
 	g_qpair = spdk_nvme_ctrlr_alloc_io_qpair(g_ctrlr, NULL, 0);
-	if (!g_qpair)
+	g_curbuf = spdk_zmalloc(g_segsize, 0x1000, NULL, SPDK_ENV_SOCKET_ID_ANY,
+							SPDK_MALLOC_DMA);
+	g_iobuf = spdk_zmalloc(g_segsize, 0x1000, NULL, SPDK_ENV_SOCKET_ID_ANY,
+						   SPDK_MALLOC_DMA);
+	if (!g_qpair || !g_curbuf || !g_iobuf)
 	{
-		fprintf(stderr, "storage_spdk: could not allocate I/O qpair\n");
+		fprintf(stderr, "storage_spdk: qpair/DMA buffer allocation failed\n");
 		return -1;
 	}
 
-	fprintf(stderr, "storage_spdk: attached %s ns1 sector=%u sectors=%llu "
-			"capacity=%lluMiB\n", path, g_sector_size,
-			(unsigned long long) g_num_sectors,
-			(unsigned long long) (g_num_sectors * g_sector_size >> 20));
+	super_read();				/* segment count: fresh dir -> 0 */
+
+	fprintf(stderr, "storage_spdk: %s ns1 sector=%u segsize=%llu segments=%u\n",
+			pci, g_sector, (unsigned long long) g_segsize, g_num_segments);
 	return 0;
 }
 
 static void
 spdk_close(void)
 {
+	flush_curbuf();
+	super_write();
+	if (g_curbuf)
+		spdk_free(g_curbuf);
+	if (g_iobuf)
+		spdk_free(g_iobuf);
 	if (g_qpair)
 		spdk_nvme_ctrlr_free_io_qpair(g_qpair);
 	if (g_ctrlr)
 		spdk_nvme_detach(g_ctrlr);
+	g_curbuf = g_iobuf = NULL;
 	g_qpair = NULL;
 	g_ctrlr = NULL;
 	g_ns = NULL;
+	PsStoragePosix.close();
 }
-
-/*
- * Byte movement -- stubbed for S1.2b.  S1.2c implements these as asynchronous
- * spdk_nvme_ns_cmd_read/write over a fixed-region layout (segment id + offset
- * -> LBA), with DMA buffers and completions polled by the daemon loop.
- */
-#define SPDK_TODO(name) \
-	do { \
-		fprintf(stderr, "storage_spdk: " name " not implemented yet (S1.2c)\n"); \
-	} while (0)
 
 static int
 spdk_sync(void)
 {
-	return 0;					/* flush handled at S1.2c with the write path */
+	if (flush_curbuf() != 0)
+		return -1;
+	super_write();
+	return 0;
 }
+
+/* --- segment byte I/O ---------------------------------------------------- */
 
 static int
 spdk_seg_write(int seg, uint64_t off, const void *buf, uint32_t len)
 {
-	(void) seg; (void) off; (void) buf; (void) len;
-	SPDK_TODO("seg_write");
-	return -1;
+	if (off + len > g_segsize)
+		return -1;
+	if (seg != g_curseg && load_curbuf(seg) != 0)
+		return -1;
+	memcpy(g_curbuf + off, buf, len);
+	g_dirty = 1;
+	if ((uint32_t) seg + 1 > g_num_segments)
+		g_num_segments = (uint32_t) seg + 1;
+	return 0;
 }
 
 static int
 spdk_seg_read(int seg, uint64_t off, void *buf, uint32_t len)
 {
-	(void) seg; (void) off; (void) buf; (void) len;
-	SPDK_TODO("seg_read");
-	return -1;
+	uint64_t	byte0,
+				start,
+				end,
+				lba;
+	uint32_t	sectors;
+
+	if (off + len > g_segsize)
+		return -1;
+
+	/* current append segment is authoritative in the buffer */
+	if (seg == g_curseg)
+	{
+		memcpy(buf, g_curbuf + off, len);
+		return 0;
+	}
+	if ((uint32_t) seg >= g_num_segments)
+		return -1;				/* no such segment -> end of log for recover() */
+
+	/* aligned read of the covering sectors, then slice out [off, off+len) */
+	byte0 = (uint64_t) seg * g_segsize + off;
+	start = byte0 - (byte0 % g_sector);
+	end = byte0 + len;
+	if (end % g_sector)
+		end += g_sector - (end % g_sector);
+	lba = start / g_sector;
+	sectors = (uint32_t) ((end - start) / g_sector);
+	if ((uint64_t) sectors * g_sector > g_segsize)
+		return -1;				/* scratch buffer is one segment */
+	if (do_io(g_iobuf, lba, sectors, 0) != 0)
+		return -1;
+	memcpy(buf, g_iobuf + (byte0 - start), len);
+	return 0;
 }
 
 static int64_t
 spdk_seg_size(int seg)
 {
-	(void) seg;
-	return -1;					/* no segments yet -> recover() finds an empty store */
+	if ((uint32_t) seg < g_num_segments || seg == g_curseg)
+		return (int64_t) g_segsize;
+	return -1;
 }
+
+/* --- WAL + timeline metadata: delegated to the POSIX backend ------------- */
 
 static int
 spdk_wal_append(uint32_t tl, const void *a, uint32_t alen,
 				const void *b, uint32_t blen)
 {
-	(void) tl; (void) a; (void) alen; (void) b; (void) blen;
-	SPDK_TODO("wal_append");
-	return -1;
+	return PsStoragePosix.wal_append(tl, a, alen, b, blen);
 }
 
 static int
 spdk_wal_read(uint32_t tl, uint64_t off, void *buf, uint32_t len)
 {
-	(void) tl; (void) off; (void) buf; (void) len;
-	return 0;					/* empty -> end of log */
+	return PsStoragePosix.wal_read(tl, off, buf, len);
 }
 
 static int
 spdk_meta_append(const void *buf, uint32_t len)
 {
-	(void) buf; (void) len;
-	SPDK_TODO("meta_append");
-	return -1;
+	return PsStoragePosix.meta_append(buf, len);
 }
 
 static int
 spdk_meta_read(uint64_t off, void *buf, uint32_t len)
 {
-	(void) off; (void) buf; (void) len;
-	return 0;					/* empty -> no timelines */
+	return PsStoragePosix.meta_read(off, buf, len);
 }
 
 const PsStorage PsStorageSpdk = {

--- a/contrib/pagestore/storage_spdk.c
+++ b/contrib/pagestore/storage_spdk.c
@@ -39,6 +39,14 @@
 #include "spdk/nvme.h"
 
 #include "pagestore_storage.h"
+#include "storage_spdk.h"
+
+/* Async read engine: a pool of DMA buffers to overlap page reads of one request
+ * on the NVMe queue (see ps_spdk_readv).  Each buffer holds one aligned page
+ * read; 64 KiB covers any page size we use plus the alignment slack. */
+#define PS_SPDK_POOL	64
+#define PS_SPDK_BUFSZ	65536
+static char *g_pool[PS_SPDK_POOL];
 
 #define SPDK_SUPER_MAGIC	0x53504b53	/* "SPKS" */
 
@@ -265,6 +273,16 @@ spdk_open(const char *path, uint64_t segment_size)
 		fprintf(stderr, "storage_spdk: qpair/DMA buffer allocation failed\n");
 		return -1;
 	}
+	for (int j = 0; j < PS_SPDK_POOL; j++)
+	{
+		g_pool[j] = spdk_zmalloc(PS_SPDK_BUFSZ, 0x1000, NULL,
+								 SPDK_ENV_SOCKET_ID_ANY, SPDK_MALLOC_DMA);
+		if (!g_pool[j])
+		{
+			fprintf(stderr, "storage_spdk: read-pool DMA allocation failed\n");
+			return -1;
+		}
+	}
 
 	super_read();				/* segment count: fresh dir -> 0 */
 
@@ -282,6 +300,12 @@ spdk_close(void)
 		spdk_free(g_curbuf);
 	if (g_iobuf)
 		spdk_free(g_iobuf);
+	for (int j = 0; j < PS_SPDK_POOL; j++)
+		if (g_pool[j])
+		{
+			spdk_free(g_pool[j]);
+			g_pool[j] = NULL;
+		}
 	if (g_qpair)
 		spdk_nvme_ctrlr_free_io_qpair(g_qpair);
 	if (g_ctrlr)
@@ -361,6 +385,90 @@ spdk_seg_size(int seg)
 	if ((uint32_t) seg < g_num_segments || seg == g_curseg)
 		return (int64_t) g_segsize;
 	return -1;
+}
+
+/*
+ * Batched asynchronous reads (the hot read path; see storage_spdk.h).  Reads of
+ * the current append segment are served from the DMA buffer; every other read is
+ * submitted to the NVMe queue, and a chunk of up to PS_SPDK_POOL of them is
+ * overlapped before we wait, so a multi-block request uses real queue depth
+ * instead of one I/O at a time.  A failed read leaves its dst zero-filled.
+ */
+int
+ps_spdk_readv(const PsSpdkRead *reqs, int n)
+{
+	int			i = 0;
+
+	while (i < n)
+	{
+		struct io_ctx ctx[PS_SPDK_POOL];
+		uint64_t	slice[PS_SPDK_POOL];	/* byte offset of the page in g_pool[k] */
+		const PsSpdkRead *r[PS_SPDK_POOL];	/* the request served by slot k */
+		int			chunk = 0;
+		int			done;
+
+		/* fill a chunk: buffered/missing reads served inline, device reads queued */
+		while (i < n && chunk < PS_SPDK_POOL)
+		{
+			const PsSpdkRead *q = &reqs[i++];
+			uint64_t	byte0,
+						start,
+						end;
+			uint32_t	sectors;
+
+			if (q->seg == g_curseg)
+			{
+				memcpy(q->dst, g_curbuf + q->off, q->len);
+				continue;
+			}
+			if ((uint32_t) q->seg >= g_num_segments)
+			{
+				memset(q->dst, 0, q->len);
+				continue;
+			}
+			byte0 = (uint64_t) q->seg * g_segsize + q->off;
+			start = byte0 - (byte0 % g_sector);
+			end = byte0 + q->len;
+			if (end % g_sector)
+				end += g_sector - (end % g_sector);
+			sectors = (uint32_t) ((end - start) / g_sector);
+			if ((uint64_t) sectors * g_sector > PS_SPDK_BUFSZ)
+			{
+				memset(q->dst, 0, q->len);	/* read too large for a pool buffer */
+				continue;
+			}
+			ctx[chunk].done = 0;
+			ctx[chunk].err = 0;
+			slice[chunk] = byte0 - start;
+			r[chunk] = q;
+			if (spdk_nvme_ns_cmd_read(g_ns, g_qpair, g_pool[chunk], start / g_sector,
+									  sectors, io_cb, &ctx[chunk], 0) != 0)
+			{
+				memset(q->dst, 0, q->len);	/* submission failed */
+				continue;
+			}
+			chunk++;
+		}
+
+		/* wait for this chunk's overlapped reads, then deliver the pages */
+		done = 0;
+		while (done < chunk)
+		{
+			spdk_nvme_qpair_process_completions(g_qpair, 0);
+			done = 0;
+			for (int k = 0; k < chunk; k++)
+				if (ctx[k].done)
+					done++;
+		}
+		for (int k = 0; k < chunk; k++)
+		{
+			if (ctx[k].err)
+				memset(r[k]->dst, 0, r[k]->len);
+			else
+				memcpy(r[k]->dst, g_pool[k] + slice[k], r[k]->len);
+		}
+	}
+	return 0;
 }
 
 /* --- WAL + timeline metadata: delegated to the POSIX backend ------------- */

--- a/contrib/pagestore/storage_spdk.c
+++ b/contrib/pagestore/storage_spdk.c
@@ -1,0 +1,205 @@
+/*-------------------------------------------------------------------------
+ *
+ * storage_spdk.c
+ *	  SPDK (userspace NVMe) storage backend for the page-store daemon.
+ *
+ * Optional, higher-performance alternative to storage_posix.c behind the same
+ * PsStorage interface (so the IPC ABI is unchanged and a machine without SPDK
+ * just uses the POSIX backend).  Built only when PAGESTORE_SPDK is defined and
+ * linked against SPDK; see spdk_build.sh.
+ *
+ * Status: S1.2b -- this brings up SPDK in *library mode* (spdk_env_init, no
+ * spdk_app_start) and attaches the dedicated control NVMe by PCI address,
+ * grabbing its namespace and an I/O qpair.  The actual byte movement
+ * (seg/wal/meta) is stubbed and lands in S1.2c, where it becomes asynchronous
+ * spdk_nvme_ns_cmd_* with completions driven by the daemon loop.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "spdk/env.h"
+#include "spdk/nvme.h"
+
+#include "pagestore_storage.h"
+
+/* The single control device this daemon owns. */
+static struct spdk_nvme_ctrlr *g_ctrlr;
+static struct spdk_nvme_ns *g_ns;
+static struct spdk_nvme_qpair *g_qpair;
+static uint32_t g_sector_size;	/* device LBA size (e.g. 512 or 4096) */
+static uint64_t g_num_sectors;	/* namespace capacity in sectors */
+
+static bool
+probe_cb(void *ctx, const struct spdk_nvme_transport_id *trid,
+		 struct spdk_nvme_ctrlr_opts *opts)
+{
+	(void) ctx;
+	(void) trid;
+	(void) opts;
+	return true;				/* attach every controller we probed for */
+}
+
+static void
+attach_cb(void *ctx, const struct spdk_nvme_transport_id *trid,
+		  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
+{
+	(void) ctx;
+	(void) trid;
+	(void) opts;
+	if (!g_ctrlr)				/* we probe a single PCI addr; take the first */
+		g_ctrlr = ctrlr;
+}
+
+/*
+ * open(): 'path' is the control disk's PCI address (e.g. "0000:06:00.0").
+ * Initialize the SPDK environment in library mode, attach the controller, and
+ * grab namespace 1 plus an I/O qpair.
+ */
+static int
+spdk_open(const char *path, uint64_t segment_size)
+{
+	struct spdk_env_opts opts;
+	struct spdk_nvme_transport_id trid;
+
+	(void) segment_size;
+
+	spdk_env_opts_init(&opts);
+	opts.name = "pagestore_daemon_spdk";
+	if (spdk_env_init(&opts) < 0)
+	{
+		fprintf(stderr, "storage_spdk: spdk_env_init failed\n");
+		return -1;
+	}
+
+	memset(&trid, 0, sizeof(trid));
+	spdk_nvme_trid_populate_transport(&trid, SPDK_NVME_TRANSPORT_PCIE);
+	snprintf(trid.traddr, sizeof(trid.traddr), "%s", path);
+
+	if (spdk_nvme_probe(&trid, NULL, probe_cb, attach_cb, NULL) != 0 || !g_ctrlr)
+	{
+		fprintf(stderr, "storage_spdk: could not attach NVMe at %s "
+				"(bound to vfio-pci? see spdk_setup.sh)\n", path);
+		return -1;
+	}
+
+	g_ns = spdk_nvme_ctrlr_get_ns(g_ctrlr, 1);
+	if (!g_ns || !spdk_nvme_ns_is_active(g_ns))
+	{
+		fprintf(stderr, "storage_spdk: namespace 1 not active on %s\n", path);
+		return -1;
+	}
+	g_sector_size = spdk_nvme_ns_get_sector_size(g_ns);
+	g_num_sectors = spdk_nvme_ns_get_num_sectors(g_ns);
+
+	g_qpair = spdk_nvme_ctrlr_alloc_io_qpair(g_ctrlr, NULL, 0);
+	if (!g_qpair)
+	{
+		fprintf(stderr, "storage_spdk: could not allocate I/O qpair\n");
+		return -1;
+	}
+
+	fprintf(stderr, "storage_spdk: attached %s ns1 sector=%u sectors=%llu "
+			"capacity=%lluMiB\n", path, g_sector_size,
+			(unsigned long long) g_num_sectors,
+			(unsigned long long) (g_num_sectors * g_sector_size >> 20));
+	return 0;
+}
+
+static void
+spdk_close(void)
+{
+	if (g_qpair)
+		spdk_nvme_ctrlr_free_io_qpair(g_qpair);
+	if (g_ctrlr)
+		spdk_nvme_detach(g_ctrlr);
+	g_qpair = NULL;
+	g_ctrlr = NULL;
+	g_ns = NULL;
+}
+
+/*
+ * Byte movement -- stubbed for S1.2b.  S1.2c implements these as asynchronous
+ * spdk_nvme_ns_cmd_read/write over a fixed-region layout (segment id + offset
+ * -> LBA), with DMA buffers and completions polled by the daemon loop.
+ */
+#define SPDK_TODO(name) \
+	do { \
+		fprintf(stderr, "storage_spdk: " name " not implemented yet (S1.2c)\n"); \
+	} while (0)
+
+static int
+spdk_sync(void)
+{
+	return 0;					/* flush handled at S1.2c with the write path */
+}
+
+static int
+spdk_seg_write(int seg, uint64_t off, const void *buf, uint32_t len)
+{
+	(void) seg; (void) off; (void) buf; (void) len;
+	SPDK_TODO("seg_write");
+	return -1;
+}
+
+static int
+spdk_seg_read(int seg, uint64_t off, void *buf, uint32_t len)
+{
+	(void) seg; (void) off; (void) buf; (void) len;
+	SPDK_TODO("seg_read");
+	return -1;
+}
+
+static int64_t
+spdk_seg_size(int seg)
+{
+	(void) seg;
+	return -1;					/* no segments yet -> recover() finds an empty store */
+}
+
+static int
+spdk_wal_append(uint32_t tl, const void *a, uint32_t alen,
+				const void *b, uint32_t blen)
+{
+	(void) tl; (void) a; (void) alen; (void) b; (void) blen;
+	SPDK_TODO("wal_append");
+	return -1;
+}
+
+static int
+spdk_wal_read(uint32_t tl, uint64_t off, void *buf, uint32_t len)
+{
+	(void) tl; (void) off; (void) buf; (void) len;
+	return 0;					/* empty -> end of log */
+}
+
+static int
+spdk_meta_append(const void *buf, uint32_t len)
+{
+	(void) buf; (void) len;
+	SPDK_TODO("meta_append");
+	return -1;
+}
+
+static int
+spdk_meta_read(uint64_t off, void *buf, uint32_t len)
+{
+	(void) off; (void) buf; (void) len;
+	return 0;					/* empty -> no timelines */
+}
+
+const PsStorage PsStorageSpdk = {
+	.name = "spdk",
+	.open = spdk_open,
+	.close = spdk_close,
+	.sync = spdk_sync,
+	.seg_write = spdk_seg_write,
+	.seg_read = spdk_seg_read,
+	.seg_size = spdk_seg_size,
+	.wal_append = spdk_wal_append,
+	.wal_read = spdk_wal_read,
+	.meta_append = spdk_meta_append,
+	.meta_read = spdk_meta_read,
+};

--- a/contrib/pagestore/storage_spdk.h
+++ b/contrib/pagestore/storage_spdk.h
@@ -1,0 +1,34 @@
+/*-------------------------------------------------------------------------
+ *
+ * storage_spdk.h
+ *	  Extra (beyond the PsStorage vtable) entry points of the SPDK backend,
+ *	  used only by the SPDK daemon frontend for the asynchronous read path.
+ *
+ * The PsStorage vtable stays synchronous (the shared brain and recover() use
+ * it); this batched read API lets the SPDK frontend overlap many page reads of
+ * one request on the NVMe queue instead of waiting for each in turn.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef STORAGE_SPDK_H
+#define STORAGE_SPDK_H
+
+#include <stdint.h>
+
+/* One page read: 'len' bytes at (seg, off) copied into 'dst' (shared memory). */
+typedef struct PsSpdkRead
+{
+	int			seg;
+	uint64_t	off;
+	void	   *dst;
+	uint32_t	len;
+} PsSpdkRead;
+
+/*
+ * Issue all 'n' reads, overlapping the device reads on the NVMe queue, and wait
+ * for them all.  Reads of the current (buffered) append segment are served from
+ * memory.  A read that fails leaves its 'dst' zero-filled.  Returns 0.
+ */
+extern int	ps_spdk_readv(const PsSpdkRead *reqs, int n);
+
+#endif							/* STORAGE_SPDK_H */

--- a/contrib/pagestore/storage_spdk.h
+++ b/contrib/pagestore/storage_spdk.h
@@ -5,8 +5,10 @@
  *	  used only by the SPDK daemon frontend for the asynchronous read path.
  *
  * The PsStorage vtable stays synchronous (the shared brain and recover() use
- * it); this batched read API lets the SPDK frontend overlap many page reads of
- * one request on the NVMe queue instead of waiting for each in turn.
+ * it).  This async submit/poll API lets the SPDK frontend keep many page reads
+ * -- across many request channels -- in flight on the NVMe queue at once and
+ * serve each reply from its completion, instead of finishing one request before
+ * starting the next.
  *
  *-------------------------------------------------------------------------
  */
@@ -15,20 +17,22 @@
 
 #include <stdint.h>
 
-/* One page read: 'len' bytes at (seg, off) copied into 'dst' (shared memory). */
-typedef struct PsSpdkRead
-{
-	int			seg;
-	uint64_t	off;
-	void	   *dst;
-	uint32_t	len;
-} PsSpdkRead;
+/* Completion callback: ok=1 if the page was delivered, 0 on a device error
+ * (in which case the engine has zero-filled dst). */
+typedef void (*PsSpdkDone) (void *arg, int ok);
 
 /*
- * Issue all 'n' reads, overlapping the device reads on the NVMe queue, and wait
- * for them all.  Reads of the current (buffered) append segment are served from
- * memory.  A read that fails leaves its 'dst' zero-filled.  Returns 0.
+ * Submit one page read of 'len' bytes at (seg, off) into 'dst' (shared memory).
+ * A read of the current (buffered) append segment is served from memory and
+ * 'done' is called before returning; a device read is queued and 'done' fires
+ * later from ps_spdk_poll().  Either way the engine copies into dst (or zeroes
+ * it on error) before calling done.  If no DMA buffer is free it polls until one
+ * frees, so submission always eventually succeeds.  Returns 0.
  */
-extern int	ps_spdk_readv(const PsSpdkRead *reqs, int n);
+extern int	ps_spdk_read_async(int seg, uint64_t off, void *dst, uint32_t len,
+							   PsSpdkDone done, void *arg);
+
+/* Drive NVMe completions; returns the number processed. */
+extern int	ps_spdk_poll(void);
 
 #endif							/* STORAGE_SPDK_H */

--- a/contrib/pagestore/wal_only_redo_demo.sh
+++ b/contrib/pagestore/wal_only_redo_demo.sh
@@ -70,10 +70,13 @@ SQL
 # create the table and change it; its pages are written LOCALLY, never shipped
 $P -c "CREATE TABLE t(id int primary key, v text); INSERT INTO t VALUES (1,'base');" >/dev/null
 $P -c "UPDATE t SET v='changed' WHERE id=1;" >/dev/null
-startseg=$(sed -n 's/.*(file \([0-9A-F]\{24\}\)).*/\1/p' "$D/backup_label")
-for _ in $(seq 1 50); do
+# Wait until the UPDATE's WAL segment is archived to the store (async), not just
+# the backup-start segment -- the change is in a later segment, and waiting only
+# for the start segment races on slower CI runners.
+updseg=$($P -c "SELECT pg_walfile_name(pg_current_wal_lsn());")
+for _ in $(seq 1 100); do
 	$P -c "SELECT pg_switch_wal();" >/dev/null 2>&1
-	[ -f "$D/pg_wal/archive_status/$startseg.done" ] && break
+	[ -f "$D/pg_wal/archive_status/$updseg.done" ] && break
 	sleep 0.2
 done
 # table t's relation file exists locally (the writer did not page-ship it)

--- a/contrib/pagestore/wal_only_redo_demo.sh
+++ b/contrib/pagestore/wal_only_redo_demo.sh
@@ -74,9 +74,10 @@ $P -c "UPDATE t SET v='changed' WHERE id=1;" >/dev/null
 # the backup-start segment -- the change is in a later segment, and waiting only
 # for the start segment races on slower CI runners.
 updseg=$($P -c "SELECT pg_walfile_name(pg_current_wal_lsn());")
-for _ in $(seq 1 100); do
+for _ in $(seq 1 150); do
 	$P -c "SELECT pg_switch_wal();" >/dev/null 2>&1
-	[ -f "$D/pg_wal/archive_status/$updseg.done" ] && break
+	last=$($P -c "SELECT last_archived_wal FROM pg_stat_archiver;" 2>/dev/null)
+	[[ -n "$last" && ! "$last" < "$updseg" ]] && break	# archived through updseg
 	sleep 0.2
 done
 # table t's relation file exists locally (the writer did not page-ship it)

--- a/contrib/pagestore/wal_only_redo_demo.sh
+++ b/contrib/pagestore/wal_only_redo_demo.sh
@@ -97,7 +97,14 @@ echo "restore_command = '$WALRESTORE --shm $SHM --timeline 0 --segsize 16777216 
 rm -f "$D"/pg_wal/0000000*
 
 if "$BIN/pg_ctl" -D "$D" -l "$D/r.log" -w start >/dev/null 2>&1; then
-	val=$($P -c "SELECT v FROM t WHERE id=1;" 2>/dev/null)
+	# hot standby accepts connections during recovery, so retry until replay has
+	# rebuilt the table from WAL (it does not exist until CREATE TABLE is replayed)
+	val=
+	for _ in $(seq 1 100); do
+		val=$($P -c "SELECT v FROM t WHERE id=1;" 2>/dev/null)
+		[ "$val" = "changed" ] && break
+		sleep 0.2
+	done
 	if [ "$val" = "changed" ]; then
 		echo "ok   - table read served from the store (local heap removed); redo built it from WAL"
 		echo "wal-only redo demo: PASS"


### PR DESCRIPTION
Adds an optional, higher-performance **SPDK (userspace NVMe) storage backend**
for the page-store daemon. The IPC ABI and the compute side are unchanged: a
machine that cannot run SPDK keeps using the portable POSIX backend, and SPDK is
just a second storage implementation inside the daemon. Stacked on #5.

See `contrib/pagestore/SPDK_NOTES.md` for the full research + staged plan and
`DESIGN_NOTES.md` #3 for the cache direction.

## What's here (S0 → S1.2c-3)

- **Pluggable storage seam.** All of the daemon's raw byte movement and
  enumeration go through a `PsStorage` vtable (`pagestore_storage.h`);
  `storage_posix.c` is the libc-only default (the prior file layout, moved
  verbatim). The store's brain — indexes, COW/read-through, timelines, per-page
  WAL index, recovery, `ps_handle_meta` — is extracted to `pagestore_core.{c,h}`
  and compiled into both daemons.
- **Two binaries, one brain.** `pagestore_daemon` (POSIX, synchronous, unchanged
  behaviour) and `pagestore_daemon_spdk` (opt-in, built by `spdk_build.sh`, links
  SPDK in library mode). Both reuse `pagestore_core.c`.
- **Real NVMe I/O.** `storage_spdk.c` serves page segments from the raw namespace
  via async `spdk_nvme_ns_cmd_*`; shipped WAL + timeline metadata stay on the
  filesystem for now (small, not hot). Segment count persists in
  `<store>/spdk_super`.
- **Cross-channel async loop.** The SPDK daemon overlaps many channels' page
  reads on the NVMe queue (256-buffer DMA pool, per-channel in-flight tracking,
  completion-driven replies).

## Validation

- The SPDK daemon is argument-compatible with the standalone harness, so
  `sudo PS_SPDK_PCI=<addr> ./pagestore_test ./pagestore_daemon_spdk` runs the full
  suite: **110/110** (page I/O, COW, branches, shipped WAL, vectored I/O,
  8-client concurrency, daemon-restart recovery — pages on real NVMe).
- The POSIX daemon and its CI job are unaffected (SPDK is not wired into meson;
  it needs a local SPDK build + a vfio-bound disk).
- `pagestore_bench.c` (indicative): random reads scale with concurrency —
  1 client 671 MiB/s, 4 → 2167, 16 → 2443 MiB/s (313 Kpages/s).

## Not in this PR (recorded as design)

The benchmark shows SPDK loses *sequential* reads only because it gave up the
kernel page cache + readahead. The next step is a **database-adapted
materialization cache** (cache page versions to skip device read *and* redo;
value-aware, scan-resistant; unified with the LSM image layers) — not a generic
block cache. See `DESIGN_NOTES.md` #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)