### PR TITLE
contrib/pagestore: delta layers + read plan (LSM phase 7a/7b)

### DIFF
--- a/contrib/pagestore/LSM_ARCHITECTURE.md
+++ b/contrib/pagestore/LSM_ARCHITECTURE.md
@@ -3,6 +3,9 @@
 This document describes the intended LSM-like architecture for `contrib/pagestore`.
 It complements `LSM_OBJECT_STORAGE_PLAN.md`: that document is the phased plan;
 this document is the target architecture and module boundary reference.
+See `MATERIALIZATION.md` for the deployment-agnostic ingest/materialize
+abstraction (page-ingest vs wal-ingest, and where redo runs: local worker vs
+cloud serverless) that this layer model plugs into.
 
 ## Design intent
 

--- a/contrib/pagestore/MATERIALIZATION.md
+++ b/contrib/pagestore/MATERIALIZATION.md
@@ -1,0 +1,154 @@
+# pagestore — ingest & materialization abstraction
+
+How changes *enter* the store (ingest) and how a logical "page as of an LSN" is
+*produced* (materialize) are abstracted behind narrow interfaces, so that the
+**same logical pipeline runs unchanged on POSIX, SPDK and cloud** — only the
+backend bindings (and *where* materialization runs) differ.
+
+This doc sits above [`LSM_ARCHITECTURE.md`](LSM_ARCHITECTURE.md) (the layer
+model, read planner, compaction/GC), [`WAL_REDO.md`](WAL_REDO.md) (the redo
+mechanics) and [`LSM_OBJECT_STORAGE_PLAN.md`](LSM_OBJECT_STORAGE_PLAN.md)
+(tiering). It defines the *deployment-agnostic* contract those pieces plug into.
+
+## First principle: WAL is truth, page is a materialized view
+
+A page is never the unit that *must* be durable — the change is. The durable
+record can be either the **page** (page-ingest) or the **WAL** (wal-ingest); a
+page at a given LSN is then a *view* derived from the nearest base image plus the
+WAL deltas after it. Two corollaries drive the whole design:
+
+1. **Redo (WAL→page) is a materialization step, never on the hot read path.**
+   Reads return an already-materialized versioned page (from a cache or an image
+   layer). Materialization happens at *ingest time*, in the *background*, or for
+   *cold* pages — but a hot read pays no redo. (This is the Aurora placement, not
+   Neon's read-time redo; it keeps local-NVMe reads fast.)
+2. **Pages are cached at multiple tiers; only one tier is authoritative.** The
+   compute-local cache (RAM buffer pool + local-NVMe page cache, à la Neon LFC /
+   Aurora Optimized Reads) accelerates reads and is *non-authoritative* (rebuilt
+   on miss). The store's sealed image layers are the durable authority.
+
+## The two abstract operations
+
+### `ship` — get a change into the store durably
+
+Ingest is a *policy*, expressed over the existing IPC opcodes:
+
+| policy | what crosses to the store | lands in | seals to |
+|--------|---------------------------|----------|----------|
+| **page-ingest** | full page (`WRITEV`/`EXTEND`) | memtable | image layer |
+| **wal-ingest**  | WAL records (`WAL_APPEND`)   | delta staging | delta layer |
+
+Both go through the *same* shape: `ship → mutable staging → sealed immutable
+layer → manifest`. page-ingest seals **image** layers (already materialized);
+wal-ingest seals **delta** layers (need materialization to become pages).
+
+The choice is per-deployment policy, not a code fork (see the binding table).
+
+### `materialize` — turn (base image + delta chain) into an image-layer page
+
+```
+materialize(timeline, key, block, target_lsn)
+   = read plan (LSM_ARCHITECTURE read path):
+       base = newest image layer version <= target_lsn
+       deltas = delta layers covering (base_lsn, target_lsn]   (ascending)
+   -> apply deltas onto base via PG rm_redo
+   -> new image-layer page version  -> manifest ADD_LAYER
+```
+
+This is the **only** place redo runs. It is pluggable in *where* it runs — the
+`PsMaterializer` binding:
+
+| binding | runs where | redo engine | writes result to | use |
+|---------|-----------|-------------|------------------|-----|
+| **inline-none** | n/a | none | — | page-ingest: pages already materialized |
+| **local-worker** | same host (sidecar / recovery-worker-style PG in recovery) | `rm_redo` in an isolated context | local image layer + manifest | POSIX / SPDK wal-ingest |
+| **serverless** | cloud (Lambda/fn) | `rm_redo` reading layer objects from S3 | new image-layer **object** in S3 + manifest | cloud wal-ingest |
+
+Crucially the *input* (a read plan: base image object + ordered delta payloads)
+and the *output* (an image-layer page version, recorded in the manifest) are
+identical across bindings. On cloud, S3 only stores immutable layer **bytes**;
+the Lambda is the compute that reads base+deltas and produces the page — "S3
+materializes" is shorthand for "a serverless function materializes from S3".
+
+## One pipeline, three deployments
+
+```text
+              ┌─────────── ship (page | wal) ───────────┐
+ PG backend ─►│  staging (memtable | delta staging)     │
+              │      │ seal                              │
+              │      ▼                                   │
+              │  immutable layer (image | delta) ──► manifest
+              └──────────────────┬──────────────────────┘
+                                 │ (wal-ingest only)
+                    materialize (inline | local-worker | serverless)
+                                 │  rm_redo: base + deltas -> image layer
+                                 ▼
+                          image layer ──► manifest
+   read: getPage@LSN ─► page cache (compute-local ─► storage) ─► versioned image layer
+                         (no redo on this path)
+```
+
+The boxes are deployment-invariant. Only the bindings below change.
+
+### Backend binding table
+
+| concern | abstraction | POSIX | SPDK | Cloud |
+|---------|-------------|-------|------|-------|
+| byte log (seg/wal/meta) | `PsStorage` | posix files | spdk nvme | posix on instance disk |
+| layer files (local/hot) | `PsLayerStore` | posix files | spdk/posix | local cache of objects |
+| layer object tier (cold) | `PsLayerStore` object ops | none | none | **S3** |
+| ingest policy | `ship` | page (now) → wal | page → wal | **wal** |
+| materializer | `PsMaterializer` | inline / local-worker | local-worker | **serverless (Lambda)** |
+| compute page cache | materialized-page cache | RAM + local NVMe | RAM + local NVMe | RAM + local NVMe (LFC) |
+| read | read planner + cache | uniform — versioned image layers | uniform | uniform |
+
+Reading down a column gives a complete, consistent deployment. Reading across a
+row shows the *only* thing that varies is the binding — the pipeline is the same.
+
+## Invariants (must hold in every binding)
+
+- **No redo on the hot read path.** Reads resolve to a cached or sealed image
+  page; redo is confined to `materialize`.
+- **Materialize is off the foreground ack path.** `ship` acks once the change is
+  durable (page in staging+seg, or WAL durably appended). Materialization is
+  asynchronous/background/on-demand-for-cold, never blocking commit.
+- **Install-new-before-delete-old / idempotent GC** carry over unchanged from
+  `LSM_ARCHITECTURE.md` regardless of where materialize ran.
+- **The materializer's output is a normal image layer.** Whether produced by a
+  local worker or a Lambda, it is an ordinary sealed image layer recorded in the
+  manifest — the read path cannot tell the difference.
+- **Compute-local pages are a cache, the store is authority.** Losing the local
+  cache is always recoverable from the store.
+
+## Mapping to current code & status
+
+- `PsStorage` (posix / spdk) — **done** (byte-log backend).
+- `PsLayerStore` local (posix) — **done**; object/S3 ops — **planned** (tiering,
+  `LSM_OBJECT_STORAGE_PLAN.md` phases 4–6).
+- `ship` page-ingest → memtable → image layer (+manifest, compaction, GC,
+  restart-from-layers) — **done** (LSM phases 2–3).
+- `ship` wal-ingest: WAL shipping (`archive_library`) + per-page WAL index +
+  delta-layer format + read plan — **partial** (7a/7b done; continuous WAL ship
+  + auto-index still a worker).
+- `materialize`:
+  - inline-none (page-ingest) — **done** (the page is the image-layer version).
+  - local-worker — **prototype exists**: `wal_only_redo_demo.sh` runs a
+    recovery-worker that replays shipped WAL into image layers via smgr; making
+    it a *continuous* applicator is the next step.
+  - serverless (Lambda) — **planned**; same read-plan input, writes an image
+    layer object to S3.
+- `PsMaterializer` is not yet a named vtable in code — today materialization is
+  the recovery worker. Promoting it to an explicit interface (inline /
+  local-worker / serverless) is the abstraction this doc commits to.
+
+## Why this shape (vs Neon read-time redo)
+
+On **local NVMe**, reading a stored page is ~tens of µs; doing redo on the read
+path (Neon's lazy model, tuned for S3 cold storage + scale-to-zero) is slower and
+pointless. By keeping redo in `materialize` (background/cold) and serving reads
+from versioned image layers + a compute-local page cache, local deployments stay
+fast **and** the cloud deployment still gets WAL's wins (cheap durable commit,
+cheap replication, S3-economical immutable layers) — without changing the
+pipeline. The deployment that benefits from WAL-ingest most is "stateless
+compute + remote commit durability" and/or "object-storage backing"; everything
+else may stay on page-ingest. The abstraction lets both coexist.

--- a/contrib/pagestore/MATERIALIZATION.md
+++ b/contrib/pagestore/MATERIALIZATION.md
@@ -50,7 +50,10 @@ The choice is per-deployment policy, not a code fork (see the binding table).
 materialize(timeline, key, block, target_lsn)
    = read plan (LSM_ARCHITECTURE read path):
        base = newest image layer version <= target_lsn
-       deltas = delta layers covering (base_lsn, target_lsn]   (ascending)
+       deltas = delta layers covering [base_lsn, target_lsn)   (ascending)
+                (half-open: delta keys are WAL record start-LSNs and base_lsn is
+                 the start of the first record to apply; target_lsn must be a
+                 record-boundary / page LSN -- see ps_read_plan_build())
    -> apply deltas onto base via PG rm_redo
    -> new image-layer page version  -> manifest ADD_LAYER
 ```

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1029,7 +1029,7 @@ layer_map_lookup(uint32_t timeline, const PsKey *key, uint32_t block,
 		if (d->kind != PS_LAYER_IMAGE || d->timeline != timeline || d->deleting)
 			continue;
 		if (ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size,
-								  &l) == 1 && (!found || l > best))
+								  &l, NULL) == 1 && (!found || l > best))
 		{
 			best = l;
 			memcpy(out, tmp, page_size);

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -421,6 +421,125 @@ out:
 	return rc;
 }
 
+/* ===================== read plan (phase 7b) ============================ */
+
+#define PS_PLAN_MAX_CHAIN	1024	/* per-layer delta cap (chains are bounded
+									 * by compaction policy) */
+
+static int
+plan_delta_cmp(const void *pa, const void *pb)
+{
+	uint64_t	a = ((const PsPlanDelta *) pa)->lsn;
+	uint64_t	b = ((const PsPlanDelta *) pb)->lsn;
+
+	return a < b ? -1 : (a > b ? 1 : 0);
+}
+
+void
+ps_read_plan_free(PsReadPlan *plan)
+{
+	if (!plan)
+		return;
+	free(plan->base);
+	for (uint32_t i = 0; i < plan->ndelta; i++)
+		free(plan->deltas[i].bytes);
+	free(plan->deltas);
+	plan->base = NULL;
+	plan->deltas = NULL;
+	plan->ndelta = 0;
+	plan->has_base = 0;
+}
+
+int
+ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
+				   uint32_t block, uint64_t read_lsn, uint32_t page_size,
+				   PsReadPlan *plan)
+{
+	unsigned char *tmp = malloc(page_size);
+	uint64_t	lo;
+	uint32_t	cap = 0;
+	int			rc = -1;
+
+	memset(plan, 0, sizeof(*plan));
+	if (!tmp)
+		return -1;
+
+	/* 1. base = newest image-layer version <= read_lsn on this timeline */
+	for (uint32_t i = 0; i < map->nlayers; i++)
+	{
+		const PsLayerDesc *d = &map->layers[i];
+		uint64_t	l;
+
+		if (d->kind != PS_LAYER_IMAGE || d->deleting || d->timeline != timeline)
+			continue;
+		if (ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size,
+								  &l) == 1 && (!plan->has_base || l > plan->base_lsn))
+		{
+			if (!plan->base)
+				plan->base = malloc(page_size);
+			if (!plan->base)
+				goto out;
+			memcpy(plan->base, tmp, page_size);
+			plan->base_lsn = l;
+			plan->has_base = 1;
+		}
+	}
+	lo = plan->has_base ? plan->base_lsn : 0;
+
+	/* 2. deltas in (lo, read_lsn] across this timeline's delta layers */
+	for (uint32_t i = 0; i < map->nlayers; i++)
+	{
+		const PsLayerDesc *d = &map->layers[i];
+		PsDeltaOut	outs[PS_PLAN_MAX_CHAIN];
+		uint32_t	tn = 0;
+
+		if (d->kind != PS_LAYER_DELTA || d->deleting || d->timeline != timeline)
+			continue;
+		if (ps_delta_layer_collect(d, key, block, lo, read_lsn, outs,
+								   PS_PLAN_MAX_CHAIN, &tn) != 0)
+			goto out;
+		for (uint32_t j = 0; j < tn; j++)
+		{
+			unsigned char *bytes;
+
+			if (plan->ndelta == cap)
+			{
+				uint32_t	nc = cap ? cap * 2 : 16;
+				PsPlanDelta *nd = realloc(plan->deltas,
+										  (size_t) nc * sizeof(PsPlanDelta));
+
+				if (!nd)
+					goto out;
+				plan->deltas = nd;
+				cap = nc;
+			}
+			bytes = malloc(outs[j].data_len);
+			if (!bytes ||
+				ps_layer_store->read_layer_block(d, outs[j].data_off, bytes,
+												 outs[j].data_len) != 0)
+			{
+				free(bytes);
+				goto out;
+			}
+			plan->deltas[plan->ndelta].lsn = outs[j].lsn;
+			plan->deltas[plan->ndelta].len = outs[j].data_len;
+			plan->deltas[plan->ndelta].bytes = bytes;
+			plan->ndelta++;
+		}
+	}
+
+	/* 3. order the chain by ascending LSN (it spans multiple layers) */
+	if (plan->ndelta > 1)
+		qsort(plan->deltas, plan->ndelta, sizeof(PsPlanDelta), plan_delta_cmp);
+	rc = 0;
+
+out:
+	free(tmp);
+	if (rc != 0)
+		ps_read_plan_free(plan);
+	return rc;
+}
+
 int
 ps_image_layer_read_index(const PsLayerDesc *layer, PsImgIndexEnt **out,
 						  uint32_t *n)

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -670,6 +670,21 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 	/* 3. order the chain by ascending LSN (it spans multiple layers) */
 	if (plan->ndelta > 1)
 		qsort(plan->deltas, plan->ndelta, sizeof(PsPlanDelta), plan_delta_cmp);
+
+	/* 4. drop duplicate records: overlapping delta layers (e.g. a replacement
+	 * layer added before the old ones are marked deleting in the install-new-
+	 * before-delete-old compaction flow) can expose the same WAL record (same
+	 * record LSN) twice; applying it twice in rm_redo would corrupt the page.
+	 * Sorted by LSN above, so duplicates are adjacent -- keep the first. */
+	for (uint32_t i = 1; i < plan->ndelta; i++)
+		if (plan->deltas[i].lsn == plan->deltas[i - 1].lsn)
+		{
+			free(plan->deltas[i].bytes);
+			memmove(&plan->deltas[i], &plan->deltas[i + 1],
+					(size_t) (plan->ndelta - i - 1) * sizeof(PsPlanDelta));
+			plan->ndelta--;
+			i--;				/* re-check the new entry now at i */
+		}
 	rc = 0;
 
 out:

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -481,6 +481,18 @@ plan_delta_cmp(const void *pa, const void *pb)
 	return a < b ? -1 : (a > b ? 1 : 0);
 }
 
+/* order image-base candidates newest-first by their layer LSN range (lsn_end). */
+static int
+img_cand_newest_first(const void *pa, const void *pb)
+{
+	const PsLayerDesc *a = *(const PsLayerDesc *const *) pa;
+	const PsLayerDesc *b = *(const PsLayerDesc *const *) pb;
+
+	if (a->lsn_end != b->lsn_end)
+		return a->lsn_end > b->lsn_end ? -1 : 1;
+	return 0;
+}
+
 void
 ps_read_plan_free(PsReadPlan *plan)
 {
@@ -512,52 +524,100 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 	if (!tmp)
 		return -1;
 
-	/* 1. base = newest image-layer version <= read_lsn on this timeline */
-	for (uint32_t i = 0; i < map->nlayers; i++)
+	/* 1. base = newest unambiguous image-layer version <= read_lsn.  Probe
+	 * candidates newest-first (by layer lsn_end) so the freshest base is chosen
+	 * before older layers: a clearly-superseded layer (lsn_end below the base
+	 * found) is then skipped without being read, while a covering layer that could
+	 * still be the base but is corrupt/unavailable fails the plan rather than
+	 * silently selecting an older base (there may be no delta chain that recreates
+	 * the skipped image). */
 	{
-		const PsLayerDesc *d = &map->layers[i];
-		uint64_t	l;
-		int			amb;
-		int			r;
+		const PsLayerDesc **cand = NULL;
+		uint32_t	ncand = 0;
+		int			base_ok = 1;
+		int			base_ambiguous = 0;
 
-		if (d->kind != PS_LAYER_IMAGE || d->deleting || d->timeline != timeline)
-			continue;
-		/* skip an image layer whose metadata cannot hold a version of (key,block)
-		 * at or below read_lsn: an unrelated tiered-out/corrupt layer must not be
-		 * read (and so cannot fail the whole plan), matching the delta scan below */
-		if (key_cmp(key, &d->start_key) < 0 || key_cmp(key, &d->end_key) > 0 ||
-			block < d->start_block || block > d->end_block ||
-			d->lsn_start > read_lsn)
-			continue;
-		/* a layer whose newest version is at or below the base we already have can
-		 * only tie or lose, so skip it -- this also means a damaged superseded
-		 * layer can never fail a read that a newer layer already satisfies */
-		if (plan->has_base && d->lsn_end <= plan->base_lsn)
-			continue;
-		r = ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size, &l,
-								  &amb);
-		if (r < 0)
-			continue;			/* unavailable/corrupt: a newer valid layer (or an
-								 * older base + deltas) can still satisfy the read */
-		/* reject an ambiguous base: when several versions share this page LSN
-		 * (a hint-bit/same-lsn rewrite) the lsn cannot identify the right bytes,
-		 * so do not start materialization from it (the live read path serves such
-		 * pages from the authoritative segment instead) */
-		if (r == 1 && !amb && (!plan->has_base || l > plan->base_lsn))
+		if (map->nlayers)
 		{
-			if (!plan->base)
-				plan->base = malloc(page_size);
-			if (!plan->base)
+			cand = malloc((size_t) map->nlayers * sizeof(*cand));
+			if (!cand)
 				goto out;
-			memcpy(plan->base, tmp, page_size);
-			plan->base_lsn = l;
-			plan->has_base = 1;
 		}
+		for (uint32_t i = 0; i < map->nlayers; i++)
+		{
+			const PsLayerDesc *d = &map->layers[i];
+
+			if (d->kind != PS_LAYER_IMAGE || d->deleting ||
+				d->timeline != timeline)
+				continue;
+			/* skip a layer whose metadata cannot hold a version of (key,block)
+			 * at or below read_lsn (never read it) */
+			if (key_cmp(key, &d->start_key) < 0 || key_cmp(key, &d->end_key) > 0 ||
+				block < d->start_block || block > d->end_block ||
+				d->lsn_start > read_lsn)
+				continue;
+			cand[ncand++] = d;
+		}
+		qsort(cand, ncand, sizeof(*cand), img_cand_newest_first);
+		for (uint32_t j = 0; j < ncand; j++)
+		{
+			const PsLayerDesc *d = cand[j];
+			uint64_t	l;
+			int			amb;
+			int			r;
+
+			/* sorted newest-first: once a candidate's whole range is below the
+			 * base already found it cannot beat or tie it, and neither can the
+			 * rest -- stop without reading them */
+			if (plan->has_base && d->lsn_end < plan->base_lsn)
+				break;
+			r = ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size,
+									  &l, &amb);
+			if (r < 0)
+			{
+				base_ok = 0;	/* a covering candidate is corrupt/unavailable */
+				break;
+			}
+			if (r != 1)
+				continue;
+			if (amb)			/* several versions share this lsn in one layer */
+			{
+				base_ambiguous = 1;
+				break;
+			}
+			if (!plan->has_base || l > plan->base_lsn)
+			{
+				if (!plan->base)
+					plan->base = malloc(page_size);
+				if (!plan->base)
+				{
+					base_ok = 0;
+					break;
+				}
+				memcpy(plan->base, tmp, page_size);
+				plan->base_lsn = l;
+				plan->has_base = 1;
+			}
+			else if (l == plan->base_lsn)
+			{
+				base_ambiguous = 1;		/* same lsn across two layers */
+				break;
+			}
+		}
+		free(cand);
+		/* an ambiguous base (same-lsn rewrite) or a corrupt covering layer cannot
+		 * be materialized safely; fail so the caller serves from the authoritative
+		 * segment, as read_resolve() does via page_lsn_ambiguous() */
+		if (!base_ok || base_ambiguous)
+			goto out;
 	}
 	lo = plan->has_base ? plan->base_lsn : 0;
 
-	/* 2. deltas in [lo, read_lsn) across this timeline's delta layers */
-	for (uint32_t i = 0; i < map->nlayers; i++)
+	/* 2. deltas in [lo, read_lsn) across this timeline's delta layers.  When the
+	 * base already reaches read_lsn the interval is empty -- skip the scan
+	 * entirely so an irrelevant remote-only/corrupt delta layer at that boundary
+	 * cannot fail a read the base image alone already satisfies. */
+	for (uint32_t i = 0; lo < read_lsn && i < map->nlayers; i++)
 	{
 		const PsLayerDesc *d = &map->layers[i];
 		uint32_t	tn = 0;

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -600,8 +600,17 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 			}
 			else if (l == plan->base_lsn)
 			{
-				base_ambiguous = 1;		/* same lsn across two layers */
-				break;
+				/* same lsn in two layers: tolerate an identical-bytes duplicate --
+				 * crash-safe compaction (install-new-before-delete-old) briefly
+				 * leaves the old and new image layers both live with the same
+				 * version -- but a genuine same-lsn rewrite (different bytes, e.g.
+				 * hint bits) is ambiguous and must fail to the segment path */
+				if (memcmp(plan->base, tmp, page_size) != 0)
+				{
+					base_ambiguous = 1;
+					break;
+				}
+				/* identical duplicate base -> keep the one already chosen */
 			}
 		}
 		free(cand);

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -684,10 +684,17 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 	 * layer added before the old ones are marked deleting in the install-new-
 	 * before-delete-old compaction flow) can expose the same WAL record (same
 	 * record LSN) twice; applying it twice in rm_redo would corrupt the page.
-	 * Sorted by LSN above, so duplicates are adjacent -- keep the first. */
+	 * Sorted by LSN above, so duplicates are adjacent.  Only drop a duplicate that
+	 * is byte-identical -- two same-LSN records with *different* payloads (a stale
+	 * replacement or a corrupt-but-self-consistent layer) are a real conflict that
+	 * qsort would resolve arbitrarily, so fail the plan instead of guessing. */
 	for (uint32_t i = 1; i < plan->ndelta; i++)
 		if (plan->deltas[i].lsn == plan->deltas[i - 1].lsn)
 		{
+			if (plan->deltas[i].len != plan->deltas[i - 1].len ||
+				memcmp(plan->deltas[i].bytes, plan->deltas[i - 1].bytes,
+					   plan->deltas[i].len) != 0)
+				goto out;		/* conflicting duplicate record -> reject */
 			free(plan->deltas[i].bytes);
 			memmove(&plan->deltas[i], &plan->deltas[i + 1],
 					(size_t) (plan->ndelta - i - 1) * sizeof(PsPlanDelta));
@@ -802,18 +809,23 @@ ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 		rc = 0;
 		goto out;
 	}
-	/* report whether the chosen version's page LSN is ambiguous within this layer
-	 * (more than one version of (key,block) shares best_lsn -- a same-lsn rewrite,
-	 * e.g. hint bits); the caller cannot trust lsn alone to identify it */
+	/* report whether the chosen version's page LSN is ambiguous within this layer:
+	 * more than one version of (key,block) shares best_lsn *with differing bytes*
+	 * (a genuine same-lsn rewrite, e.g. hint bits), which lsn alone can't identify.
+	 * Identical-byte duplicates are benign -- compaction copies the versions of
+	 * crash-overlapped layers (install-new-before-delete-old) into one new layer,
+	 * so the same (key,block,lsn) can legitimately appear twice with equal bytes;
+	 * compare the per-page crc rather than just counting. */
 	if (out_ambiguous)
 	{
-		uint32_t	dup = 0;
-
+		*out_ambiguous = 0;
 		for (uint32_t i = 0; i < foot.nrecs; i++)
 			if (idx[i].block == block && key_cmp(&idx[i].key, key) == 0 &&
-				idx[i].lsn == best_lsn && ++dup > 1)
+				idx[i].lsn == best_lsn && idx[i].crc != best_crc)
+			{
+				*out_ambiguous = 1;
 				break;
-		*out_ambiguous = (dup > 1);
+			}
 	}
 	if (ps_layer_store->read_layer_block(layer, best_off, out, page_size) != 0)
 		goto out;

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -253,6 +253,174 @@ out:
 	return rc;
 }
 
+/* ===================== delta layer file format ========================= */
+
+typedef struct DeltaSort
+{
+	PsDeltaIndexEnt ent;
+	uint32_t	src;
+} DeltaSort;
+
+static int
+delta_sort_cmp(const void *pa, const void *pb)
+{
+	const DeltaSort *a = pa;
+	const DeltaSort *b = pb;
+	int			c = key_cmp(&a->ent.key, &b->ent.key);
+
+	if (c)
+		return c;
+	if (a->ent.block != b->ent.block)
+		return a->ent.block < b->ent.block ? -1 : 1;
+	if (a->ent.lsn != b->ent.lsn)
+		return a->ent.lsn < b->ent.lsn ? -1 : 1;
+	return 0;
+}
+
+int
+ps_delta_layer_write(uint64_t layer_id, uint32_t timeline,
+					 const PsDeltaRec *recs, uint32_t n, PsLayerDesc *out)
+{
+	DeltaSort  *sorted;
+	char	   *filebuf;
+	char	   *idxsec;
+	PsDeltaFooter foot;
+	uint64_t	data_bytes = 0;
+	uint64_t	idx_bytes = (uint64_t) n * sizeof(PsDeltaIndexEnt);
+	uint64_t	total;
+	uint64_t	off;
+	char		uri[PS_LAYER_URI_MAX];
+	int			rc = -1;
+
+	if (n == 0)
+		return -1;
+	for (uint32_t i = 0; i < n; i++)
+		data_bytes += recs[i].delta_len;
+	total = data_bytes + idx_bytes + sizeof(PsDeltaFooter);
+
+	sorted = malloc((size_t) n * sizeof(DeltaSort));
+	filebuf = malloc((size_t) total);
+	if (!sorted || !filebuf)
+		goto out;
+
+	for (uint32_t i = 0; i < n; i++)
+	{
+		sorted[i].ent.key = recs[i].key;
+		sorted[i].ent.block = recs[i].block;
+		sorted[i].ent.lsn = recs[i].lsn;
+		sorted[i].ent.data_len = recs[i].delta_len;
+		sorted[i].src = i;
+	}
+	qsort(sorted, n, sizeof(DeltaSort), delta_sort_cmp);
+
+	off = 0;
+	for (uint32_t i = 0; i < n; i++)
+	{
+		sorted[i].ent.data_off = off;
+		memcpy(filebuf + off, recs[sorted[i].src].delta, sorted[i].ent.data_len);
+		off += sorted[i].ent.data_len;
+	}
+	idxsec = filebuf + data_bytes;
+	for (uint32_t i = 0; i < n; i++)
+		memcpy(idxsec + (size_t) i * sizeof(PsDeltaIndexEnt), &sorted[i].ent,
+			   sizeof(PsDeltaIndexEnt));
+	memset(&foot, 0, sizeof(foot));
+	foot.magic = PS_DELTA_MAGIC;
+	foot.version = PS_DELTA_VERSION;
+	foot.nrecs = n;
+	foot.index_off = data_bytes;
+	foot.data_crc = img_crc(filebuf, (size_t) data_bytes);
+	foot.index_crc = img_crc(idxsec, (size_t) idx_bytes);
+	memcpy(filebuf + data_bytes + idx_bytes, &foot, sizeof(foot));
+
+	if (ps_layer_store->create_local_layer(layer_id, uri, sizeof(uri)) != 0)
+		goto out;
+	if (ps_layer_store->write_local_layer(layer_id, filebuf, total) != 0 ||
+		ps_layer_store->seal_local_layer(layer_id) != 0)
+		goto out;
+
+	memset(out, 0, sizeof(*out));
+	out->layer_id = layer_id;
+	out->kind = PS_LAYER_DELTA;
+	out->timeline = timeline;
+	out->start_key = sorted[0].ent.key;
+	out->end_key = sorted[n - 1].ent.key;
+	out->start_block = sorted[0].ent.block;
+	out->end_block = sorted[n - 1].ent.block;
+	out->lsn_start = sorted[0].ent.lsn;
+	out->lsn_end = sorted[0].ent.lsn;
+	for (uint32_t i = 0; i < n; i++)
+	{
+		if (sorted[i].ent.lsn < out->lsn_start)
+			out->lsn_start = sorted[i].ent.lsn;
+		if (sorted[i].ent.lsn > out->lsn_end)
+			out->lsn_end = sorted[i].ent.lsn;
+		if (sorted[i].ent.block < out->start_block)
+			out->start_block = sorted[i].ent.block;
+		if (sorted[i].ent.block > out->end_block)
+			out->end_block = sorted[i].ent.block;
+	}
+	out->created_at_lsn = out->lsn_end;
+	out->location_count = 1;
+	out->locations[0].tier = PS_LAYER_TIER_LOCAL_HOT;
+	out->locations[0].size = total;
+	out->locations[0].available = true;
+	snprintf(out->locations[0].uri, sizeof(out->locations[0].uri), "%s", uri);
+	rc = 0;
+
+out:
+	free(sorted);
+	free(filebuf);
+	return rc;
+}
+
+int
+ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
+					   uint32_t block, uint64_t lo_lsn, uint64_t hi_lsn,
+					   PsDeltaOut *outs, uint32_t cap, uint32_t *n)
+{
+	const PsLayerLocation *loc = img_local_loc(layer);
+	PsDeltaFooter foot;
+	PsDeltaIndexEnt *idx;
+	uint64_t	idx_bytes;
+	int			rc = -1;
+
+	if (!loc || loc->size < sizeof(PsDeltaFooter))
+		return -1;
+	if (ps_layer_store->read_layer_block(layer, loc->size - sizeof(foot),
+										 &foot, sizeof(foot)) != 0)
+		return -1;
+	if (foot.magic != PS_DELTA_MAGIC || foot.version != PS_DELTA_VERSION ||
+		foot.nrecs == 0)
+		return -1;
+	idx_bytes = (uint64_t) foot.nrecs * sizeof(PsDeltaIndexEnt);
+	idx = malloc((size_t) idx_bytes);
+	if (!idx)
+		return -1;
+	if (ps_layer_store->read_layer_block(layer, foot.index_off, idx,
+										 (uint32_t) idx_bytes) != 0 ||
+		img_crc(idx, (size_t) idx_bytes) != foot.index_crc)
+		goto out;
+
+	/* index is sorted by (key, block, lsn): matches are contiguous + ascending */
+	for (uint32_t i = 0; i < foot.nrecs && *n < cap; i++)
+	{
+		if (idx[i].block != block || key_cmp(&idx[i].key, key) != 0)
+			continue;
+		if (idx[i].lsn <= lo_lsn || idx[i].lsn > hi_lsn)
+			continue;
+		outs[*n].lsn = idx[i].lsn;
+		outs[*n].data_off = (uint32_t) idx[i].data_off;
+		outs[*n].data_len = idx[i].data_len;
+		(*n)++;
+	}
+	rc = 0;
+
+out:
+	free(idx);
+	return rc;
+}
+
 int
 ps_image_layer_read_index(const PsLayerDesc *layer, PsImgIndexEnt **out,
 						  uint32_t *n)

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -302,6 +302,9 @@ ps_delta_layer_write(uint64_t layer_id, uint32_t timeline,
 	filebuf = malloc((size_t) total);
 	if (!sorted || !filebuf)
 		goto out;
+	/* zero so struct padding isn't persisted (no heap leak to disk/objects, and
+	 * the on-disk index bytes don't depend on compiler padding) */
+	memset(sorted, 0, (size_t) n * sizeof(DeltaSort));
 
 	for (uint32_t i = 0; i < n; i++)
 	{
@@ -318,6 +321,8 @@ ps_delta_layer_write(uint64_t layer_id, uint32_t timeline,
 	{
 		sorted[i].ent.data_off = off;
 		memcpy(filebuf + off, recs[sorted[i].src].delta, sorted[i].ent.data_len);
+		sorted[i].ent.crc = img_crc(recs[sorted[i].src].delta,
+								   sorted[i].ent.data_len);
 		off += sorted[i].ent.data_len;
 	}
 	idxsec = filebuf + data_bytes;
@@ -337,7 +342,21 @@ ps_delta_layer_write(uint64_t layer_id, uint32_t timeline,
 		goto out;
 	if (ps_layer_store->write_local_layer(layer_id, filebuf, total) != 0 ||
 		ps_layer_store->seal_local_layer(layer_id) != 0)
+	{
+		/* remove the unmanifested file so its reused layer_id can't dead-lock
+		 * create_local_layer's O_EXCL on a later flush (see ps_image_layer_write) */
+		PsLayerDesc orphan;
+
+		memset(&orphan, 0, sizeof(orphan));
+		orphan.layer_id = layer_id;
+		orphan.location_count = 1;
+		orphan.locations[0].tier = PS_LAYER_TIER_LOCAL_HOT;
+		orphan.locations[0].available = true;
+		snprintf(orphan.locations[0].uri, sizeof(orphan.locations[0].uri),
+				 "%s", uri);
+		ps_layer_store->delete_local_layer(&orphan);
 		goto out;
+	}
 
 	memset(out, 0, sizeof(*out));
 	out->layer_id = layer_id;
@@ -394,6 +413,11 @@ ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 		foot.nrecs == 0)
 		return -1;
 	idx_bytes = (uint64_t) foot.nrecs * sizeof(PsDeltaIndexEnt);
+	/* reject a footer whose index section would not fit in the file (guards a
+	 * corrupt/forged nrecs/index_off from driving a huge allocation or an OOB
+	 * read), matching the image-layer reader */
+	if (foot.index_off + idx_bytes + sizeof(foot) > loc->size)
+		return -1;
 	idx = malloc((size_t) idx_bytes);
 	if (!idx)
 		return -1;
@@ -409,11 +433,18 @@ ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 			continue;
 		if (idx[i].lsn <= lo_lsn || idx[i].lsn > hi_lsn)
 			continue;
+		/* the payload must lie wholly inside the payload section [0, index_off);
+		 * a corrupt offset/len (even with a matching index crc) must fail the
+		 * layer, not expose index/footer bytes as a WAL payload (overflow-safe) */
+		if (idx[i].data_off > foot.index_off ||
+			idx[i].data_len > foot.index_off - idx[i].data_off)
+			goto out;
 		if (*n == cap)
 			goto out;			/* rc stays -1: the chain would be truncated */
 		outs[*n].lsn = idx[i].lsn;
 		outs[*n].data_off = idx[i].data_off;
 		outs[*n].data_len = idx[i].data_len;
+		outs[*n].crc = idx[i].crc;
 		(*n)++;
 	}
 	rc = 0;
@@ -501,6 +532,13 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 
 		if (d->kind != PS_LAYER_DELTA || d->deleting || d->timeline != timeline)
 			continue;
+		/* skip a layer whose key/block/LSN range cannot overlap (lo, read_lsn]:
+		 * its metadata already proves it is irrelevant, so a remote-only/evicted/
+		 * corrupt unrelated layer must not be touched (let alone fail the read) */
+		if (key_cmp(key, &d->start_key) < 0 || key_cmp(key, &d->end_key) > 0 ||
+			block < d->start_block || block > d->end_block ||
+			d->lsn_end <= lo || d->lsn_start > read_lsn)
+			continue;
 		if (ps_delta_layer_collect(d, key, block, lo, read_lsn, outs,
 								   PS_PLAN_MAX_CHAIN, &tn) != 0)
 			goto out;
@@ -522,8 +560,11 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 			bytes = malloc(outs[j].data_len);
 			if (!bytes ||
 				ps_layer_store->read_layer_block(d, outs[j].data_off, bytes,
-												 outs[j].data_len) != 0)
+												 outs[j].data_len) != 0 ||
+				img_crc(bytes, outs[j].data_len) != outs[j].crc)
 			{
+				/* a payload that fails its per-record crc is corrupt: reject the
+				 * read instead of feeding bad bytes to the redo helper */
 				free(bytes);
 				goto out;
 			}

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -431,7 +431,12 @@ ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 	{
 		if (idx[i].block != block || key_cmp(&idx[i].key, key) != 0)
 			continue;
-		if (idx[i].lsn <= lo_lsn || idx[i].lsn > hi_lsn)
+		/* half-open [lo_lsn, hi_lsn): delta keys are WAL record *start* LSNs while
+		 * an image/page LSN is the previous record's end == the next record's
+		 * start.  So a base at lo_lsn needs the record whose start == lo_lsn
+		 * applied, and a record starting exactly at hi_lsn (== read_lsn) is past
+		 * the requested state and must be excluded. */
+		if (idx[i].lsn < lo_lsn || idx[i].lsn >= hi_lsn)
 			continue;
 		/* the payload must lie wholly inside the payload section [0, index_off);
 		 * a corrupt offset/len (even with a matching index crc) must fail the
@@ -512,7 +517,7 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 	{
 		const PsLayerDesc *d = &map->layers[i];
 		uint64_t	l;
-
+		int			amb;
 		int			r;
 
 		if (d->kind != PS_LAYER_IMAGE || d->deleting || d->timeline != timeline)
@@ -524,14 +529,21 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 			block < d->start_block || block > d->end_block ||
 			d->lsn_start > read_lsn)
 			continue;
-		r = ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size, &l);
+		/* a layer whose newest version is at or below the base we already have can
+		 * only tie or lose, so skip it -- this also means a damaged superseded
+		 * layer can never fail a read that a newer layer already satisfies */
+		if (plan->has_base && d->lsn_end <= plan->base_lsn)
+			continue;
+		r = ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size, &l,
+								  &amb);
 		if (r < 0)
-			goto out;			/* read/format error: do not pick a wrong base */
-		/* '>=' so that on an equal page LSN (a same-lsn rewrite, e.g. hint bits)
-		 * the later-created layer wins -- map order follows layer creation, so a
-		 * newer image for the same (key,block,lsn) is authoritative over an older
-		 * one carrying the same page LSN */
-		if (r == 1 && (!plan->has_base || l >= plan->base_lsn))
+			continue;			/* unavailable/corrupt: a newer valid layer (or an
+								 * older base + deltas) can still satisfy the read */
+		/* reject an ambiguous base: when several versions share this page LSN
+		 * (a hint-bit/same-lsn rewrite) the lsn cannot identify the right bytes,
+		 * so do not start materialization from it (the live read path serves such
+		 * pages from the authoritative segment instead) */
+		if (r == 1 && !amb && (!plan->has_base || l > plan->base_lsn))
 		{
 			if (!plan->base)
 				plan->base = malloc(page_size);
@@ -544,7 +556,7 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 	}
 	lo = plan->has_base ? plan->base_lsn : 0;
 
-	/* 2. deltas in (lo, read_lsn] across this timeline's delta layers */
+	/* 2. deltas in [lo, read_lsn) across this timeline's delta layers */
 	for (uint32_t i = 0; i < map->nlayers; i++)
 	{
 		const PsLayerDesc *d = &map->layers[i];
@@ -552,12 +564,12 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 
 		if (d->kind != PS_LAYER_DELTA || d->deleting || d->timeline != timeline)
 			continue;
-		/* skip a layer whose key/block/LSN range cannot overlap (lo, read_lsn]:
+		/* skip a layer whose key/block/LSN range cannot overlap [lo, read_lsn):
 		 * its metadata already proves it is irrelevant, so a remote-only/evicted/
 		 * corrupt unrelated layer must not be touched (let alone fail the read) */
 		if (key_cmp(key, &d->start_key) < 0 || key_cmp(key, &d->end_key) > 0 ||
 			block < d->start_block || block > d->end_block ||
-			d->lsn_end <= lo || d->lsn_start > read_lsn)
+			d->lsn_end < lo || d->lsn_start >= read_lsn)
 			continue;
 		if (ps_delta_layer_collect(d, key, block, lo, read_lsn, &douts,
 								   &dcap, &tn) != 0)
@@ -650,7 +662,8 @@ ps_image_layer_read_index(const PsLayerDesc *layer, PsImgIndexEnt **out,
 int
 ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 					  uint32_t block, uint64_t read_lsn,
-					  void *out, uint32_t page_size, uint64_t *out_lsn)
+					  void *out, uint32_t page_size, uint64_t *out_lsn,
+					  int *out_ambiguous)
 {
 	const PsLayerLocation *loc = img_local_loc(layer);
 	PsImgFooter foot;
@@ -698,10 +711,25 @@ ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 			found = 1;
 		}
 	}
+	if (out_ambiguous)
+		*out_ambiguous = 0;
 	if (!found)
 	{
 		rc = 0;
 		goto out;
+	}
+	/* report whether the chosen version's page LSN is ambiguous within this layer
+	 * (more than one version of (key,block) shares best_lsn -- a same-lsn rewrite,
+	 * e.g. hint bits); the caller cannot trust lsn alone to identify it */
+	if (out_ambiguous)
+	{
+		uint32_t	dup = 0;
+
+		for (uint32_t i = 0; i < foot.nrecs; i++)
+			if (idx[i].block == block && key_cmp(&idx[i].key, key) == 0 &&
+				idx[i].lsn == best_lsn && ++dup > 1)
+				break;
+		*out_ambiguous = (dup > 1);
 	}
 	if (ps_layer_store->read_layer_block(layer, best_off, out, page_size) != 0)
 		goto out;

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -396,7 +396,7 @@ out:
 int
 ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 					   uint32_t block, uint64_t lo_lsn, uint64_t hi_lsn,
-					   PsDeltaOut *outs, uint32_t cap, uint32_t *n)
+					   PsDeltaOut **outs, uint32_t *cap, uint32_t *n)
 {
 	const PsLayerLocation *loc = img_local_loc(layer);
 	PsDeltaFooter foot;
@@ -439,12 +439,23 @@ ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 		if (idx[i].data_off > foot.index_off ||
 			idx[i].data_len > foot.index_off - idx[i].data_off)
 			goto out;
-		if (*n == cap)
-			goto out;			/* rc stays -1: the chain would be truncated */
-		outs[*n].lsn = idx[i].lsn;
-		outs[*n].data_off = idx[i].data_off;
-		outs[*n].data_len = idx[i].data_len;
-		outs[*n].crc = idx[i].crc;
+		/* grow the output as needed -- no fixed per-layer cap, since a hot page
+		 * can legitimately have many deltas in one sealed layer and the caller's
+		 * plan->deltas is itself growable */
+		if (*n == *cap)
+		{
+			uint32_t	nc = *cap ? *cap * 2 : 16;
+			PsDeltaOut *no = realloc(*outs, (size_t) nc * sizeof(PsDeltaOut));
+
+			if (!no)
+				goto out;
+			*outs = no;
+			*cap = nc;
+		}
+		(*outs)[*n].lsn = idx[i].lsn;
+		(*outs)[*n].data_off = idx[i].data_off;
+		(*outs)[*n].data_len = idx[i].data_len;
+		(*outs)[*n].crc = idx[i].crc;
 		(*n)++;
 	}
 	rc = 0;
@@ -455,9 +466,6 @@ out:
 }
 
 /* ===================== read plan (phase 7b) ============================ */
-
-#define PS_PLAN_MAX_CHAIN	1024	/* per-layer delta cap (chains are bounded
-									 * by compaction policy) */
 
 static int
 plan_delta_cmp(const void *pa, const void *pb)
@@ -491,6 +499,8 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 	unsigned char *tmp = malloc(page_size);
 	uint64_t	lo;
 	uint32_t	cap = 0;
+	PsDeltaOut *douts = NULL;	/* growable collect buffer, reused per layer */
+	uint32_t	dcap = 0;
 	int			rc = -1;
 
 	memset(plan, 0, sizeof(*plan));
@@ -507,10 +517,21 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 
 		if (d->kind != PS_LAYER_IMAGE || d->deleting || d->timeline != timeline)
 			continue;
+		/* skip an image layer whose metadata cannot hold a version of (key,block)
+		 * at or below read_lsn: an unrelated tiered-out/corrupt layer must not be
+		 * read (and so cannot fail the whole plan), matching the delta scan below */
+		if (key_cmp(key, &d->start_key) < 0 || key_cmp(key, &d->end_key) > 0 ||
+			block < d->start_block || block > d->end_block ||
+			d->lsn_start > read_lsn)
+			continue;
 		r = ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size, &l);
 		if (r < 0)
 			goto out;			/* read/format error: do not pick a wrong base */
-		if (r == 1 && (!plan->has_base || l > plan->base_lsn))
+		/* '>=' so that on an equal page LSN (a same-lsn rewrite, e.g. hint bits)
+		 * the later-created layer wins -- map order follows layer creation, so a
+		 * newer image for the same (key,block,lsn) is authoritative over an older
+		 * one carrying the same page LSN */
+		if (r == 1 && (!plan->has_base || l >= plan->base_lsn))
 		{
 			if (!plan->base)
 				plan->base = malloc(page_size);
@@ -527,7 +548,6 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 	for (uint32_t i = 0; i < map->nlayers; i++)
 	{
 		const PsLayerDesc *d = &map->layers[i];
-		PsDeltaOut	outs[PS_PLAN_MAX_CHAIN];
 		uint32_t	tn = 0;
 
 		if (d->kind != PS_LAYER_DELTA || d->deleting || d->timeline != timeline)
@@ -539,8 +559,8 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 			block < d->start_block || block > d->end_block ||
 			d->lsn_end <= lo || d->lsn_start > read_lsn)
 			continue;
-		if (ps_delta_layer_collect(d, key, block, lo, read_lsn, outs,
-								   PS_PLAN_MAX_CHAIN, &tn) != 0)
+		if (ps_delta_layer_collect(d, key, block, lo, read_lsn, &douts,
+								   &dcap, &tn) != 0)
 			goto out;
 		for (uint32_t j = 0; j < tn; j++)
 		{
@@ -557,19 +577,19 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 				plan->deltas = nd;
 				cap = nc;
 			}
-			bytes = malloc(outs[j].data_len);
+			bytes = malloc(douts[j].data_len);
 			if (!bytes ||
-				ps_layer_store->read_layer_block(d, outs[j].data_off, bytes,
-												 outs[j].data_len) != 0 ||
-				img_crc(bytes, outs[j].data_len) != outs[j].crc)
+				ps_layer_store->read_layer_block(d, douts[j].data_off, bytes,
+												 douts[j].data_len) != 0 ||
+				img_crc(bytes, douts[j].data_len) != douts[j].crc)
 			{
 				/* a payload that fails its per-record crc is corrupt: reject the
 				 * read instead of feeding bad bytes to the redo helper */
 				free(bytes);
 				goto out;
 			}
-			plan->deltas[plan->ndelta].lsn = outs[j].lsn;
-			plan->deltas[plan->ndelta].len = outs[j].data_len;
+			plan->deltas[plan->ndelta].lsn = douts[j].lsn;
+			plan->deltas[plan->ndelta].len = douts[j].data_len;
 			plan->deltas[plan->ndelta].bytes = bytes;
 			plan->ndelta++;
 		}
@@ -582,6 +602,7 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 
 out:
 	free(tmp);
+	free(douts);
 	if (rc != 0)
 		ps_read_plan_free(plan);
 	return rc;

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -403,14 +403,16 @@ ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 		goto out;
 
 	/* index is sorted by (key, block, lsn): matches are contiguous + ascending */
-	for (uint32_t i = 0; i < foot.nrecs && *n < cap; i++)
+	for (uint32_t i = 0; i < foot.nrecs; i++)
 	{
 		if (idx[i].block != block || key_cmp(&idx[i].key, key) != 0)
 			continue;
 		if (idx[i].lsn <= lo_lsn || idx[i].lsn > hi_lsn)
 			continue;
+		if (*n == cap)
+			goto out;			/* rc stays -1: the chain would be truncated */
 		outs[*n].lsn = idx[i].lsn;
-		outs[*n].data_off = (uint32_t) idx[i].data_off;
+		outs[*n].data_off = idx[i].data_off;
 		outs[*n].data_len = idx[i].data_len;
 		(*n)++;
 	}
@@ -470,10 +472,14 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 		const PsLayerDesc *d = &map->layers[i];
 		uint64_t	l;
 
+		int			r;
+
 		if (d->kind != PS_LAYER_IMAGE || d->deleting || d->timeline != timeline)
 			continue;
-		if (ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size,
-								  &l) == 1 && (!plan->has_base || l > plan->base_lsn))
+		r = ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size, &l);
+		if (r < 0)
+			goto out;			/* read/format error: do not pick a wrong base */
+		if (r == 1 && (!plan->has_base || l > plan->base_lsn))
 		{
 			if (!plan->base)
 				plan->base = malloc(page_size);

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -206,7 +206,7 @@ typedef struct PsDeltaRec
 typedef struct PsDeltaOut
 {
 	uint64_t	lsn;
-	uint32_t	data_off;
+	uint64_t	data_off;
 	uint32_t	data_len;
 } PsDeltaOut;
 

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -135,13 +135,15 @@ extern int	ps_image_layer_write(uint64_t layer_id, uint32_t timeline,
 /*
  * Look up the newest version of (key, block) with lsn <= read_lsn in image
  * layer 'layer'.  On a hit copies page_size bytes into out, stores that
- * version's lsn in *out_lsn (if non-NULL), and returns 1; 0 if the layer has no
- * such page; -1 on read/format error.
+ * version's lsn in *out_lsn (if non-NULL), sets *out_ambiguous (if non-NULL) to
+ * 1 when more than one version shares that lsn (a same-lsn rewrite the lsn can't
+ * disambiguate), and returns 1; 0 if the layer has no such page; -1 on
+ * read/format error.
  */
 extern int	ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 								  uint32_t block, uint64_t read_lsn,
 								  void *out, uint32_t page_size,
-								  uint64_t *out_lsn);
+								  uint64_t *out_lsn, int *out_ambiguous);
 
 /*
  * Read an image layer's full index (every (key, block, lsn) entry), for
@@ -218,8 +220,11 @@ extern int	ps_delta_layer_write(uint64_t layer_id, uint32_t timeline,
 								 PsLayerDesc *out);
 
 /*
- * Collect the deltas of (key, block) with lo_lsn < lsn <= hi_lsn from delta
+ * Collect the deltas of (key, block) with lo_lsn <= lsn < hi_lsn from delta
  * layer 'layer', in ascending LSN order, appending to *outs and updating *n.
+ * (Half-open: delta keys are WAL record start-LSNs and an image base_lsn is the
+ * start of the first record to apply, so the base's record is included and a
+ * record starting exactly at hi_lsn==read_lsn is excluded.)
  * *outs and *cap are a caller-owned growable buffer (start them NULL and 0; the
  * callee realloc's as needed and the caller frees *outs); there is no fixed
  * per-layer chain cap.  Each entry describes offset+len+crc of the payload in the

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -244,13 +244,18 @@ extern int	ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
  * apply, so the base's record is included and one starting at read_lsn is not).
  *
  * Precondition: read_lsn must be a record-boundary LSN -- a page LSN / pd_lsn,
- * i.e. the end of one record == the start of the next.  Every caller in this
- * system passes one (read_resolve a version's pd_lsn, read_at a snapshot LSN), so
- * the start-LSN-keyed [base_lsn, read_lsn) is exact: a version visible at end
- * E_j is produced by a record starting at E_{j-1}, and the records to apply are
- * exactly those with start in [base_lsn, read_lsn).  A read_lsn that fell *inside*
- * a record would wrongly include that record (whose result is newer than
- * read_lsn); such non-boundary LSNs are not produced by the page store.
+ * i.e. the end of one record == the start of the next.  Under it the start-LSN-
+ * keyed [base_lsn, read_lsn) is exact: a version visible at end E_j is produced
+ * by a record starting at E_{j-1}, so the records to apply are exactly those with
+ * start in [base_lsn, read_lsn).  A read_lsn that fell *inside* a record would
+ * wrongly include that record (whose result is newer than read_lsn).
+ *
+ * This is the *materialization* path (reconstructing a committed page version);
+ * it is not the arbitrary-LSN time-travel path.  The live read path -- including
+ * read_at, whose SQL entry takes an arbitrary pg_lsn that may fall between
+ * versions -- is served by read_resolve()/the version chain (newest version <=
+ * read_lsn), not by this planner.  Wiring the planner to arbitrary read-LSNs
+ * would first require keying deltas by record *end* LSN (a follow-up).
  *
  * The redo helper (7c)
  * applies the deltas onto the base; if there are no deltas the base *is* the

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -170,7 +170,7 @@ extern uint32_t ps_image_page_crc(const void *page, uint32_t len);
  * stores and serves the ordered deltas.
  * ------------------------------------------------------------------------- */
 #define PS_DELTA_MAGIC		0x544c4450	/* "PDLT" */
-#define PS_DELTA_VERSION	1
+#define PS_DELTA_VERSION	2			/* v2 added the per-record crc */
 
 typedef struct PsDeltaIndexEnt
 {
@@ -179,6 +179,7 @@ typedef struct PsDeltaIndexEnt
 	uint64_t	lsn;			/* record LSN of this delta */
 	uint64_t	data_off;		/* byte offset of the payload in the file */
 	uint32_t	data_len;		/* payload length */
+	uint32_t	crc;			/* checksum of this payload, verified before use */
 } PsDeltaIndexEnt;
 
 typedef struct PsDeltaFooter
@@ -208,6 +209,7 @@ typedef struct PsDeltaOut
 	uint64_t	lsn;
 	uint64_t	data_off;
 	uint32_t	data_len;
+	uint32_t	crc;			/* expected checksum of the payload bytes */
 } PsDeltaOut;
 
 /* Write 'n' deltas into delta layer 'layer_id', seal it, fill *out. */

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -219,15 +219,17 @@ extern int	ps_delta_layer_write(uint64_t layer_id, uint32_t timeline,
 
 /*
  * Collect the deltas of (key, block) with lo_lsn < lsn <= hi_lsn from delta
- * layer 'layer', in ascending LSN order.  Appends up to *cap entries to outs
- * (each describing offset+len of the payload within the layer) and updates *n;
- * call ps_layer_store read_layer_block at (data_off,data_len) to fetch a
+ * layer 'layer', in ascending LSN order, appending to *outs and updating *n.
+ * *outs and *cap are a caller-owned growable buffer (start them NULL and 0; the
+ * callee realloc's as needed and the caller frees *outs); there is no fixed
+ * per-layer chain cap.  Each entry describes offset+len+crc of the payload in the
+ * layer; call ps_layer_store read_layer_block at (data_off,data_len) to fetch a
  * payload.  Returns 0 on success, -1 on read/format error.
  */
 extern int	ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 								   uint32_t block, uint64_t lo_lsn,
-								   uint64_t hi_lsn, PsDeltaOut *outs,
-								   uint32_t cap, uint32_t *n);
+								   uint64_t hi_lsn, PsDeltaOut **outs,
+								   uint32_t *cap, uint32_t *n);
 
 /* ---------------------------------------------------------------------------
  * Read plan (phase 7b): how to reconstruct (key, block) as of read_lsn from the

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -242,6 +242,16 @@ extern int	ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
  * delta in [base_lsn, read_lsn), in ascending LSN order (half-open: delta keys
  * are WAL record start-LSNs, and base_lsn is the start of the first record to
  * apply, so the base's record is included and one starting at read_lsn is not).
+ *
+ * Precondition: read_lsn must be a record-boundary LSN -- a page LSN / pd_lsn,
+ * i.e. the end of one record == the start of the next.  Every caller in this
+ * system passes one (read_resolve a version's pd_lsn, read_at a snapshot LSN), so
+ * the start-LSN-keyed [base_lsn, read_lsn) is exact: a version visible at end
+ * E_j is produced by a record starting at E_{j-1}, and the records to apply are
+ * exactly those with start in [base_lsn, read_lsn).  A read_lsn that fell *inside*
+ * a record would wrongly include that record (whose result is newer than
+ * read_lsn); such non-boundary LSNs are not produced by the page store.
+ *
  * The redo helper (7c)
  * applies the deltas onto the base; if there are no deltas the base *is* the
  * page.  Payloads are materialized into the plan so the consumer needs no layer

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -156,4 +156,75 @@ extern int	ps_image_layer_read_index(const PsLayerDesc *layer,
  * read page bytes directly (compaction) validate them against idx[].crc. */
 extern uint32_t ps_image_page_crc(const void *page, uint32_t len);
 
+/* ---------------------------------------------------------------------------
+ * Delta layer file format (phase 7).
+ *
+ * A delta layer is an immutable file holding redo inputs (WAL records / page
+ * deltas) keyed by (key, block, record_lsn), variable length:
+ *     [ delta payloads, back to back ]
+ *     [ index : nrecs * PsDeltaIndexEnt, sorted by (key, block, lsn) ]
+ *     [ footer : PsDeltaFooter ]
+ * A read applies the deltas of (key, block) in ascending LSN order on top of a
+ * base image (an image layer) to reconstruct the page as of read_lsn.  The redo
+ * itself (rm_redo on a held page) is the wal-redo helper -- this format just
+ * stores and serves the ordered deltas.
+ * ------------------------------------------------------------------------- */
+#define PS_DELTA_MAGIC		0x544c4450	/* "PDLT" */
+#define PS_DELTA_VERSION	1
+
+typedef struct PsDeltaIndexEnt
+{
+	PsKey		key;
+	uint32_t	block;
+	uint64_t	lsn;			/* record LSN of this delta */
+	uint64_t	data_off;		/* byte offset of the payload in the file */
+	uint32_t	data_len;		/* payload length */
+} PsDeltaIndexEnt;
+
+typedef struct PsDeltaFooter
+{
+	uint32_t	magic;
+	uint32_t	version;
+	uint32_t	nrecs;
+	uint32_t	_pad;
+	uint64_t	index_off;		/* == payload section size */
+	uint32_t	data_crc;
+	uint32_t	index_crc;
+} PsDeltaFooter;
+
+/* One delta (redo input) to write into a delta layer. */
+typedef struct PsDeltaRec
+{
+	PsKey		key;
+	uint32_t	block;
+	uint64_t	lsn;
+	const void *delta;
+	uint32_t	delta_len;
+} PsDeltaRec;
+
+/* A delta read back from a layer (payload pointer is into a caller-freed buf). */
+typedef struct PsDeltaOut
+{
+	uint64_t	lsn;
+	uint32_t	data_off;
+	uint32_t	data_len;
+} PsDeltaOut;
+
+/* Write 'n' deltas into delta layer 'layer_id', seal it, fill *out. */
+extern int	ps_delta_layer_write(uint64_t layer_id, uint32_t timeline,
+								 const PsDeltaRec *recs, uint32_t n,
+								 PsLayerDesc *out);
+
+/*
+ * Collect the deltas of (key, block) with lo_lsn < lsn <= hi_lsn from delta
+ * layer 'layer', in ascending LSN order.  Appends up to *cap entries to outs
+ * (each describing offset+len of the payload within the layer) and updates *n;
+ * call ps_layer_store read_layer_block at (data_off,data_len) to fetch a
+ * payload.  Returns 0 on success, -1 on read/format error.
+ */
+extern int	ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
+								   uint32_t block, uint64_t lo_lsn,
+								   uint64_t hi_lsn, PsDeltaOut *outs,
+								   uint32_t cap, uint32_t *n);
+
 #endif							/* PAGESTORE_LAYER_H */

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -227,4 +227,39 @@ extern int	ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 								   uint64_t hi_lsn, PsDeltaOut *outs,
 								   uint32_t cap, uint32_t *n);
 
+/* ---------------------------------------------------------------------------
+ * Read plan (phase 7b): how to reconstruct (key, block) as of read_lsn from the
+ * layers -- the newest image-layer version <= read_lsn (the base) plus every
+ * delta in (base_lsn, read_lsn], in ascending LSN order.  The redo helper (7c)
+ * applies the deltas onto the base; if there are no deltas the base *is* the
+ * page.  Payloads are materialized into the plan so the consumer needs no layer
+ * access.  Single timeline for now (branch ancestry is a follow-up).
+ * ------------------------------------------------------------------------- */
+typedef struct PsPlanDelta
+{
+	uint64_t	lsn;
+	uint32_t	len;
+	unsigned char *bytes;		/* malloc'd payload */
+} PsPlanDelta;
+
+typedef struct PsReadPlan
+{
+	int			has_base;
+	uint64_t	base_lsn;
+	unsigned char *base;		/* malloc'd page_size, or NULL if no base */
+	PsPlanDelta *deltas;		/* malloc'd, ascending lsn */
+	uint32_t	ndelta;
+} PsReadPlan;
+
+/*
+ * Build the read plan for (timeline, key, block) as of read_lsn from 'map'.
+ * Returns 0 on success (plan filled; plan->has_base may be 0 if no image covers
+ * it), -1 on a read/format error.  Free with ps_read_plan_free.
+ */
+extern int	ps_read_plan_build(const PsLayerMap *map, uint32_t timeline,
+							   const PsKey *key, uint32_t block,
+							   uint64_t read_lsn, uint32_t page_size,
+							   PsReadPlan *plan);
+extern void ps_read_plan_free(PsReadPlan *plan);
+
 #endif							/* PAGESTORE_LAYER_H */

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -239,7 +239,10 @@ extern int	ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 /* ---------------------------------------------------------------------------
  * Read plan (phase 7b): how to reconstruct (key, block) as of read_lsn from the
  * layers -- the newest image-layer version <= read_lsn (the base) plus every
- * delta in (base_lsn, read_lsn], in ascending LSN order.  The redo helper (7c)
+ * delta in [base_lsn, read_lsn), in ascending LSN order (half-open: delta keys
+ * are WAL record start-LSNs, and base_lsn is the start of the first record to
+ * apply, so the base's record is included and one starting at read_lsn is not).
+ * The redo helper (7c)
  * applies the deltas onto the base; if there are no deltas the base *is* the
  * page.  Payloads are materialized into the plan so the consumer needs no layer
  * access.  Single timeline for now (branch ancestry is a follow-up).

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -92,17 +92,26 @@ main(void)
 	r = ps_image_layer_lookup(&d, &k9, 0, 1000, out, psz, NULL, NULL);
 	check(r == 0, "absent key -> no version");
 
-	/* same-lsn duplicate versions of one (key,block) -> lookup reports ambiguous
-	 * (the read plan must not start materialization from such a base) */
+	/* same-lsn duplicate versions of one (key,block): ambiguous only when the
+	 * bytes differ (a genuine rewrite).  Identical-byte duplicates within a layer
+	 * are benign (compaction merges crash-overlapped layers into one). */
 	{
-		PsLayerDesc da;
-		PsImgRec	dup[2] = {{k5, 0, 400, pg[0]}, {k5, 0, 400, pg[1]}};
+		PsLayerDesc da,
+					di;
+		PsImgRec	dup[2] = {{k5, 0, 400, pg[0]}, {k5, 0, 400, pg[1]}};	/* differ */
+		PsImgRec	idup[2] = {{k5, 0, 400, pg[2]}, {k5, 0, 400, pg[2]}};	/* same */
 		int			amb = -1;
 
 		check(ps_image_layer_write(11, 0, dup, 2, psz, &da) == 0,
-			  "write same-lsn duplicate layer");
+			  "write same-lsn differing-bytes layer");
 		r = ps_image_layer_lookup(&da, &k5, 0, 400, out, psz, NULL, &amb);
-		check(r == 1 && amb == 1, "same-lsn duplicate -> ambiguous");
+		check(r == 1 && amb == 1, "same-lsn differing bytes -> ambiguous");
+		amb = -1;
+		check(ps_image_layer_write(19, 0, idup, 2, psz, &di) == 0,
+			  "write same-lsn identical-bytes layer");
+		r = ps_image_layer_lookup(&di, &k5, 0, 400, out, psz, NULL, &amb);
+		check(r == 1 && amb == 0 && out[0] == 0xA3,
+			  "same-lsn identical bytes -> not ambiguous (compaction overlap)");
 		amb = -1;
 		r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, &amb);
 		check(r == 1 && amb == 0, "distinct lsn -> not ambiguous");
@@ -283,6 +292,24 @@ main(void)
 			  "overlapping layers expose record @200 once (deduped)");
 		ps_read_plan_free(&plan);
 		ps_layer_map_free(&map);
+
+		/* but two same-LSN delta records with *different* payloads are a real
+		 * conflict (qsort order is arbitrary) -> fail the plan, don't guess */
+		{
+			PsLayerDesc d3;
+			PsDeltaRec	dc[1] = {{k5, 0, 200, "zZZZ", 4}};	/* same lsn, diff bytes */
+			PsLayerMap	m2;
+			PsReadPlan	p2;
+
+			check(ps_delta_layer_write(20, 0, dc, 1, &d3) == 0, "conflict: delta3");
+			ps_layer_map_init(&m2);
+			ps_layer_map_add(&m2, &img);
+			ps_layer_map_add(&m2, &d1);		/* y200 */
+			ps_layer_map_add(&m2, &d3);		/* zZZZ @200 */
+			check(ps_read_plan_build(&m2, 0, &k5, 0, 300, psz, &p2) == -1,
+				  "conflicting same-lsn delta payloads -> plan rejects");
+			ps_layer_map_free(&m2);
+		}
 	}
 
 	/* --- read plan: identical-bytes duplicate base is tolerated, not rejected --- */

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -139,6 +139,47 @@ main(void)
 		check(r == 0 && dn == 1 && outs[0].lsn == 150, "delta collect other block");
 	}
 
+	/* --- read plan: base image + ordered delta chain --- */
+	{
+		PsLayerDesc img,
+					dl;
+		PsLayerMap	map;
+		PsReadPlan	plan;
+		PsImgRec	irecs[2] = {{k5, 0, 100, pg[0]}, {k5, 0, 200, pg[1]}};
+		PsDeltaRec	drecs[3] = {
+			{k5, 0, 150, "x150", 4}, {k5, 0, 250, "x250", 4}, {k5, 0, 300, "x300", 4},
+		};
+
+		check(ps_image_layer_write(9, 0, irecs, 2, psz, &img) == 0, "plan: image");
+		check(ps_delta_layer_write(10, 0, drecs, 3, &dl) == 0, "plan: delta");
+		ps_layer_map_init(&map);
+		ps_layer_map_add(&map, &img);
+		ps_layer_map_add(&map, &dl);
+
+		/* @250: base=image@200 (0xA2); deltas in (200,250] = {250} */
+		check(ps_read_plan_build(&map, 0, &k5, 0, 250, psz, &plan) == 0, "plan@250");
+		check(plan.has_base && plan.base_lsn == 200 && plan.base[0] == 0xA2,
+			  "plan@250 base = image@200");
+		check(plan.ndelta == 1 && plan.deltas[0].lsn == 250 &&
+			  memcmp(plan.deltas[0].bytes, "x250", 4) == 0, "plan@250 one delta");
+		ps_read_plan_free(&plan);
+
+		/* @300: base=image@200; deltas in (200,300] = {250,300} ascending */
+		check(ps_read_plan_build(&map, 0, &k5, 0, 300, psz, &plan) == 0, "plan@300");
+		check(plan.base_lsn == 200 && plan.ndelta == 2 &&
+			  plan.deltas[0].lsn == 250 && plan.deltas[1].lsn == 300,
+			  "plan@300 chain {250,300}");
+		ps_read_plan_free(&plan);
+
+		/* @180: base=image@100 (0xA1); deltas in (100,180] = {150} */
+		check(ps_read_plan_build(&map, 0, &k5, 0, 180, psz, &plan) == 0, "plan@180");
+		check(plan.base_lsn == 100 && plan.base[0] == 0xA1 && plan.ndelta == 1 &&
+			  plan.deltas[0].lsn == 150, "plan@180 base@100 + delta150");
+		ps_read_plan_free(&plan);
+
+		ps_layer_map_free(&map);
+	}
+
 	fprintf(stderr, "%d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;
 }

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -257,6 +257,34 @@ main(void)
 		ps_layer_map_free(&map);
 	}
 
+	/* --- read plan: overlapping delta layers expose a record only once --- */
+	{
+		PsLayerDesc img,
+					d1,
+					d2;
+		PsLayerMap	map;
+		PsReadPlan	plan;
+		PsImgRec	irecs[1] = {{k5, 0, 100, pg[0]}};
+		/* two delta layers both carrying the (5,0)@200 record (e.g. a replacement
+		 * layer added before the old one is marked deleting in compaction) */
+		PsDeltaRec	da[1] = {{k5, 0, 200, "y200", 4}};
+		PsDeltaRec	db[1] = {{k5, 0, 200, "y200", 4}};
+
+		check(ps_image_layer_write(14, 0, irecs, 1, psz, &img) == 0, "dedup: image");
+		check(ps_delta_layer_write(15, 0, da, 1, &d1) == 0, "dedup: delta1");
+		check(ps_delta_layer_write(16, 0, db, 1, &d2) == 0, "dedup: delta2");
+		ps_layer_map_init(&map);
+		ps_layer_map_add(&map, &img);
+		ps_layer_map_add(&map, &d1);
+		ps_layer_map_add(&map, &d2);
+		check(ps_read_plan_build(&map, 0, &k5, 0, 300, psz, &plan) == 0,
+			  "dedup: plan built");
+		check(plan.ndelta == 1 && plan.deltas[0].lsn == 200,
+			  "overlapping layers expose record @200 once (deduped)");
+		ps_read_plan_free(&plan);
+		ps_layer_map_free(&map);
+	}
+
 	fprintf(stderr, "%d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;
 }

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -107,6 +107,38 @@ main(void)
 		check(r == 1 && out[0] == 0xA2, "uncorrupted page still served");
 	}
 
+	/* --- delta layer: ordered collect in an LSN range --- */
+	{
+		PsLayerDesc dd;
+		PsDeltaRec	drecs[4] = {
+			{k5, 0, 300, "D300", 4}, {k5, 0, 100, "D100", 4},
+			{k5, 0, 200, "DD200", 5}, {k5, 1, 150, "E150", 4},
+		};
+		PsDeltaOut	outs[8];
+		uint32_t	dn = 0;
+		unsigned char dbuf[16];
+
+		check(ps_delta_layer_write(8, 0, drecs, 4, &dd) == 0, "write delta layer");
+		check(dd.kind == PS_LAYER_DELTA && dd.lsn_start == 100 &&
+			  dd.lsn_end == 300, "delta layer kind + lsn range");
+
+		/* (5,0) in (100, 300]: expect 200 then 300, ascending; 100 excluded */
+		r = ps_delta_layer_collect(&dd, &k5, 0, 100, 300, outs, 8, &dn);
+		check(r == 0 && dn == 2, "delta collect (100,300] -> 2 records");
+		check(outs[0].lsn == 200 && outs[1].lsn == 300, "deltas in ascending LSN");
+		check(ps_layer_store->read_layer_block(&dd, outs[0].data_off, dbuf,
+											   outs[0].data_len) == 0 &&
+			  outs[0].data_len == 5 && memcmp(dbuf, "DD200", 5) == 0,
+			  "delta payload readable (200)");
+
+		dn = 0;
+		r = ps_delta_layer_collect(&dd, &k5, 0, 0, 1000, outs, 8, &dn);
+		check(r == 0 && dn == 3, "delta collect (0,1000] -> all 3 of (5,0)");
+		dn = 0;
+		r = ps_delta_layer_collect(&dd, &k5, 1, 0, 1000, outs, 8, &dn);
+		check(r == 0 && dn == 1 && outs[0].lsn == 150, "delta collect other block");
+	}
+
 	fprintf(stderr, "%d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;
 }

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -77,20 +77,36 @@ main(void)
 	check(d.lsn_start == 100 && d.lsn_end == 300, "layer lsn range");
 
 	/* newest version <= read_lsn */
-	r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, NULL);
 	check(r == 1 && out[0] == 0xA2, "(5,0)@<=250 -> version 200");
-	r = ps_image_layer_lookup(&d, &k5, 0, 1000, out, psz, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 1000, out, psz, NULL, NULL);
 	check(r == 1 && out[0] == 0xA3, "(5,0)@<=1000 -> version 300");
-	r = ps_image_layer_lookup(&d, &k5, 0, 100, out, psz, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 100, out, psz, NULL, NULL);
 	check(r == 1 && out[0] == 0xA1, "(5,0)@<=100 -> version 100 (exact)");
-	r = ps_image_layer_lookup(&d, &k5, 0, 50, out, psz, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 50, out, psz, NULL, NULL);
 	check(r == 0, "(5,0)@<=50 -> no version (older than oldest)");
-	r = ps_image_layer_lookup(&d, &k5, 1, 1000, out, psz, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 1, 1000, out, psz, NULL, NULL);
 	check(r == 1 && out[0] == 0xB1, "(5,1) -> version 150");
-	r = ps_image_layer_lookup(&d, &k6, 0, 1000, out, psz, NULL);
+	r = ps_image_layer_lookup(&d, &k6, 0, 1000, out, psz, NULL, NULL);
 	check(r == 1 && out[0] == 0xC1, "(6,0) -> version 250");
-	r = ps_image_layer_lookup(&d, &k9, 0, 1000, out, psz, NULL);
+	r = ps_image_layer_lookup(&d, &k9, 0, 1000, out, psz, NULL, NULL);
 	check(r == 0, "absent key -> no version");
+
+	/* same-lsn duplicate versions of one (key,block) -> lookup reports ambiguous
+	 * (the read plan must not start materialization from such a base) */
+	{
+		PsLayerDesc da;
+		PsImgRec	dup[2] = {{k5, 0, 400, pg[0]}, {k5, 0, 400, pg[1]}};
+		int			amb = -1;
+
+		check(ps_image_layer_write(11, 0, dup, 2, psz, &da) == 0,
+			  "write same-lsn duplicate layer");
+		r = ps_image_layer_lookup(&da, &k5, 0, 400, out, psz, NULL, &amb);
+		check(r == 1 && amb == 1, "same-lsn duplicate -> ambiguous");
+		amb = -1;
+		r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, &amb);
+		check(r == 1 && amb == 0, "distinct lsn -> not ambiguous");
+	}
 
 	/* corrupt a page byte on disk -> lookup must reject it (per-page crc),
 	 * not hand back bad bytes.  (5,0)@100 sorts first, so its page is at off 0. */
@@ -101,9 +117,9 @@ main(void)
 		check(fd >= 0 && pwrite(fd, &bad, 1, 0) == 1, "corrupt a page byte");
 		if (fd >= 0)
 			close(fd);
-		r = ps_image_layer_lookup(&d, &k5, 0, 100, out, psz, NULL);
+		r = ps_image_layer_lookup(&d, &k5, 0, 100, out, psz, NULL, NULL);
 		check(r == -1, "corrupted page -> lookup rejects (data crc)");
-		r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL);
+		r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, NULL);
 		check(r == 1 && out[0] == 0xA2, "uncorrupted page still served");
 	}
 
@@ -123,18 +139,18 @@ main(void)
 		check(dd.kind == PS_LAYER_DELTA && dd.lsn_start == 100 &&
 			  dd.lsn_end == 300, "delta layer kind + lsn range");
 
-		/* (5,0) in (100, 300]: expect 200 then 300, ascending; 100 excluded */
+		/* (5,0) in [100, 300): half-open -> 100 then 200, ascending; 300 excluded */
 		r = ps_delta_layer_collect(&dd, &k5, 0, 100, 300, &outs, &ocap, &dn);
-		check(r == 0 && dn == 2, "delta collect (100,300] -> 2 records");
-		check(outs[0].lsn == 200 && outs[1].lsn == 300, "deltas in ascending LSN");
-		check(ps_layer_store->read_layer_block(&dd, outs[0].data_off, dbuf,
-											   outs[0].data_len) == 0 &&
-			  outs[0].data_len == 5 && memcmp(dbuf, "DD200", 5) == 0,
+		check(r == 0 && dn == 2, "delta collect [100,300) -> 2 records");
+		check(outs[0].lsn == 100 && outs[1].lsn == 200, "deltas in ascending LSN");
+		check(ps_layer_store->read_layer_block(&dd, outs[1].data_off, dbuf,
+											   outs[1].data_len) == 0 &&
+			  outs[1].data_len == 5 && memcmp(dbuf, "DD200", 5) == 0,
 			  "delta payload readable (200)");
 
 		dn = 0;
 		r = ps_delta_layer_collect(&dd, &k5, 0, 0, 1000, &outs, &ocap, &dn);
-		check(r == 0 && dn == 3, "delta collect (0,1000] -> all 3 of (5,0)");
+		check(r == 0 && dn == 3, "delta collect [0,1000) -> all 3 of (5,0)");
 		dn = 0;
 		r = ps_delta_layer_collect(&dd, &k5, 1, 0, 1000, &outs, &ocap, &dn);
 		check(r == 0 && dn == 1 && outs[0].lsn == 150, "delta collect other block");
@@ -170,22 +186,21 @@ main(void)
 		ps_layer_map_add(&map, &img);
 		ps_layer_map_add(&map, &dl);
 
-		/* @250: base=image@200 (0xA2); deltas in (200,250] = {250} */
+		/* @250: base=image@200 (0xA2); deltas in [200,250) = {} (250 excluded) */
 		check(ps_read_plan_build(&map, 0, &k5, 0, 250, psz, &plan) == 0, "plan@250");
 		check(plan.has_base && plan.base_lsn == 200 && plan.base[0] == 0xA2,
 			  "plan@250 base = image@200");
-		check(plan.ndelta == 1 && plan.deltas[0].lsn == 250 &&
-			  memcmp(plan.deltas[0].bytes, "x250", 4) == 0, "plan@250 one delta");
+		check(plan.ndelta == 0, "plan@250 no deltas (250 is exclusive upper bound)");
 		ps_read_plan_free(&plan);
 
-		/* @300: base=image@200; deltas in (200,300] = {250,300} ascending */
+		/* @300: base=image@200; deltas in [200,300) = {250} (300 excluded) */
 		check(ps_read_plan_build(&map, 0, &k5, 0, 300, psz, &plan) == 0, "plan@300");
-		check(plan.base_lsn == 200 && plan.ndelta == 2 &&
-			  plan.deltas[0].lsn == 250 && plan.deltas[1].lsn == 300,
-			  "plan@300 chain {250,300}");
+		check(plan.base_lsn == 200 && plan.ndelta == 1 &&
+			  plan.deltas[0].lsn == 250 &&
+			  memcmp(plan.deltas[0].bytes, "x250", 4) == 0, "plan@300 chain {250}");
 		ps_read_plan_free(&plan);
 
-		/* @180: base=image@100 (0xA1); deltas in (100,180] = {150} */
+		/* @180: base=image@100 (0xA1); deltas in [100,180) = {150} */
 		check(ps_read_plan_build(&map, 0, &k5, 0, 180, psz, &plan) == 0, "plan@180");
 		check(plan.base_lsn == 100 && plan.base[0] == 0xA1 && plan.ndelta == 1 &&
 			  plan.deltas[0].lsn == 150, "plan@180 base@100 + delta150");

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -114,7 +114,8 @@ main(void)
 			{k5, 0, 300, "D300", 4}, {k5, 0, 100, "D100", 4},
 			{k5, 0, 200, "DD200", 5}, {k5, 1, 150, "E150", 4},
 		};
-		PsDeltaOut	outs[8];
+		PsDeltaOut *outs = NULL;	/* growable: no fixed per-layer chain cap */
+		uint32_t	ocap = 0;
 		uint32_t	dn = 0;
 		unsigned char dbuf[16];
 
@@ -123,7 +124,7 @@ main(void)
 			  dd.lsn_end == 300, "delta layer kind + lsn range");
 
 		/* (5,0) in (100, 300]: expect 200 then 300, ascending; 100 excluded */
-		r = ps_delta_layer_collect(&dd, &k5, 0, 100, 300, outs, 8, &dn);
+		r = ps_delta_layer_collect(&dd, &k5, 0, 100, 300, &outs, &ocap, &dn);
 		check(r == 0 && dn == 2, "delta collect (100,300] -> 2 records");
 		check(outs[0].lsn == 200 && outs[1].lsn == 300, "deltas in ascending LSN");
 		check(ps_layer_store->read_layer_block(&dd, outs[0].data_off, dbuf,
@@ -132,17 +133,24 @@ main(void)
 			  "delta payload readable (200)");
 
 		dn = 0;
-		r = ps_delta_layer_collect(&dd, &k5, 0, 0, 1000, outs, 8, &dn);
+		r = ps_delta_layer_collect(&dd, &k5, 0, 0, 1000, &outs, &ocap, &dn);
 		check(r == 0 && dn == 3, "delta collect (0,1000] -> all 3 of (5,0)");
 		dn = 0;
-		r = ps_delta_layer_collect(&dd, &k5, 1, 0, 1000, outs, 8, &dn);
+		r = ps_delta_layer_collect(&dd, &k5, 1, 0, 1000, &outs, &ocap, &dn);
 		check(r == 0 && dn == 1 && outs[0].lsn == 150, "delta collect other block");
 
-		/* overflow: (5,0) has 3 matches but the cap is 2 -> error, not a silent
-		 * truncated chain */
-		dn = 0;
-		r = ps_delta_layer_collect(&dd, &k5, 0, 0, 1000, outs, 2, &dn);
-		check(r == -1, "delta collect overflow (cap < matches) -> error");
+		/* a small starting buffer must grow to hold all matches (no fixed cap):
+		 * collect into a fresh NULL/0 buffer and expect all 3, not an overflow */
+		{
+			PsDeltaOut *g = NULL;
+			uint32_t	gcap = 0,
+						gn = 0;
+
+			r = ps_delta_layer_collect(&dd, &k5, 0, 0, 1000, &g, &gcap, &gn);
+			check(r == 0 && gn == 3, "delta collect grows buffer -> all 3 (no cap)");
+			free(g);
+		}
+		free(outs);
 	}
 
 	/* --- read plan: base image + ordered delta chain --- */

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -237,10 +237,10 @@ main(void)
 		ps_layer_map_init(&map);
 		ps_layer_map_add(&map, &a);
 		ps_layer_map_add(&map, &b);
-		/* same page LSN split across two image layers -> ambiguous base -> reject
-		 * (caller would serve from the authoritative segment) */
+		/* same page LSN in two image layers with *different* bytes (a genuine
+		 * same-lsn rewrite) -> ambiguous base -> reject (segment serves it) */
 		check(ps_read_plan_build(&map, 0, &k5, 0, 600, psz, &plan) == -1,
-			  "cross-layer same-lsn base -> plan rejects (ambiguous)");
+			  "cross-layer same-lsn base, differing bytes -> plan rejects");
 
 		/* a covering image layer that is corrupt must fail the plan, not fall back
 		 * to an older base: corrupt B's page on disk, read at 500 */
@@ -281,6 +281,29 @@ main(void)
 			  "dedup: plan built");
 		check(plan.ndelta == 1 && plan.deltas[0].lsn == 200,
 			  "overlapping layers expose record @200 once (deduped)");
+		ps_read_plan_free(&plan);
+		ps_layer_map_free(&map);
+	}
+
+	/* --- read plan: identical-bytes duplicate base is tolerated, not rejected --- */
+	{
+		PsLayerDesc a,
+					b;
+		PsLayerMap	map;
+		PsReadPlan	plan;
+		/* two image layers with the SAME (key,block,lsn) AND identical bytes --
+		 * the crash-safe compaction overlap (install-new-before-delete-old) */
+		PsImgRec	ra[1] = {{k5, 0, 700, pg[2]}};
+		PsImgRec	rb[1] = {{k5, 0, 700, pg[2]}};
+
+		check(ps_image_layer_write(17, 0, ra, 1, psz, &a) == 0, "dupbase: layer A");
+		check(ps_image_layer_write(18, 0, rb, 1, psz, &b) == 0, "dupbase: layer B");
+		ps_layer_map_init(&map);
+		ps_layer_map_add(&map, &a);
+		ps_layer_map_add(&map, &b);
+		check(ps_read_plan_build(&map, 0, &k5, 0, 800, psz, &plan) == 0 &&
+			  plan.has_base && plan.base_lsn == 700 && plan.base[0] == 0xA3,
+			  "identical duplicate base across layers -> tolerated (not ambiguous)");
 		ps_read_plan_free(&plan);
 		ps_layer_map_free(&map);
 	}

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -223,6 +223,40 @@ main(void)
 		ps_layer_map_free(&map);
 	}
 
+	/* --- read plan: cross-layer ambiguity + corrupt base both fail the plan --- */
+	{
+		PsLayerDesc a,
+					b;
+		PsLayerMap	map;
+		PsReadPlan	plan;
+		PsImgRec	ra[1] = {{k5, 0, 500, pg[0]}};
+		PsImgRec	rb[1] = {{k5, 0, 500, pg[1]}};	/* same (key,block,lsn) */
+
+		check(ps_image_layer_write(12, 0, ra, 1, psz, &a) == 0, "amb: layer A@500");
+		check(ps_image_layer_write(13, 0, rb, 1, psz, &b) == 0, "amb: layer B@500");
+		ps_layer_map_init(&map);
+		ps_layer_map_add(&map, &a);
+		ps_layer_map_add(&map, &b);
+		/* same page LSN split across two image layers -> ambiguous base -> reject
+		 * (caller would serve from the authoritative segment) */
+		check(ps_read_plan_build(&map, 0, &k5, 0, 600, psz, &plan) == -1,
+			  "cross-layer same-lsn base -> plan rejects (ambiguous)");
+
+		/* a covering image layer that is corrupt must fail the plan, not fall back
+		 * to an older base: corrupt B's page on disk, read at 500 */
+		{
+			int			fd = open(b.locations[0].uri, O_WRONLY);
+			unsigned char bad = 0xFF;
+
+			check(fd >= 0 && pwrite(fd, &bad, 1, 0) == 1, "amb: corrupt B page");
+			if (fd >= 0)
+				close(fd);
+			check(ps_read_plan_build(&map, 0, &k5, 0, 600, psz, &plan) == -1,
+				  "corrupt covering base layer -> plan fails (no stale fallback)");
+		}
+		ps_layer_map_free(&map);
+	}
+
 	fprintf(stderr, "%d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;
 }

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -137,6 +137,12 @@ main(void)
 		dn = 0;
 		r = ps_delta_layer_collect(&dd, &k5, 1, 0, 1000, outs, 8, &dn);
 		check(r == 0 && dn == 1 && outs[0].lsn == 150, "delta collect other block");
+
+		/* overflow: (5,0) has 3 matches but the cap is 2 -> error, not a silent
+		 * truncated chain */
+		dn = 0;
+		r = ps_delta_layer_collect(&dd, &k5, 0, 0, 1000, outs, 2, &dn);
+		check(r == -1, "delta collect overflow (cap < matches) -> error");
 	}
 
 	/* --- read plan: base image + ordered delta chain --- */

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -183,6 +183,20 @@ main(void)
 			  plan.deltas[0].lsn == 150, "plan@180 base@100 + delta150");
 		ps_read_plan_free(&plan);
 
+		/* corrupt a delta payload byte on disk -> the read plan must reject it
+		 * (per-record crc), not feed bad WAL bytes to redo.  x150 sorts first, so
+		 * its payload is at offset 0. */
+		{
+			int			fd = open(dl.locations[0].uri, O_WRONLY);
+			unsigned char bad = 0xFF;
+
+			check(fd >= 0 && pwrite(fd, &bad, 1, 0) == 1, "corrupt a delta byte");
+			if (fd >= 0)
+				close(fd);
+			check(ps_read_plan_build(&map, 0, &k5, 0, 180, psz, &plan) == -1,
+				  "corrupted delta payload -> read plan rejects (crc)");
+		}
+
 		ps_layer_map_free(&map);
 	}
 


### PR DESCRIPTION
Foundation for the WAL-delta + redo read path: the immutable delta-layer file format and writer/reader (7a), and the read plan (base image + ordered delta chain) a redo helper consumes (7b). Includes MATERIALIZATION.md (deployment-agnostic ingest/materialize abstraction: page-ingest vs wal-ingest; redo placement inline/local-worker/serverless). Layer unit test 26/0; not yet wired into the live read path (redo apply is a later step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)