### PR TITLE
contrib/pagestore: LSM layer foundation hardening + CI

### DIFF
--- a/.github/workflows/pagestore-test.yml
+++ b/.github/workflows/pagestore-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Compile daemon and test harness
         working-directory: contrib/pagestore
         run: |
-          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c pagestore_core.c storage_posix.c -lrt
+          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c pagestore_core.c storage_posix.c pagestore_layer.c pagestore_layer_store.c pagestore_manifest.c -lrt
           cc -O2 -Wall -Wextra -Werror -o pagestore_test   pagestore_test.c   -lrt
 
       - name: Run standalone test suite

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -24,20 +24,29 @@ ps_layer_map_free(PsLayerMap *map)
 }
 
 int
-ps_layer_map_add(PsLayerMap *map, const PsLayerDesc *desc)
+ps_layer_map_reserve(PsLayerMap *map, uint32_t capacity)
 {
-	if (map->nlayers == map->capacity)
+	if (capacity > map->capacity)
 	{
 		uint32_t	newcap = map->capacity ? map->capacity * 2 : 64;
 		PsLayerDesc *newlayers;
 
+		while (newcap < capacity)
+			newcap *= 2;
 		newlayers = realloc(map->layers, (size_t) newcap * sizeof(PsLayerDesc));
 		if (newlayers == NULL)
 			return -1;
 		map->layers = newlayers;
 		map->capacity = newcap;
 	}
+	return 0;
+}
 
+int
+ps_layer_map_add(PsLayerMap *map, const PsLayerDesc *desc)
+{
+	if (ps_layer_map_reserve(map, map->nlayers + 1) != 0)
+		return -1;
 	map->layers[map->nlayers++] = *desc;
 	return 0;
 }

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -75,6 +75,7 @@ typedef struct PsLayerMap
 
 extern void ps_layer_map_init(PsLayerMap *map);
 extern void ps_layer_map_free(PsLayerMap *map);
+extern int	ps_layer_map_reserve(PsLayerMap *map, uint32_t capacity);
 extern int	ps_layer_map_add(PsLayerMap *map, const PsLayerDesc *desc);
 extern uint32_t ps_layer_map_count(const PsLayerMap *map);
 

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -17,6 +17,7 @@
 
 #include "pagestore_ipc.h"
 
+#define PS_LAYER_MAX_LOCATIONS	3
 #define PS_LAYER_URI_MAX	512
 
 typedef enum PsLayerKind
@@ -56,7 +57,7 @@ typedef struct PsLayerDesc
 	uint64_t	lsn_end;
 
 	uint32_t	location_count;
-	PsLayerLocation locations[3];
+	PsLayerLocation locations[PS_LAYER_MAX_LOCATIONS];
 
 	uint64_t	created_at_lsn;
 	uint64_t	remote_uploaded_lsn;

--- a/contrib/pagestore/pagestore_layer_store.c
+++ b/contrib/pagestore/pagestore_layer_store.c
@@ -154,6 +154,7 @@ static int
 local_delete_local_layer(const PsLayerDesc *layer)
 {
 	int			rc = 0;
+	int			unlinked = 0;
 	uint32_t	nlocs;
 
 	nlocs = layer->location_count;
@@ -168,8 +169,12 @@ local_delete_local_layer(const PsLayerDesc *layer)
 		{
 			if (unlink(layer->locations[i].uri) != 0 && errno != ENOENT)
 				rc = -1;
+			else
+				unlinked = 1;
 		}
 	}
+	if (unlinked && local_fsync_dir() != 0)
+		rc = -1;
 	return rc;
 }
 

--- a/contrib/pagestore/pagestore_layer_store.c
+++ b/contrib/pagestore/pagestore_layer_store.c
@@ -23,7 +23,11 @@ const PsLayerStore *ps_layer_store = &PsLayerStoreLocal;
 static int
 local_open(const char *store_dir)
 {
-	snprintf(layer_dir, sizeof(layer_dir), "%s", store_dir);
+	int			n;
+
+	n = snprintf(layer_dir, sizeof(layer_dir), "%s", store_dir);
+	if (n < 0 || (size_t) n >= sizeof(layer_dir))
+		return -1;
 	return 0;
 }
 
@@ -33,11 +37,16 @@ local_close(void)
 	layer_dir[0] = '\0';
 }
 
-static void
+static int
 local_layer_path(uint64_t layer_id, char *buf, size_t buflen)
 {
-	snprintf(buf, buflen, "%s/layer_%016llx",
-			 layer_dir, (unsigned long long) layer_id);
+	int			n;
+
+	n = snprintf(buf, buflen, "%s/layer_%016llx",
+				 layer_dir, (unsigned long long) layer_id);
+	if (n < 0 || (size_t) n >= buflen)
+		return -1;
+	return 0;
 }
 
 static int
@@ -45,13 +54,20 @@ local_create_local_layer(uint64_t layer_id, char *uri, uint32_t uri_len)
 {
 	char		path[4096];
 	int			fd;
+	int			n;
 
-	local_layer_path(layer_id, path, sizeof(path));
+	if (local_layer_path(layer_id, path, sizeof(path)) != 0)
+		return -1;
 	fd = open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
 	if (fd < 0)
 		return -1;
 	close(fd);
-	snprintf(uri, uri_len, "%s", path);
+	n = snprintf(uri, uri_len, "%s", path);
+	if (n < 0 || (uint32_t) n >= uri_len)
+	{
+		unlink(path);
+		return -1;
+	}
 	return 0;
 }
 
@@ -69,8 +85,13 @@ local_read_layer_block(const PsLayerDesc *layer, uint64_t off,
 	const char *path = NULL;
 	int			fd;
 	ssize_t		n;
+	uint32_t	nlocs;
 
-	for (uint32_t i = 0; i < layer->location_count; i++)
+	nlocs = layer->location_count;
+	if (nlocs > PS_LAYER_MAX_LOCATIONS)
+		return -1;
+
+	for (uint32_t i = 0; i < nlocs; i++)
 	{
 		if ((layer->locations[i].tier == PS_LAYER_TIER_LOCAL_HOT ||
 			 layer->locations[i].tier == PS_LAYER_TIER_LOCAL_COLD) &&
@@ -104,8 +125,13 @@ static int
 local_delete_local_layer(const PsLayerDesc *layer)
 {
 	int			rc = 0;
+	uint32_t	nlocs;
 
-	for (uint32_t i = 0; i < layer->location_count; i++)
+	nlocs = layer->location_count;
+	if (nlocs > PS_LAYER_MAX_LOCATIONS)
+		return -1;
+
+	for (uint32_t i = 0; i < nlocs; i++)
 	{
 		if ((layer->locations[i].tier == PS_LAYER_TIER_LOCAL_HOT ||
 			 layer->locations[i].tier == PS_LAYER_TIER_LOCAL_COLD) &&

--- a/contrib/pagestore/pagestore_layer_store.c
+++ b/contrib/pagestore/pagestore_layer_store.c
@@ -50,6 +50,20 @@ local_layer_path(uint64_t layer_id, char *buf, size_t buflen)
 }
 
 static int
+local_fsync_dir(void)
+{
+	int			fd;
+	int			rc;
+
+	fd = open(layer_dir, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	rc = fsync(fd);
+	close(fd);
+	return rc;
+}
+
+static int
 local_create_local_layer(uint64_t layer_id, char *uri, uint32_t uri_len)
 {
 	char		path[4096];
@@ -62,6 +76,11 @@ local_create_local_layer(uint64_t layer_id, char *uri, uint32_t uri_len)
 	if (fd < 0)
 		return -1;
 	close(fd);
+	if (local_fsync_dir() != 0)
+	{
+		unlink(path);
+		return -1;
+	}
 	n = snprintf(uri, uri_len, "%s", path);
 	if (n < 0 || (uint32_t) n >= uri_len)
 	{

--- a/contrib/pagestore/pagestore_layer_store.c
+++ b/contrib/pagestore/pagestore_layer_store.c
@@ -74,8 +74,18 @@ local_create_local_layer(uint64_t layer_id, char *uri, uint32_t uri_len)
 static int
 local_seal_local_layer(uint64_t layer_id)
 {
-	(void) layer_id;
-	return 0;
+	char		path[4096];
+	int			fd;
+	int			rc;
+
+	if (local_layer_path(layer_id, path, sizeof(path)) != 0)
+		return -1;
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	rc = fsync(fd);
+	close(fd);
+	return rc;
 }
 
 static int

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -101,6 +101,12 @@ manifest_find_layer(PsLayerMap *map, uint64_t layer_id)
 }
 
 static int
+manifest_layer_exists(PsLayerMap *map, uint64_t layer_id)
+{
+	return manifest_find_layer(map, layer_id) != NULL;
+}
+
+static int
 manifest_layer_desc_valid(const PsLayerDesc *desc)
 {
 	return desc->location_count <= PS_LAYER_MAX_LOCATIONS;
@@ -201,7 +207,8 @@ ps_manifest_replay(PsLayerMap *map)
 						goto done;	/* torn tail */
 					}
 					if (!manifest_layer_desc_valid(&desc) ||
-						ps_layer_map_add(map, &desc) != 0)
+						(!manifest_layer_exists(map, desc.layer_id) &&
+						 ps_layer_map_add(map, &desc) != 0))
 					{
 						close(fd);
 						return -1;
@@ -340,6 +347,8 @@ ps_manifest_add_layer(const PsLayerDesc *desc)
 {
 	if (!manifest_layer_desc_valid(desc))
 		return -1;
+	if (manifest_layer_exists(&ps_layer_map, desc->layer_id))
+		return 0;
 	if (manifest_append(PS_MANIFEST_ADD_LAYER, desc, sizeof(*desc)) != 0)
 		return -1;
 	return ps_layer_map_add(&ps_layer_map, desc);

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -80,6 +80,12 @@ manifest_find_layer(PsLayerMap *map, uint64_t layer_id)
 	return NULL;
 }
 
+static int
+manifest_layer_desc_valid(const PsLayerDesc *desc)
+{
+	return desc->location_count <= PS_LAYER_MAX_LOCATIONS;
+}
+
 static void
 manifest_remove_from_map(PsLayerMap *map, uint64_t layer_id)
 {
@@ -132,8 +138,9 @@ ps_manifest_replay(PsLayerMap *map)
 		n = read(fd, &rec, sizeof(rec));
 		if (n == 0)
 			break;
-		if (n != (ssize_t) sizeof(rec) ||
-			rec.magic != PS_MANIFEST_MAGIC ||
+		if (n != (ssize_t) sizeof(rec))
+			break;				/* torn tail */
+		if (rec.magic != PS_MANIFEST_MAGIC ||
 			rec.version != PS_MANIFEST_VERSION)
 		{
 			close(fd);
@@ -145,9 +152,17 @@ ps_manifest_replay(PsLayerMap *map)
 			case PS_MANIFEST_ADD_LAYER:
 				{
 					PsLayerDesc desc;
+					ssize_t		nread;
 
-					if (rec.len != sizeof(desc) ||
-						read(fd, &desc, sizeof(desc)) != (ssize_t) sizeof(desc) ||
+					if (rec.len != sizeof(desc))
+					{
+						close(fd);
+						return -1;
+					}
+					nread = read(fd, &desc, sizeof(desc));
+					if (nread != (ssize_t) sizeof(desc))
+						goto done;	/* torn tail */
+					if (!manifest_layer_desc_valid(&desc) ||
 						ps_layer_map_add(map, &desc) != 0)
 					{
 						close(fd);
@@ -160,13 +175,16 @@ ps_manifest_replay(PsLayerMap *map)
 				{
 					PsManifestLayerIdEvent ev;
 					PsLayerDesc *layer;
+					ssize_t		nread;
 
-					if (rec.len != sizeof(ev) ||
-						read(fd, &ev, sizeof(ev)) != (ssize_t) sizeof(ev))
+					if (rec.len != sizeof(ev))
 					{
 						close(fd);
 						return -1;
 					}
+					nread = read(fd, &ev, sizeof(ev));
+					if (nread != (ssize_t) sizeof(ev))
+						goto done;	/* torn tail */
 					layer = manifest_find_layer(map, ev.layer_id);
 					if (layer != NULL)
 					{
@@ -180,13 +198,16 @@ ps_manifest_replay(PsLayerMap *map)
 				{
 					PsManifestLayerIdEvent ev;
 					PsLayerDesc *layer;
+					ssize_t		nread;
 
-					if (rec.len != sizeof(ev) ||
-						read(fd, &ev, sizeof(ev)) != (ssize_t) sizeof(ev))
+					if (rec.len != sizeof(ev))
 					{
 						close(fd);
 						return -1;
 					}
+					nread = read(fd, &ev, sizeof(ev));
+					if (nread != (ssize_t) sizeof(ev))
+						goto done;	/* torn tail */
 					layer = manifest_find_layer(map, ev.layer_id);
 					if (layer != NULL)
 						layer->deleting = true;
@@ -196,13 +217,16 @@ ps_manifest_replay(PsLayerMap *map)
 			case PS_MANIFEST_REMOVE_LAYER:
 				{
 					PsManifestLayerIdEvent ev;
+					ssize_t		nread;
 
-					if (rec.len != sizeof(ev) ||
-						read(fd, &ev, sizeof(ev)) != (ssize_t) sizeof(ev))
+					if (rec.len != sizeof(ev))
 					{
 						close(fd);
 						return -1;
 					}
+					nread = read(fd, &ev, sizeof(ev));
+					if (nread != (ssize_t) sizeof(ev))
+						goto done;	/* torn tail */
 					manifest_remove_from_map(map, ev.layer_id);
 					break;
 				}
@@ -211,13 +235,16 @@ ps_manifest_replay(PsLayerMap *map)
 				{
 					PsManifestLayerIdEvent ev;
 					PsLayerDesc *layer;
+					ssize_t		nread;
 
-					if (rec.len != sizeof(ev) ||
-						read(fd, &ev, sizeof(ev)) != (ssize_t) sizeof(ev))
+					if (rec.len != sizeof(ev))
 					{
 						close(fd);
 						return -1;
 					}
+					nread = read(fd, &ev, sizeof(ev));
+					if (nread != (ssize_t) sizeof(ev))
+						goto done;	/* torn tail */
 					layer = manifest_find_layer(map, ev.layer_id);
 					if (layer != NULL)
 					{
@@ -237,6 +264,7 @@ ps_manifest_replay(PsLayerMap *map)
 		}
 	}
 
+done:
 	close(fd);
 	return 0;
 }
@@ -244,6 +272,8 @@ ps_manifest_replay(PsLayerMap *map)
 int
 ps_manifest_add_layer(const PsLayerDesc *desc)
 {
+	if (!manifest_layer_desc_valid(desc))
+		return -1;
 	if (manifest_append(PS_MANIFEST_ADD_LAYER, desc, sizeof(*desc)) != 0)
 		return -1;
 	return ps_layer_map_add(&ps_layer_map, desc);

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -13,6 +13,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "pagestore_manifest.h"
@@ -42,6 +43,45 @@ typedef struct PsManifestLayerIdEvent
 	uint64_t	layer_id;
 	uint64_t	value;
 } PsManifestLayerIdEvent;
+
+typedef struct PsManifestKeyDisk
+{
+	uint32_t	spcOid;
+	uint32_t	dbOid;
+	uint32_t	relNumber;
+	int32_t		forkNum;
+} PsManifestKeyDisk;
+
+typedef struct PsManifestLocationDisk
+{
+	uint32_t	tier;
+	char		uri[PS_LAYER_URI_MAX];
+	uint64_t	size;
+	uint32_t	generation;
+	uint8_t		available;
+	uint8_t		pad[3];
+} PsManifestLocationDisk;
+
+typedef struct PsManifestLayerDisk
+{
+	uint64_t	layer_id;
+	uint32_t	kind;
+	uint32_t	timeline;
+	PsManifestKeyDisk start_key;
+	PsManifestKeyDisk end_key;
+	uint32_t	start_block;
+	uint32_t	end_block;
+	uint64_t	lsn_start;
+	uint64_t	lsn_end;
+	uint32_t	location_count;
+	PsManifestLocationDisk locations[PS_LAYER_MAX_LOCATIONS];
+	uint64_t	created_at_lsn;
+	uint64_t	remote_uploaded_lsn;
+	uint8_t		remote_durable;
+	uint8_t		local_pinned;
+	uint8_t		deleting;
+	uint8_t		pad;
+} PsManifestLayerDisk;
 
 static char manifest_path[4096];
 static char manifest_dir[2048];
@@ -113,6 +153,92 @@ manifest_layer_desc_valid(const PsLayerDesc *desc)
 }
 
 static void
+manifest_encode_key(PsManifestKeyDisk *dst, const PsKey *src)
+{
+	dst->spcOid = src->spcOid;
+	dst->dbOid = src->dbOid;
+	dst->relNumber = src->relNumber;
+	dst->forkNum = src->forkNum;
+}
+
+static void
+manifest_decode_key(PsKey *dst, const PsManifestKeyDisk *src)
+{
+	dst->spcOid = src->spcOid;
+	dst->dbOid = src->dbOid;
+	dst->relNumber = src->relNumber;
+	dst->forkNum = src->forkNum;
+}
+
+static int
+manifest_encode_layer(PsManifestLayerDisk *dst, const PsLayerDesc *src)
+{
+	if (!manifest_layer_desc_valid(src))
+		return -1;
+	memset(dst, 0, sizeof(*dst));
+	dst->layer_id = src->layer_id;
+	dst->kind = (uint32_t) src->kind;
+	dst->timeline = src->timeline;
+	manifest_encode_key(&dst->start_key, &src->start_key);
+	manifest_encode_key(&dst->end_key, &src->end_key);
+	dst->start_block = src->start_block;
+	dst->end_block = src->end_block;
+	dst->lsn_start = src->lsn_start;
+	dst->lsn_end = src->lsn_end;
+	dst->location_count = src->location_count;
+	for (uint32_t i = 0; i < src->location_count; i++)
+	{
+		dst->locations[i].tier = (uint32_t) src->locations[i].tier;
+		memcpy(dst->locations[i].uri, src->locations[i].uri,
+			   sizeof(dst->locations[i].uri));
+		dst->locations[i].uri[PS_LAYER_URI_MAX - 1] = '\0';
+		dst->locations[i].size = src->locations[i].size;
+		dst->locations[i].generation = src->locations[i].generation;
+		dst->locations[i].available = src->locations[i].available ? 1 : 0;
+	}
+	dst->created_at_lsn = src->created_at_lsn;
+	dst->remote_uploaded_lsn = src->remote_uploaded_lsn;
+	dst->remote_durable = src->remote_durable ? 1 : 0;
+	dst->local_pinned = src->local_pinned ? 1 : 0;
+	dst->deleting = src->deleting ? 1 : 0;
+	return 0;
+}
+
+static int
+manifest_decode_layer(PsLayerDesc *dst, const PsManifestLayerDisk *src)
+{
+	if (src->location_count > PS_LAYER_MAX_LOCATIONS)
+		return -1;
+	memset(dst, 0, sizeof(*dst));
+	dst->layer_id = src->layer_id;
+	dst->kind = (PsLayerKind) src->kind;
+	dst->timeline = src->timeline;
+	manifest_decode_key(&dst->start_key, &src->start_key);
+	manifest_decode_key(&dst->end_key, &src->end_key);
+	dst->start_block = src->start_block;
+	dst->end_block = src->end_block;
+	dst->lsn_start = src->lsn_start;
+	dst->lsn_end = src->lsn_end;
+	dst->location_count = src->location_count;
+	for (uint32_t i = 0; i < src->location_count; i++)
+	{
+		dst->locations[i].tier = (PsLayerTier) src->locations[i].tier;
+		memcpy(dst->locations[i].uri, src->locations[i].uri,
+			   sizeof(dst->locations[i].uri));
+		dst->locations[i].uri[PS_LAYER_URI_MAX - 1] = '\0';
+		dst->locations[i].size = src->locations[i].size;
+		dst->locations[i].generation = src->locations[i].generation;
+		dst->locations[i].available = src->locations[i].available != 0;
+	}
+	dst->created_at_lsn = src->created_at_lsn;
+	dst->remote_uploaded_lsn = src->remote_uploaded_lsn;
+	dst->remote_durable = src->remote_durable != 0;
+	dst->local_pinned = src->local_pinned != 0;
+	dst->deleting = src->deleting != 0;
+	return 0;
+}
+
+static void
 manifest_remove_from_map(PsLayerMap *map, uint64_t layer_id)
 {
 	for (uint32_t i = 0; i < map->nlayers; i++)
@@ -156,6 +282,8 @@ ps_manifest_replay(PsLayerMap *map)
 	int			fd;
 	off_t		good_off = 0;
 	int			truncate_tail = 0;
+	off_t		file_size;
+	struct stat st;
 
 	fd = open(manifest_path, O_RDWR);
 	if (fd < 0)
@@ -164,6 +292,12 @@ ps_manifest_replay(PsLayerMap *map)
 			return 0;
 		return -1;
 	}
+	if (fstat(fd, &st) != 0)
+	{
+		close(fd);
+		return -1;
+	}
+	file_size = st.st_size;
 
 	for (;;)
 	{
@@ -183,6 +317,12 @@ ps_manifest_replay(PsLayerMap *map)
 		if (rec.magic != PS_MANIFEST_MAGIC ||
 			rec.version != PS_MANIFEST_VERSION)
 		{
+			if (rec_off + (off_t) sizeof(rec) >= file_size)
+			{
+				truncate_tail = 1;
+				good_off = rec_off;
+				break;			/* invalid torn tail header */
+			}
 			close(fd);
 			return -1;
 		}
@@ -191,22 +331,23 @@ ps_manifest_replay(PsLayerMap *map)
 		{
 			case PS_MANIFEST_ADD_LAYER:
 				{
+					PsManifestLayerDisk disk;
 					PsLayerDesc desc;
 					ssize_t		nread;
 
-					if (rec.len != sizeof(desc))
+					if (rec.len != sizeof(disk))
 					{
 						close(fd);
 						return -1;
 					}
-					nread = read(fd, &desc, sizeof(desc));
-					if (nread != (ssize_t) sizeof(desc))
+					nread = read(fd, &disk, sizeof(disk));
+					if (nread != (ssize_t) sizeof(disk))
 					{
 						truncate_tail = 1;
 						good_off = rec_off;
 						goto done;	/* torn tail */
 					}
-					if (!manifest_layer_desc_valid(&desc) ||
+					if (manifest_decode_layer(&desc, &disk) != 0 ||
 						(!manifest_layer_exists(map, desc.layer_id) &&
 						 ps_layer_map_add(map, &desc) != 0))
 					{
@@ -345,11 +486,17 @@ done:
 int
 ps_manifest_add_layer(const PsLayerDesc *desc)
 {
+	PsManifestLayerDisk disk;
+
 	if (!manifest_layer_desc_valid(desc))
 		return -1;
 	if (manifest_layer_exists(&ps_layer_map, desc->layer_id))
 		return 0;
-	if (manifest_append(PS_MANIFEST_ADD_LAYER, desc, sizeof(*desc)) != 0)
+	if (ps_layer_map_reserve(&ps_layer_map, ps_layer_map_count(&ps_layer_map) + 1) != 0)
+		return -1;
+	if (manifest_encode_layer(&disk, desc) != 0)
+		return -1;
+	if (manifest_append(PS_MANIFEST_ADD_LAYER, &disk, sizeof(disk)) != 0)
 		return -1;
 	return ps_layer_map_add(&ps_layer_map, desc);
 }

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -44,7 +44,22 @@ typedef struct PsManifestLayerIdEvent
 } PsManifestLayerIdEvent;
 
 static char manifest_path[4096];
+static char manifest_dir[2048];
 PsLayerMap ps_layer_map;
+
+static int
+manifest_fsync_dir(void)
+{
+	int			fd;
+	int			rc;
+
+	fd = open(manifest_dir, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	rc = fsync(fd);
+	close(fd);
+	return rc;
+}
 
 static int
 manifest_append(uint32_t type, const void *payload, uint32_t len)
@@ -52,10 +67,13 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 	PsManifestRecord rec;
 	int			fd;
 	int			rc = 0;
+	int			created = 0;
 
 	fd = open(manifest_path, O_WRONLY | O_APPEND | O_CREAT, 0600);
 	if (fd < 0)
 		return -1;
+	if (lseek(fd, 0, SEEK_END) == 0)
+		created = 1;
 
 	rec.magic = PS_MANIFEST_MAGIC;
 	rec.version = PS_MANIFEST_VERSION;
@@ -66,6 +84,8 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 		(len > 0 && write(fd, payload, len) != (ssize_t) len))
 		rc = -1;
 	if (fsync(fd) != 0)
+		rc = -1;
+	if (created && manifest_fsync_dir() != 0)
 		rc = -1;
 	close(fd);
 	return rc;
@@ -105,7 +125,14 @@ manifest_remove_from_map(PsLayerMap *map, uint64_t layer_id)
 int
 ps_manifest_open(const char *store_dir)
 {
-	snprintf(manifest_path, sizeof(manifest_path), "%s/layers.manifest", store_dir);
+	int			n;
+
+	n = snprintf(manifest_dir, sizeof(manifest_dir), "%s", store_dir);
+	if (n < 0 || (size_t) n >= sizeof(manifest_dir))
+		return -1;
+	n = snprintf(manifest_path, sizeof(manifest_path), "%s/layers.manifest", store_dir);
+	if (n < 0 || (size_t) n >= sizeof(manifest_path))
+		return -1;
 	ps_layer_map_init(&ps_layer_map);
 	return 0;
 }
@@ -121,8 +148,10 @@ int
 ps_manifest_replay(PsLayerMap *map)
 {
 	int			fd;
+	off_t		good_off = 0;
+	int			truncate_tail = 0;
 
-	fd = open(manifest_path, O_RDONLY);
+	fd = open(manifest_path, O_RDWR);
 	if (fd < 0)
 	{
 		if (errno == ENOENT)
@@ -134,12 +163,17 @@ ps_manifest_replay(PsLayerMap *map)
 	{
 		PsManifestRecord rec;
 		ssize_t		n;
+		off_t		rec_off = good_off;
 
 		n = read(fd, &rec, sizeof(rec));
 		if (n == 0)
 			break;
 		if (n != (ssize_t) sizeof(rec))
+		{
+			truncate_tail = 1;
+			good_off = rec_off;
 			break;				/* torn tail */
+		}
 		if (rec.magic != PS_MANIFEST_MAGIC ||
 			rec.version != PS_MANIFEST_VERSION)
 		{
@@ -161,7 +195,11 @@ ps_manifest_replay(PsLayerMap *map)
 					}
 					nread = read(fd, &desc, sizeof(desc));
 					if (nread != (ssize_t) sizeof(desc))
+					{
+						truncate_tail = 1;
+						good_off = rec_off;
 						goto done;	/* torn tail */
+					}
 					if (!manifest_layer_desc_valid(&desc) ||
 						ps_layer_map_add(map, &desc) != 0)
 					{
@@ -184,7 +222,11 @@ ps_manifest_replay(PsLayerMap *map)
 					}
 					nread = read(fd, &ev, sizeof(ev));
 					if (nread != (ssize_t) sizeof(ev))
+					{
+						truncate_tail = 1;
+						good_off = rec_off;
 						goto done;	/* torn tail */
+					}
 					layer = manifest_find_layer(map, ev.layer_id);
 					if (layer != NULL)
 					{
@@ -207,7 +249,11 @@ ps_manifest_replay(PsLayerMap *map)
 					}
 					nread = read(fd, &ev, sizeof(ev));
 					if (nread != (ssize_t) sizeof(ev))
+					{
+						truncate_tail = 1;
+						good_off = rec_off;
 						goto done;	/* torn tail */
+					}
 					layer = manifest_find_layer(map, ev.layer_id);
 					if (layer != NULL)
 						layer->deleting = true;
@@ -226,7 +272,11 @@ ps_manifest_replay(PsLayerMap *map)
 					}
 					nread = read(fd, &ev, sizeof(ev));
 					if (nread != (ssize_t) sizeof(ev))
+					{
+						truncate_tail = 1;
+						good_off = rec_off;
 						goto done;	/* torn tail */
+					}
 					manifest_remove_from_map(map, ev.layer_id);
 					break;
 				}
@@ -244,7 +294,11 @@ ps_manifest_replay(PsLayerMap *map)
 					}
 					nread = read(fd, &ev, sizeof(ev));
 					if (nread != (ssize_t) sizeof(ev))
+					{
+						truncate_tail = 1;
+						good_off = rec_off;
 						goto done;	/* torn tail */
+					}
 					layer = manifest_find_layer(map, ev.layer_id);
 					if (layer != NULL)
 					{
@@ -262,9 +316,21 @@ ps_manifest_replay(PsLayerMap *map)
 				close(fd);
 				return -1;
 		}
+		good_off = lseek(fd, 0, SEEK_CUR);
+		if (good_off < 0)
+		{
+			close(fd);
+			return -1;
+		}
 	}
 
 done:
+	if (truncate_tail &&
+		(ftruncate(fd, good_off) != 0 || fsync(fd) != 0))
+	{
+		close(fd);
+		return -1;
+	}
 	close(fd);
 	return 0;
 }


### PR DESCRIPTION
Hardens the LSM layer-metadata foundation on top of the merged foundation: manifest skeleton/replay hardening, durability hooks, idempotent layer adds, and a standalone-CI link fix. No functional engine change yet — groundwork the image-layer phases build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)