### PR TITLE
contrib/pagestore: materialized-page cache + SPDK integration (LSM phase 8)

### DIFF
--- a/.github/workflows/pagestore-test.yml
+++ b/.github/workflows/pagestore-test.yml
@@ -28,9 +28,10 @@ jobs:
       - name: Compile daemon and test harness
         working-directory: contrib/pagestore
         run: |
-          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c pagestore_core.c storage_posix.c pagestore_layer.c pagestore_layer_store.c pagestore_manifest.c pagestore_memtable.c -lrt
+          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c pagestore_core.c storage_posix.c pagestore_layer.c pagestore_layer_store.c pagestore_manifest.c pagestore_memtable.c pagestore_pgcache.c -lrt
           cc -O2 -Wall -Wextra -Werror -o pagestore_test   pagestore_test.c   -lrt
           cc -O2 -Wall -Wextra -Werror -o pagestore_layer_test pagestore_layer_test.c pagestore_layer.c pagestore_layer_store.c -lrt
+          cc -O2 -Wall -Wextra -Werror -o pagestore_pgcache_test pagestore_pgcache_test.c pagestore_pgcache.c -lrt
 
       - name: Run standalone test suite
         working-directory: contrib/pagestore
@@ -39,6 +40,10 @@ jobs:
       - name: Run image-layer unit test
         working-directory: contrib/pagestore
         run: ./pagestore_layer_test
+
+      - name: Run materialized-page cache unit test
+        working-directory: contrib/pagestore
+        run: ./pagestore_pgcache_test
 
   # In-engine test: build PostgreSQL and exercise the real path (smgr hijack,
   # localsvc backend over the daemon, COW read_at, WAL shipping).  Heavier --

--- a/contrib/pagestore/meson.build
+++ b/contrib/pagestore/meson.build
@@ -23,7 +23,7 @@ contrib_targets += pagestore
 pagestore_daemon = executable('pagestore_daemon',
   files('pagestore_daemon.c', 'pagestore_core.c', 'storage_posix.c',
         'pagestore_layer.c', 'pagestore_layer_store.c', 'pagestore_manifest.c',
-        'pagestore_memtable.c'),
+        'pagestore_memtable.c', 'pagestore_pgcache.c'),
   kwargs: default_bin_args,
 )
 contrib_targets += pagestore_daemon
@@ -74,6 +74,17 @@ pagestore_layer_test = executable('pagestore_layer_test',
 )
 test('pagestore_layer',
   pagestore_layer_test,
+  suite: ['pagestore'],
+  timeout: 60,
+)
+
+# Unit test for the scan-resistant materialized-page cache (no daemon, no PG).
+pagestore_pgcache_test = executable('pagestore_pgcache_test',
+  files('pagestore_pgcache_test.c', 'pagestore_pgcache.c'),
+  install: false,
+)
+test('pagestore_pgcache',
+  pagestore_pgcache_test,
   suite: ['pagestore'],
   timeout: 60,
 )

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -632,6 +632,45 @@ read_through(uint32_t timeline, const PsKey *key, uint32_t block,
 }
 
 /*
+ * Like read_through(), but for frontends that cache pages keyed by
+ * (timeline,key,block,lsn).  It also reports the timeline the version was found
+ * on (*src_tl): a read falls through to ancestor timelines, so an inherited page
+ * must be cached under its source timeline, not the requested one -- otherwise a
+ * branch that later writes its own same-lsn copy of the block would keep hitting
+ * the inherited bytes.  And it reports whether that version's page LSN is
+ * ambiguous (*ambiguous): a same-lsn rewrite (e.g. hint bits) means the lsn does
+ * not uniquely identify the version, so it is not safe to serve from or store in
+ * an lsn-keyed cache.  Returns the chosen PageVer, or NULL (with *src_tl set to
+ * the requested timeline and *ambiguous cleared).
+ */
+PageVer *
+read_through_cacheable(uint32_t timeline, const PsKey *key, uint32_t block,
+					   uint64_t read_lsn, uint32_t *src_tl, int *ambiguous)
+{
+	for (;;)
+	{
+		PageEnt    *e = page_find(timeline, key, block);
+		PageVer    *v = e ? page_visible(e, read_lsn) : NULL;
+
+		if (v)
+		{
+			*src_tl = timeline;
+			*ambiguous = page_lsn_ambiguous(e, v->lsn);
+			return v;
+		}
+		if (!timeline_has_parent(timeline))
+		{
+			*src_tl = timeline;
+			*ambiguous = 0;
+			return NULL;
+		}
+		if (timelines[timeline].branch_lsn < read_lsn)
+			read_lsn = timelines[timeline].branch_lsn;
+		timeline = (uint32_t) timelines[timeline].parent;
+	}
+}
+
+/*
  * Fork size visible on 'timeline': the maximum block count across the timeline
  * and all its ancestors.  A branch that has written only some blocks of a fork
  * still inherits the parent's full size (the unwritten blocks are served by

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1366,7 +1366,15 @@ ps_core_open(const char *store_dir)
 			return -1;
 	}
 	/* the materialized-page cache helps both read paths (read_resolve and the
-	 * SPDK async path), so it is not gated on use_layers */
+	 * SPDK async path), so it is not gated on use_layers.  Reject a negative
+	 * --cache-pages before the unsigned cast (it would become a huge capacity and
+	 * make ps_pgcache_init attempt an enormous allocation); 0 disables the cache. */
+	if (cache_pages < 0)
+	{
+		fprintf(stderr, "pagestore_core: --cache-pages must be >= 0 (got %d)\n",
+				cache_pages);
+		return -1;
+	}
 	ps_pgcache_init((uint32_t) cache_pages, page_size);
 	fprintf(stderr, "pagestore_core: %u image layer(s) in map after manifest "
 			"replay (next layer id %llu)\n", ps_layer_map.nlayers,

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -36,12 +36,14 @@
 #include "pagestore_layer_store.h"
 #include "pagestore_manifest.h"
 #include "pagestore_memtable.h"
+#include "pagestore_pgcache.h"
 
 /* configuration, set by the frontend before ps_core_open() */
 uint32_t	page_size = PS_DEFAULT_PAGE_SIZE;
 uint64_t	segment_size = 8 * 1024 * 1024;
 int			flush_pages = 256;	/* memtable flush threshold (pages) */
 int			compact_layers = 8;	/* compact a timeline past this many image layers */
+int			cache_pages = 1024;	/* materialized-page cache size (pages; 0=off) */
 /*
  * Use the LSM read path: rebuild the index from image layers on restart and
  * (in the frontend) serve reads via read_resolve.  The POSIX daemon enables it;
@@ -1066,28 +1068,38 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 		if (pv)
 		{
 			uint64_t	l;
+			int			served;
+
+			/* fast path: materialized-page cache, keyed by the resolved version */
+			if (ps_pgcache_lookup(tl, key, block, pv->lsn, out))
+				return 1;
 
 			/* The memtable / image-layer fast paths identify a version only by
 			 * lsn; if that lsn is ambiguous (a same-lsn rewrite, e.g. hint bits),
 			 * a same-lsn hit may be an older version than the authoritative latest
 			 * append, so serve from the segment (pv's exact location) instead. */
-			if (!page_lsn_ambiguous(e, pv->lsn))
+			if (!page_lsn_ambiguous(e, pv->lsn) && g_memtable &&
+				ps_memtable_lookup(g_memtable, tl, key, block, rl, &l, out) &&
+				l == pv->lsn)
 			{
-				if (g_memtable &&
-					ps_memtable_lookup(g_memtable, tl, key, block, rl, &l, out) &&
-					l == pv->lsn)
-				{
-					rr_mem++;
-					return 1;	/* served from the memtable */
-				}
-				if (layer_map_lookup(tl, key, block, rl, &l, out) && l == pv->lsn)
-				{
-					rr_layer++;
-					return 1;	/* served from an image layer */
-				}
+				rr_mem++;
+				served = 1;		/* served from the memtable */
 			}
-			rr_seg++;
-			return read_version(pv, out) == 0 ? 1 : 0;	/* segment fallback */
+			else if (!page_lsn_ambiguous(e, pv->lsn) &&
+					 layer_map_lookup(tl, key, block, rl, &l, out) &&
+					 l == pv->lsn)
+			{
+				rr_layer++;
+				served = 1;		/* served from an image layer */
+			}
+			else
+			{
+				rr_seg++;
+				served = (read_version(pv, out) == 0);	/* segment fallback */
+			}
+			if (served)
+				ps_pgcache_insert(tl, key, block, pv->lsn, out);
+			return served ? 1 : 0;
 		}
 		if (!timeline_has_parent(tl))
 			return 0;
@@ -1255,6 +1267,7 @@ ps_core_close(void)
 				count_image_layers(ct) > (uint32_t) compact_layers)
 				compact_timeline(ct);
 	}
+	ps_pgcache_free();
 	ps_manifest_close();
 }
 
@@ -1310,6 +1323,7 @@ ps_core_open(const char *store_dir)
 		g_memtable = ps_memtable_create(page_size, (uint32_t) flush_pages);
 		if (!g_memtable)
 			return -1;
+		ps_pgcache_init((uint32_t) cache_pages, page_size);
 	}
 	fprintf(stderr, "pagestore_core: %u image layer(s) in map after manifest "
 			"replay (next layer id %llu)\n", ps_layer_map.nlayers,

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1323,8 +1323,10 @@ ps_core_open(const char *store_dir)
 		g_memtable = ps_memtable_create(page_size, (uint32_t) flush_pages);
 		if (!g_memtable)
 			return -1;
-		ps_pgcache_init((uint32_t) cache_pages, page_size);
 	}
+	/* the materialized-page cache helps both read paths (read_resolve and the
+	 * SPDK async path), so it is not gated on use_layers */
+	ps_pgcache_init((uint32_t) cache_pages, page_size);
 	fprintf(stderr, "pagestore_core: %u image layer(s) in map after manifest "
 			"replay (next layer id %llu)\n", ps_layer_map.nlayers,
 			(unsigned long long) g_next_layer_id);

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1069,23 +1069,25 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 		{
 			uint64_t	l;
 			int			served;
+			/* If pv->lsn is ambiguous (a same-lsn rewrite, e.g. hint bits) the
+			 * lsn does not uniquely identify a version, so every lsn-keyed fast
+			 * path -- the materialized-page cache, the memtable and the image
+			 * layers -- may return an older version than the authoritative latest
+			 * append.  Bypass all of them (including caching the result) and serve
+			 * from the segment (pv's exact location). */
+			int			ambig = page_lsn_ambiguous(e, pv->lsn);
 
-			/* fast path: materialized-page cache, keyed by the resolved version */
-			if (ps_pgcache_lookup(tl, key, block, pv->lsn, out))
+			if (!ambig && ps_pgcache_lookup(tl, key, block, pv->lsn, out))
 				return 1;
 
-			/* The memtable / image-layer fast paths identify a version only by
-			 * lsn; if that lsn is ambiguous (a same-lsn rewrite, e.g. hint bits),
-			 * a same-lsn hit may be an older version than the authoritative latest
-			 * append, so serve from the segment (pv's exact location) instead. */
-			if (!page_lsn_ambiguous(e, pv->lsn) && g_memtable &&
+			if (!ambig && g_memtable &&
 				ps_memtable_lookup(g_memtable, tl, key, block, rl, &l, out) &&
 				l == pv->lsn)
 			{
 				rr_mem++;
 				served = 1;		/* served from the memtable */
 			}
-			else if (!page_lsn_ambiguous(e, pv->lsn) &&
+			else if (!ambig &&
 					 layer_map_lookup(tl, key, block, rl, &l, out) &&
 					 l == pv->lsn)
 			{
@@ -1097,7 +1099,7 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 				rr_seg++;
 				served = (read_version(pv, out) == 0);	/* segment fallback */
 			}
-			if (served)
+			if (served && !ambig)
 				ps_pgcache_insert(tl, key, block, pv->lsn, out);
 			return served ? 1 : 0;
 		}

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -65,6 +65,14 @@ extern int	append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 						const unsigned char *page);
 extern PageVer *read_through(uint32_t timeline, const PsKey *key, uint32_t block,
 							 uint64_t read_lsn);
+/*
+ * read_through() variant for lsn-keyed page caches: also reports the timeline the
+ * version was found on (*src_tl, the correct cache key under COW inheritance) and
+ * whether its page LSN is ambiguous (*ambiguous, i.e. unsafe to cache by lsn).
+ */
+extern PageVer *read_through_cacheable(uint32_t timeline, const PsKey *key,
+									   uint32_t block, uint64_t read_lsn,
+									   uint32_t *src_tl, int *ambiguous);
 extern int	read_version(const PageVer *v, unsigned char *out);
 
 /*

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -37,6 +37,7 @@ extern uint32_t page_size;
 extern uint64_t segment_size;
 extern int	flush_pages;		/* memtable flush threshold in pages */
 extern int	compact_layers;		/* compact a timeline past this many image layers */
+extern int	cache_pages;		/* materialized-page cache size (pages; 0=off) */
 extern int	use_layers;			/* rebuild read state from layers (vs segments) */
 extern const PsStorage *ps_storage;
 

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -30,6 +30,7 @@
 
 #include "pagestore_ipc.h"
 #include "pagestore_core.h"
+#include "pagestore_pgcache.h"
 
 static volatile sig_atomic_t stop_requested = 0;
 
@@ -126,6 +127,8 @@ main(int argc, char **argv)
 			flush_pages = atoi(argv[++i]);
 		else if (strcmp(argv[i], "--compact-layers") == 0 && i + 1 < argc)
 			compact_layers = atoi(argv[++i]);
+		else if (strcmp(argv[i], "--cache-pages") == 0 && i + 1 < argc)
+			cache_pages = atoi(argv[++i]);
 		else if (strcmp(argv[i], "--storage") == 0 && i + 1 < argc)
 		{
 			const char *name = argv[++i];
@@ -237,13 +240,19 @@ main(int argc, char **argv)
 	{
 		uint64_t	rm,
 					rl,
-					rs;
+					rs,
+					ch,
+					cm,
+					ce;
 
 		ps_core_read_stats(&rm, &rl, &rs);
+		ps_pgcache_stats(&ch, &cm, &ce);
 		fprintf(stderr, "pagestore_daemon: shutting down (%u image layers; reads "
-				"mem=%llu layer=%llu seg=%llu)\n", ps_core_layer_count(),
+				"mem=%llu layer=%llu seg=%llu; pgcache hit=%llu miss=%llu evict=%llu)\n",
+				ps_core_layer_count(),
 				(unsigned long long) rm, (unsigned long long) rl,
-				(unsigned long long) rs);
+				(unsigned long long) rs, (unsigned long long) ch,
+				(unsigned long long) cm, (unsigned long long) ce);
 	}
 	ps_core_close();			/* flush the memtable so restart rebuilds from layers */
 	munmap(shm, PS_SHM_SIZE);

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -31,6 +31,7 @@
 
 #include "pagestore_ipc.h"
 #include "pagestore_core.h"
+#include "pagestore_pgcache.h"
 #include "storage_spdk.h"
 
 /* most page reads a single request can carry (nblocks * page_size <= io_unit) */
@@ -45,23 +46,39 @@ on_signal(int sig)
 	stop_requested = 1;
 }
 
+/* per-block context for one async page read: lets the completion populate the
+ * materialized-page cache and find its parent request */
+typedef struct BlkCtx
+{
+	struct ReqState *rs;
+	uint32_t	tl;
+	PsKey		key;
+	uint32_t	block;
+	uint64_t	lsn;
+	unsigned char *dst;
+} BlkCtx;
+
 /* per-channel in-flight read request */
 typedef struct ReqState
 {
 	PsChannel  *ch;
 	int			active;			/* a read request is in flight on this channel */
 	int			pending;		/* page reads not yet completed */
+	BlkCtx		blk[MAX_BLOCKS];	/* one per submitted (cache-missed) read */
 } ReqState;
 
 static ReqState reqstate[PS_MAX_CHANNELS];
 
-/* one page read finished; when the last of a request lands, publish the reply */
+/* one page read finished: cache the page, and when the last of a request lands
+ * publish the reply */
 static void
 read_done(void *arg, int ok)
 {
-	ReqState   *rs = arg;
+	BlkCtx	   *bc = arg;
+	ReqState   *rs = bc->rs;
 
-	(void) ok;					/* the engine already delivered/zeroed the page */
+	if (ok)						/* the engine delivered the page into bc->dst */
+		ps_pgcache_insert(bc->tl, &bc->key, bc->block, bc->lsn, bc->dst);
 	if (--rs->pending == 0)
 	{
 		rs->active = 0;			/* clear before publishing DONE */
@@ -117,7 +134,6 @@ begin(uint32_t i, PsChannel *ch)
 
 		case PS_OP_READV:
 			{
-				PageVer    *locs[MAX_BLOCKS];
 				uint32_t	nb = ch->nblocks;
 				ReqState   *rs = &reqstate[i];
 
@@ -129,31 +145,39 @@ begin(uint32_t i, PsChannel *ch)
 				}
 				rs->ch = ch;
 				rs->pending = 0;
-				for (uint32_t b = 0; b < nb; b++)
-				{
-					locs[b] = read_through(tl, &ch->key, ch->blocknum + b,
-										   UINT64_MAX);
-					if (locs[b])
-						rs->pending++;
-				}
-				if (rs->pending == 0)	/* all unwritten -> zeros */
-				{
-					memset(ch->data, 0, (size_t) nb * page_size);
-					ps_store_release(&ch->state, PS_STATE_DONE);
-					return;
-				}
 				rs->active = 1;
+				/* completions only fire from ps_spdk_poll() (the main loop), not
+				 * during submit, so incrementing pending as we go is safe */
 				for (uint32_t b = 0; b < nb; b++)
 				{
 					unsigned char *dst = ch->data + (size_t) b * page_size;
+					uint32_t	blk = ch->blocknum + b;
+					PageVer    *v = read_through(tl, &ch->key, blk, UINT64_MAX);
+					BlkCtx	   *bc;
 
-					if (!locs[b])
-						memset(dst, 0, page_size);
-					else
-						ps_spdk_read_async(locs[b]->seg, locs[b]->off, dst,
-										   page_size, read_done, rs);
+					if (!v)
+					{
+						memset(dst, 0, page_size);	/* unwritten -> zeros */
+						continue;
+					}
+					if (ps_pgcache_lookup(tl, &ch->key, blk, v->lsn, dst))
+						continue;	/* RAM hit -> no device read */
+					bc = &rs->blk[rs->pending++];
+					bc->rs = rs;
+					bc->tl = tl;
+					bc->key = ch->key;
+					bc->block = blk;
+					bc->lsn = v->lsn;
+					bc->dst = dst;
+					ps_spdk_read_async(v->seg, v->off, dst, page_size,
+									   read_done, bc);
 				}
-				return;			/* DONE published by read_done */
+				if (rs->pending == 0)	/* all cached or unwritten */
+				{
+					rs->active = 0;
+					ps_store_release(&ch->state, PS_STATE_DONE);
+				}
+				return;			/* DONE published by read_done otherwise */
 			}
 
 		case PS_OP_READ_AT:
@@ -161,6 +185,7 @@ begin(uint32_t i, PsChannel *ch)
 				PageVer    *v = read_through(tl, &ch->key, ch->blocknum,
 											 ch->req_lsn);
 				ReqState   *rs = &reqstate[i];
+				BlkCtx	   *bc;
 
 				if (!v)
 				{
@@ -168,11 +193,24 @@ begin(uint32_t i, PsChannel *ch)
 					ps_store_release(&ch->state, PS_STATE_DONE);
 					return;
 				}
+				if (ps_pgcache_lookup(tl, &ch->key, ch->blocknum, v->lsn,
+									  ch->data))
+				{
+					ps_store_release(&ch->state, PS_STATE_DONE);	/* RAM hit */
+					return;
+				}
 				rs->ch = ch;
 				rs->pending = 1;
 				rs->active = 1;
+				bc = &rs->blk[0];
+				bc->rs = rs;
+				bc->tl = tl;
+				bc->key = ch->key;
+				bc->block = ch->blocknum;
+				bc->lsn = v->lsn;
+				bc->dst = ch->data;
 				ps_spdk_read_async(v->seg, v->off, ch->data, page_size,
-								   read_done, rs);
+								   read_done, bc);
 				return;
 			}
 
@@ -308,7 +346,16 @@ main(int argc, char **argv)
 		}
 	}
 
-	fprintf(stderr, "pagestore_daemon_spdk: shutting down\n");
+	{
+		uint64_t	ch,
+					cm,
+					ce;
+
+		ps_pgcache_stats(&ch, &cm, &ce);
+		fprintf(stderr, "pagestore_daemon_spdk: shutting down (pgcache hit=%llu "
+				"miss=%llu evict=%llu)\n", (unsigned long long) ch,
+				(unsigned long long) cm, (unsigned long long) ce);
+	}
 	ps_core_close();			/* flush the memtable into a layer before detaching */
 	ps_storage->close();
 	munmap(shm, PS_SHM_SIZE);

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -213,6 +213,8 @@ main(int argc, char **argv)
 			flush_pages = atoi(argv[++i]);
 		else if (strcmp(argv[i], "--compact-layers") == 0 && i + 1 < argc)
 			compact_layers = atoi(argv[++i]);
+		else if (strcmp(argv[i], "--cache-pages") == 0 && i + 1 < argc)
+			cache_pages = atoi(argv[++i]);
 		else
 		{
 			fprintf(stderr, "usage: %s --shm NAME --store DIR --pci ADDR "

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -51,10 +51,11 @@ on_signal(int sig)
 typedef struct BlkCtx
 {
 	struct ReqState *rs;
-	uint32_t	tl;
+	uint32_t	tl;				/* resolved source timeline (the cache key) */
 	PsKey		key;
 	uint32_t	block;
 	uint64_t	lsn;
+	int			cacheable;		/* 0 if the version's lsn is ambiguous */
 	unsigned char *dst;
 } BlkCtx;
 
@@ -77,7 +78,7 @@ read_done(void *arg, int ok)
 	BlkCtx	   *bc = arg;
 	ReqState   *rs = bc->rs;
 
-	if (ok)						/* the engine delivered the page into bc->dst */
+	if (ok && bc->cacheable)	/* the engine delivered the page into bc->dst */
 		ps_pgcache_insert(bc->tl, &bc->key, bc->block, bc->lsn, bc->dst);
 	if (--rs->pending == 0)
 	{
@@ -155,7 +156,11 @@ begin(uint32_t i, PsChannel *ch)
 				{
 					unsigned char *dst = ch->data + (size_t) b * page_size;
 					uint32_t	blk = ch->blocknum + b;
-					PageVer    *v = read_through(tl, &ch->key, blk, UINT64_MAX);
+					uint32_t	stl;
+					int			ambig;
+					PageVer    *v = read_through_cacheable(tl, &ch->key, blk,
+														  UINT64_MAX, &stl,
+														  &ambig);
 					BlkCtx	   *bc;
 
 					if (!v)
@@ -163,14 +168,18 @@ begin(uint32_t i, PsChannel *ch)
 						memset(dst, 0, page_size);	/* unwritten -> zeros */
 						continue;
 					}
-					if (ps_pgcache_lookup(tl, &ch->key, blk, v->lsn, dst))
+					/* cache by the resolved source timeline; bypass the cache for
+					 * same-lsn-ambiguous versions (the lsn key can't tell them
+					 * apart), matching read_resolve() on the POSIX path */
+					if (!ambig && ps_pgcache_lookup(stl, &ch->key, blk, v->lsn, dst))
 						continue;	/* RAM hit -> no device read */
 					bc = &rs->blk[nsub++];
 					bc->rs = rs;
-					bc->tl = tl;
+					bc->tl = stl;
 					bc->key = ch->key;
 					bc->block = blk;
 					bc->lsn = v->lsn;
+					bc->cacheable = !ambig;
 					bc->dst = dst;
 					rs->pending++;
 					ps_spdk_read_async(v->seg, v->off, dst, page_size,
@@ -188,8 +197,11 @@ begin(uint32_t i, PsChannel *ch)
 
 		case PS_OP_READ_AT:
 			{
-				PageVer    *v = read_through(tl, &ch->key, ch->blocknum,
-											 ch->req_lsn);
+				uint32_t	stl;
+				int			ambig;
+				PageVer    *v = read_through_cacheable(tl, &ch->key,
+													  ch->blocknum, ch->req_lsn,
+													  &stl, &ambig);
 				ReqState   *rs = &reqstate[i];
 				BlkCtx	   *bc;
 
@@ -199,8 +211,10 @@ begin(uint32_t i, PsChannel *ch)
 					ps_store_release(&ch->state, PS_STATE_DONE);
 					return;
 				}
-				if (ps_pgcache_lookup(tl, &ch->key, ch->blocknum, v->lsn,
-									  ch->data))
+				/* cache by the resolved source timeline; bypass for ambiguous
+				 * same-lsn versions (see READV above) */
+				if (!ambig && ps_pgcache_lookup(stl, &ch->key, ch->blocknum,
+												v->lsn, ch->data))
 				{
 					ps_store_release(&ch->state, PS_STATE_DONE);	/* RAM hit */
 					return;
@@ -210,10 +224,11 @@ begin(uint32_t i, PsChannel *ch)
 				rs->active = 1;
 				bc = &rs->blk[0];
 				bc->rs = rs;
-				bc->tl = tl;
+				bc->tl = stl;
 				bc->key = ch->key;
 				bc->block = ch->blocknum;
 				bc->lsn = v->lsn;
+				bc->cacheable = !ambig;
 				bc->dst = ch->data;
 				ps_spdk_read_async(v->seg, v->off, ch->data, page_size,
 								   read_done, bc);

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -136,6 +136,7 @@ begin(uint32_t i, PsChannel *ch)
 			{
 				uint32_t	nb = ch->nblocks;
 				ReqState   *rs = &reqstate[i];
+				uint32_t	nsub = 0;
 
 				if (nb > MAX_BLOCKS || (uint64_t) nb * page_size > PS_IO_UNIT)
 				{
@@ -144,10 +145,12 @@ begin(uint32_t i, PsChannel *ch)
 					return;
 				}
 				rs->ch = ch;
-				rs->pending = 0;
+				/* start pending at 1 as a submit guard: ps_spdk_read_async() can
+				 * invoke read_done inline (the active append segment, error
+				 * paths), so without this the request could publish DONE / clear
+				 * active mid-loop while later blocks are still being submitted */
+				rs->pending = 1;
 				rs->active = 1;
-				/* completions only fire from ps_spdk_poll() (the main loop), not
-				 * during submit, so incrementing pending as we go is safe */
 				for (uint32_t b = 0; b < nb; b++)
 				{
 					unsigned char *dst = ch->data + (size_t) b * page_size;
@@ -162,17 +165,20 @@ begin(uint32_t i, PsChannel *ch)
 					}
 					if (ps_pgcache_lookup(tl, &ch->key, blk, v->lsn, dst))
 						continue;	/* RAM hit -> no device read */
-					bc = &rs->blk[rs->pending++];
+					bc = &rs->blk[nsub++];
 					bc->rs = rs;
 					bc->tl = tl;
 					bc->key = ch->key;
 					bc->block = blk;
 					bc->lsn = v->lsn;
 					bc->dst = dst;
+					rs->pending++;
 					ps_spdk_read_async(v->seg, v->off, dst, page_size,
 									   read_done, bc);
 				}
-				if (rs->pending == 0)	/* all cached or unwritten */
+				/* release the submit guard; if every read already completed
+				 * (inline) or there were none, this publishes DONE now */
+				if (--rs->pending == 0)
 				{
 					rs->active = 0;
 					ps_store_release(&ch->state, PS_STATE_DONE);

--- a/contrib/pagestore/pagestore_pgcache.c
+++ b/contrib/pagestore/pagestore_pgcache.c
@@ -1,0 +1,204 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_pgcache.c
+ *	  Scan-resistant CLOCK materialized-page cache.  See pagestore_pgcache.h.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <stdlib.h>
+#include <string.h>
+
+#include "pagestore_pgcache.h"
+
+typedef struct PgKey
+{
+	uint32_t	timeline;
+	uint32_t	block;
+	uint64_t	lsn;
+	PsKey		key;
+} PgKey;
+
+typedef struct Slot
+{
+	int			valid;
+	uint8_t		ref;			/* CLOCK reference bit */
+	PgKey		k;
+	int			hnext;			/* next slot in its hash bucket, or -1 */
+} Slot;
+
+static uint32_t cache_max;		/* capacity in pages (0 = disabled) */
+static uint32_t cache_psz;
+static Slot *slots;
+static unsigned char *pages;	/* cache_max * cache_psz, slot i at i*psz */
+static int *buckets;			/* nbuckets heads (slot index or -1) */
+static uint32_t nbuckets;
+static uint32_t nused;			/* slots populated so far (<= cache_max) */
+static uint32_t hand;			/* CLOCK hand */
+static uint64_t st_hits,
+			st_misses,
+			st_evict;
+
+static uint32_t
+key_hash(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
+{
+	uint64_t	h = 1469598103934665603ULL;	/* FNV-1a over the fields */
+	const uint64_t pr = 1099511628211ULL;
+	uint64_t	parts[6];
+
+	parts[0] = tl;
+	parts[1] = key->spcOid;
+	parts[2] = ((uint64_t) key->dbOid << 32) | key->relNumber;
+	parts[3] = key->forkNum;
+	parts[4] = block;
+	parts[5] = lsn;
+	for (int i = 0; i < 6; i++)
+		h = (h ^ parts[i]) * pr;
+	return (uint32_t) (h ^ (h >> 32));
+}
+
+static int
+key_eq(const PgKey *a, uint32_t tl, const PsKey *key, uint32_t block,
+	   uint64_t lsn)
+{
+	return a->timeline == tl && a->block == block && a->lsn == lsn &&
+		a->key.spcOid == key->spcOid && a->key.dbOid == key->dbOid &&
+		a->key.relNumber == key->relNumber && a->key.forkNum == key->forkNum;
+}
+
+void
+ps_pgcache_init(uint32_t max_pages, uint32_t page_size)
+{
+	cache_max = max_pages;
+	cache_psz = page_size;
+	st_hits = st_misses = st_evict = 0;
+	nused = hand = 0;
+	if (max_pages == 0)
+		return;
+	nbuckets = max_pages * 2 + 1;
+	slots = calloc(max_pages, sizeof(Slot));
+	pages = malloc((size_t) max_pages * page_size);
+	buckets = malloc((size_t) nbuckets * sizeof(int));
+	if (!slots || !pages || !buckets)
+	{
+		ps_pgcache_free();
+		cache_max = 0;
+		return;
+	}
+	for (uint32_t i = 0; i < nbuckets; i++)
+		buckets[i] = -1;
+}
+
+void
+ps_pgcache_free(void)
+{
+	free(slots);
+	free(pages);
+	free(buckets);
+	slots = NULL;
+	pages = NULL;
+	buckets = NULL;
+	cache_max = 0;
+}
+
+static int
+find_slot(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn,
+		  uint32_t *out_bucket)
+{
+	uint32_t	b = key_hash(tl, key, block, lsn) % nbuckets;
+
+	if (out_bucket)
+		*out_bucket = b;
+	for (int i = buckets[b]; i >= 0; i = slots[i].hnext)
+		if (slots[i].valid && key_eq(&slots[i].k, tl, key, block, lsn))
+			return i;
+	return -1;
+}
+
+int
+ps_pgcache_lookup(uint32_t tl, const PsKey *key, uint32_t block,
+				  uint64_t version_lsn, void *out)
+{
+	int			s;
+
+	if (cache_max == 0)
+		return 0;
+	s = find_slot(tl, key, block, version_lsn, NULL);
+	if (s < 0)
+	{
+		st_misses++;
+		return 0;
+	}
+	slots[s].ref = 1;			/* re-reference: survives the next sweep */
+	memcpy(out, pages + (size_t) s * cache_psz, cache_psz);
+	st_hits++;
+	return 1;
+}
+
+/* unlink slot s from its hash bucket chain */
+static void
+bucket_remove(int s)
+{
+	uint32_t	b = key_hash(slots[s].k.timeline, &slots[s].k.key,
+							 slots[s].k.block, slots[s].k.lsn) % nbuckets;
+	int		   *pp = &buckets[b];
+
+	while (*pp >= 0 && *pp != s)
+		pp = &slots[*pp].hnext;
+	if (*pp == s)
+		*pp = slots[s].hnext;
+}
+
+void
+ps_pgcache_insert(uint32_t tl, const PsKey *key, uint32_t block,
+				  uint64_t version_lsn, const void *page)
+{
+	uint32_t	b;
+	int			s;
+
+	if (cache_max == 0)
+		return;
+	s = find_slot(tl, key, block, version_lsn, &b);
+	if (s >= 0)
+	{							/* already present: refresh bytes + reference */
+		memcpy(pages + (size_t) s * cache_psz, page, cache_psz);
+		slots[s].ref = 1;
+		return;
+	}
+
+	if (nused < cache_max)
+		s = (int) nused++;		/* still filling */
+	else
+	{
+		/* CLOCK: advance over referenced slots (clearing), evict first ref=0 */
+		while (slots[hand].ref)
+		{
+			slots[hand].ref = 0;
+			hand = (hand + 1) % cache_max;
+		}
+		s = (int) hand;
+		hand = (hand + 1) % cache_max;
+		bucket_remove(s);
+		st_evict++;
+	}
+
+	slots[s].valid = 1;
+	slots[s].ref = 0;			/* scan-resistant: new entries start unreferenced */
+	slots[s].k.timeline = tl;
+	slots[s].k.key = *key;
+	slots[s].k.block = block;
+	slots[s].k.lsn = version_lsn;
+	memcpy(pages + (size_t) s * cache_psz, page, cache_psz);
+	slots[s].hnext = buckets[b];
+	buckets[b] = s;
+}
+
+void
+ps_pgcache_stats(uint64_t *hits, uint64_t *misses, uint64_t *evictions)
+{
+	if (hits)
+		*hits = st_hits;
+	if (misses)
+		*misses = st_misses;
+	if (evictions)
+		*evictions = st_evict;
+}

--- a/contrib/pagestore/pagestore_pgcache.h
+++ b/contrib/pagestore/pagestore_pgcache.h
@@ -1,0 +1,44 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_pgcache.h
+ *	  Materialized-page cache for the page-store daemon (LSM phase 8).
+ *
+ * A database-adapted cache (NOT a generic fs/block LRU): it caches *materialized
+ * page versions* keyed by the semantic identity (timeline, key, block,
+ * version_lsn), sitting in front of the layer/segment read so a hot read is a
+ * RAM hit instead of a layer pread + layer-map scan (and, once delta replay
+ * exists, instead of a redo).  Eviction is scan-resistant CLOCK: a new entry is
+ * inserted unreferenced, so a one-shot scan's pages are evicted first and only a
+ * re-referenced page survives.
+ *
+ * The version_lsn is the *resolved* authoritative version (page_visible's lsn),
+ * not the read_lsn -- so one cached version serves every read_lsn that resolves
+ * to it.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PAGESTORE_PGCACHE_H
+#define PAGESTORE_PGCACHE_H
+
+#include <stdint.h>
+
+#include "pagestore_ipc.h"
+
+/* Initialize with a capacity in pages (0 disables the cache). */
+extern void ps_pgcache_init(uint32_t max_pages, uint32_t page_size);
+extern void ps_pgcache_free(void);
+
+/* Look up (timeline, key, block, version_lsn); on hit copy page_size bytes into
+ * out and return 1, else 0. */
+extern int	ps_pgcache_lookup(uint32_t timeline, const PsKey *key,
+							  uint32_t block, uint64_t version_lsn, void *out);
+
+/* Insert/refresh (timeline, key, block, version_lsn) -> page. */
+extern void ps_pgcache_insert(uint32_t timeline, const PsKey *key,
+							  uint32_t block, uint64_t version_lsn,
+							  const void *page);
+
+extern void ps_pgcache_stats(uint64_t *hits, uint64_t *misses,
+							 uint64_t *evictions);
+
+#endif							/* PAGESTORE_PGCACHE_H */

--- a/contrib/pagestore/pagestore_pgcache_test.c
+++ b/contrib/pagestore/pagestore_pgcache_test.c
@@ -1,0 +1,94 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_pgcache_test.c
+ *	  Standalone unit test for the scan-resistant materialized-page cache.
+ *	  No daemon, no PostgreSQL.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "pagestore_pgcache.h"
+
+static int	run = 0,
+			failed = 0;
+
+static void
+check(int cond, const char *msg)
+{
+	run++;
+	if (!cond)
+	{
+		failed++;
+		fprintf(stderr, "  FAIL: %s\n", msg);
+	}
+}
+
+#define PSZ 64
+
+static void
+fill(unsigned char *p, unsigned char v)
+{
+	memset(p, v, PSZ);
+}
+
+int
+main(void)
+{
+	PsKey		k = {1, 1, 5, 0};
+	unsigned char in[PSZ],
+				out[PSZ];
+	uint64_t	hits,
+				misses,
+				evict;
+
+	ps_pgcache_init(4, PSZ);
+
+	/* basic insert + hit */
+	fill(in, 0xAA);
+	ps_pgcache_insert(0, &k, 7, 100, in);
+	check(ps_pgcache_lookup(0, &k, 7, 100, out) == 1 && out[0] == 0xAA,
+		  "insert then hit");
+
+	/* miss on absent block / lsn */
+	check(ps_pgcache_lookup(0, &k, 8, 100, out) == 0, "miss on other block");
+	check(ps_pgcache_lookup(0, &k, 7, 200, out) == 0, "miss on other version_lsn");
+
+	/* version_lsn keying: two versions of the same (key,block) coexist */
+	fill(in, 0xBB);
+	ps_pgcache_insert(0, &k, 7, 200, in);
+	check(ps_pgcache_lookup(0, &k, 7, 100, out) == 1 && out[0] == 0xAA &&
+		  ps_pgcache_lookup(0, &k, 7, 200, out) == 1 && out[0] == 0xBB,
+		  "two versions keyed by lsn");
+
+	/* --- scan resistance: a hot page re-referenced each round survives a
+	 * stream of one-shot scan pages; the scan pages churn through the rest --- */
+	ps_pgcache_free();
+	ps_pgcache_init(4, PSZ);
+	fill(in, 0x11);
+	ps_pgcache_insert(0, &k, 1, 1, in);	/* hot page H = (block 1, lsn 1) */
+	ps_pgcache_lookup(0, &k, 1, 1, out);	/* reference it */
+	for (uint32_t i = 0; i < 3; i++)	/* fillers to capacity */
+	{
+		fill(in, (unsigned char) (0x20 + i));
+		ps_pgcache_insert(0, &k, 100 + i, 1, in);
+	}
+	for (uint32_t i = 0; i < 16; i++)	/* long one-shot scan, re-touching H */
+	{
+		fill(in, 0x80);
+		ps_pgcache_insert(0, &k, 1000 + i, 1, in);
+		ps_pgcache_lookup(0, &k, 1, 1, out);	/* H stays hot */
+	}
+	check(ps_pgcache_lookup(0, &k, 1, 1, out) == 1 && out[0] == 0x11,
+		  "hot page survives a long scan (scan-resistant)");
+	check(ps_pgcache_lookup(0, &k, 1000, 1, out) == 0,
+		  "early scan page evicted");
+
+	ps_pgcache_stats(&hits, &misses, &evict);
+	check(evict > 0, "evictions occurred under pressure");
+
+	ps_pgcache_free();
+	fprintf(stderr, "%d checks, %d failed\n", run, failed);
+	return failed ? 1 : 0;
+}

--- a/contrib/pagestore/spdk_build.sh
+++ b/contrib/pagestore/spdk_build.sh
@@ -39,7 +39,7 @@ cc -O2 -Wall -Wextra -DPAGESTORE_SPDK -I"$here" $cflags \
 	"$here/pagestore_daemon_spdk.c" "$here/pagestore_core.c" \
 	"$here/storage_spdk.c" "$here/storage_posix.c" \
 	"$here/pagestore_layer.c" "$here/pagestore_layer_store.c" \
-	"$here/pagestore_manifest.c" "$here/pagestore_memtable.c" \
+	"$here/pagestore_manifest.c" "$here/pagestore_memtable.c" "$here/pagestore_pgcache.c" \
 	$rpath $spdk_libs -lrt
 set +x
 echo "built $out"


### PR DESCRIPTION
Database-adapted (not block-LRU) materialized-page cache: scan-resistant CLOCK keyed by (timeline,key,block,version_lsn); immutable versions -> no invalidation on write. Wired into read_resolve and into the SPDK async read path (RAM hit skips the NVMe read; read-populate on completion) without serializing the pipeline. pgcache unit 7/0; POSIX+SPDK 116/116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)