### PR TITLE
contrib/pagestore: read-amp pruning + background compaction (sharding prep)

### DIFF
--- a/contrib/pagestore/LSM_ARCHITECTURE.md
+++ b/contrib/pagestore/LSM_ARCHITECTURE.md
@@ -397,6 +397,9 @@ state and retention rules permit deletion.
 
 ## Sharding model
 
+See `SHARDING.md` for the detailed shard-by-key design, shared-state handling,
+client-side routing, and the behavior-preserving migration plan.
+
 Later multi-core implementation should shard by logical key:
 
 ```mermaid

--- a/contrib/pagestore/LSM_ARCHITECTURE.md
+++ b/contrib/pagestore/LSM_ARCHITECTURE.md
@@ -289,6 +289,14 @@ nearest image layer at or before read_lsn
 If a child timeline lacks a page version, the planner walks to the parent
 timeline as of the branch LSN.
 
+The planner must prune layers before reading them: use each layer's min/max key
+range (`PsLayerDesc.start_key`/`end_key`) and a per-layer bloom filter to skip
+layers that cannot hold the key, instead of scanning every layer of a timeline
+(RocksDB/ScyllaDB both rely on this).  The prototype's `layer_map_lookup`
+currently scans all of a timeline's image layers; read amplification grows with
+the layer count, so this pruning is required as layer counts rise (and per
+shard).
+
 ## Compaction path
 
 ```mermaid
@@ -312,6 +320,19 @@ Compaction goals:
 
 Compaction must be install-new-before-delete-old.  Old layers remain readable
 until the manifest durably exposes the replacement.
+
+Execution & strategy (informed by RocksDB/ScyllaDB; see `SHARDING.md`):
+
+- **Run compaction in the background, never on the foreground write/serve
+  thread.**  The current prototype calls it inline from the write path; that must
+  become a background per-shard task with write backpressure (high-water mark on
+  layer count / memtable backlog) before multi-core sharding, à la ScyllaDB's
+  compaction/flush controllers.
+- **Use a real strategy, not "merge all".**  Start with size-tiered (merge
+  similarly-sized layers); adopt an incremental/fragmented scheme (ScyllaDB ICS)
+  if temporary space amplification during a merge matters.
+- Version-level GC (drop versions below the retained-LSN horizon) happens during
+  compaction; the prototype currently keeps every version.
 
 ## Tiering path
 

--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -1,5 +1,34 @@
 # pagestore — multi-core sharding design
 
+## Guiding principle: follow ScyllaDB
+
+ScyllaDB is our primary reference for the concurrency/engine model.  Concrete
+principles we commit to (adopt incrementally; adapt, don't clone Seastar):
+
+- **Share-nothing shard-per-core.** `hash(key) -> shard`; each core owns its
+  data and takes no global lock on the hot path; cross-shard only by message
+  passing.
+- **Run-to-completion, never block a shard thread.** Per-core async/polled IO
+  (SPDK qpair per thread); the synchronous POSIX backend is the explicit slow-path
+  exception.
+- **Autonomous controllers + backpressure.** Compaction/flush are not merely
+  "background" — they are scheduled under CPU/IO shares with backpressure (throttle
+  writes only at a high-water mark) so foreground read latency stays bounded.
+- **Per-core I/O scheduler with priority classes:** query > flush > compaction;
+  background work must not starve foreground reads.
+- **Engine-managed memory:** cache + memtable share a per-shard memory budget the
+  engine evicts under pressure (à la Scylla's unified cache), not fixed separate
+  allocations.
+- **Semantic cache** (materialized pages, like Scylla's row cache), client-side
+  shard routing (like shard-aware drivers).
+
+Adaptation limits: we are a freestanding daemon talking to PostgreSQL over shared
+memory, not a networked DB on Seastar.  Adopt the principles; build a custom
+allocator / full scheduler only where it pays.  Redo/materialization is our own
+cross-process concern (see `MATERIALIZATION.md`), not a Scylla mechanism.
+
+## Overview
+
 The daemon is single-threaded: one thread polls every channel and owns all state
 lock-free.  On fast NVMe/SPDK that single core is the throughput ceiling.  This
 doc commits to a shard-by-key model that keeps each shard single-owner and

--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -108,6 +108,36 @@ timeline tree under a brief coordination point, not on the read/write hot path.
 Each step is independently testable; step 2 is the big mechanical change and is
 behavior-preserving, so the risky parallelism (step 4) sits on a proven refactor.
 
+## Engine refinements this sharding depends on (informed by ScyllaDB)
+
+ScyllaDB is the reference for share-nothing shard-per-core LSM (Seastar:
+`hash(key) -> core`, per-core memtable/SSTable/cache, shard-aware clients,
+per-core I/O scheduler).  This design matches it.  But a few engine details must
+change *before or with* sharding, or per-shard threads will stall:
+
+1. **Compaction must move off the serve thread (hard prerequisite).** Today
+   `maybe_compact()` runs inline in `append_page()` on the write path.  Once each
+   shard is a single thread, an inline compaction blocks that shard's reads and
+   writes for the whole merge.  Compaction must become a **background per-shard
+   task** with **backpressure** (throttle/stall writes only when the layer count
+   or memtable backlog crosses a high-water mark), à la ScyllaDB's compaction /
+   flush controllers.  Until this lands, sharding would just multiply stalls.
+2. **Real compaction strategy, not "merge all".** The current policy rewrites all
+   of a timeline's image layers into one whenever the count exceeds a threshold —
+   unbounded read/space amplification control.  Adopt **size-tiered** (simplest:
+   merge similarly-sized layers) first; if space amplification matters, an
+   **incremental / fragmented** scheme (ScyllaDB ICS) bounds the temporary space a
+   compaction needs.  Per-shard, so it stays lock-free.
+3. **Per-layer key range (min/max) + bloom to skip layers.** `layer_map_lookup`
+   scans every image layer of a timeline (O(layers)).  Record each layer's
+   min/max key (already have start/end_key in `PsLayerDesc`) and *use it to
+   prune*, and add a per-layer bloom filter, so a read touches only layers that
+   can hold the key — RocksDB/ScyllaDB both rely on this.  Read amplification
+   only gets worse with more layers per shard.
+
+These are tracked as co-requisites: step 4 (real parallelism) should not ship
+without (1); (2) and (3) can land incrementally alongside.
+
 ## Invariants
 
 - Every version/timeline/block of a given key lives on exactly one shard.

--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -1,0 +1,116 @@
+# pagestore — multi-core sharding design
+
+The daemon is single-threaded: one thread polls every channel and owns all state
+lock-free.  On fast NVMe/SPDK that single core is the throughput ceiling.  This
+doc commits to a shard-by-key model that keeps each shard single-owner and
+lock-free (no global locks on the hot path) and lays out an incremental migration
+that never breaks the standalone suite.
+
+Expands the sketch in `LSM_ARCHITECTURE.md` (§Sharding model).
+
+## Shard key: `hash(key) mod nshards` — block- and timeline-independent
+
+The shard is chosen from the **logical key only** (spcOid, dbOid, relNumber,
+forkNum) — *not* the block number, *not* the timeline.  Two properties make this
+the right cut:
+
+1. **A multi-block `READV` stays on one shard.** All blocks of a relation+fork
+   hash to the same shard, so a vectored read is served by a single core without
+   splitting across shards.
+2. **COW read-through stays on one shard.** `read_through` walks a key's parent
+   timelines as of the branch LSN; since the shard ignores timeline, every
+   timeline's versions of a given key live on the same shard — the ancestry walk
+   is local, no cross-core coordination.
+
+Trade-off: a single hot relation maps to one shard (no intra-relation
+parallelism).  Acceptable — real workloads spread across many relations/forks,
+and keeping per-key state on one core is what makes it lock-free.
+
+## What each shard owns (single-owner, lock-free)
+
+```text
+Shard {
+  page_idx        // version index for this shard's keys
+  fork_idx        // relation sizes for this shard's keys
+  memtable        // staging -> image layers (this shard's keys only)
+  pgcache         // materialized-page cache (this shard's keys)
+  layer_map       // the layers THIS shard produced (cover only its keys)
+  next_layer_id   // namespaced per shard (no cross-shard id collision)
+  append cursor   // its own segment namespace (seg files tagged by shard)
+  SPDK qpair      // per-thread NVMe queue (SPDK is per-thread)
+}
+```
+
+Because the shard key is block-independent, a sealed image/delta layer produced
+by a shard covers **only that shard's keys** — no layer ever spans shards, so the
+layer map partitions cleanly and compaction/GC stay per-shard and lock-free.
+
+## Shared state (kept off the hot path)
+
+- **Timelines (branch tree)** — global, read-mostly.  Every shard needs it for
+  `read_through` ancestry.  Replicate a read-only copy per shard; on branch
+  create (rare) coordinate an update (brief barrier or per-shard apply of a
+  broadcast event).  No per-read locking.
+- **Manifest** — **per-shard manifest logs** (each shard owns its layers, so its
+  ADD/SEAL/DELETE events are independent).  Avoids a shared-manifest lock
+  entirely.  Restart replays each shard's manifest into that shard's layer map.
+- **Layer store / object store** — shared filesystem (and later S3), but layer
+  files are **namespaced by shard** (e.g. `layer_<shard>_<id>`), so concurrent
+  shards never collide and a shard's GC only touches its own files.
+- **Shipped WAL (`wal_<tl>`)** — a single global ingest stream today
+  (archive_library).  The per-page WAL index (walidx) shards by key like
+  everything else; raw WAL transport stays global (secondary while page-ingest is
+  the default).
+
+## Request routing: client-side over partitioned channel pools
+
+No central router thread (a hop would re-serialize).  Instead:
+
+- The shm channels are partitioned into `nshards` pools; shard *s* polls only
+  pool *s*.
+- The localsvc **client** computes `s = hash(key) mod nshards` and posts the
+  request on a channel from pool *s*.  A backend claims one channel per shard it
+  talks to (lazily).
+- A `READV` is single-key, so it always lands on one pool — no split.
+
+`nshards` is published in the shm header so the client and daemon agree.
+
+## Threading
+
+`nshards` worker threads, each running the existing serve loop over its channel
+pool and owning its `Shard` struct.  POSIX: synchronous serve per shard.  SPDK:
+each shard thread opens its own NVMe qpair and runs its own submit/poll loop
+(SPDK is designed for per-thread qpairs), so async batching scales per core.
+
+## Crash consistency
+
+Per-shard manifests + per-shard layer namespaces mean the existing rules
+(install-new-before-delete, idempotent GC, restart-from-manifest) apply unchanged
+*within* a shard.  `layer_id` is namespaced per shard so ids never collide.
+Branch creation is the only cross-shard write; it updates the (replicated)
+timeline tree under a brief coordination point, not on the read/write hot path.
+
+## Migration plan (each step keeps the standalone suite green)
+
+1. **This design.**
+2. **Refactor global state into a `Shard` struct, `nshards = 1`, still one
+   thread.** Pure mechanical refactor (page_idx/fork_idx/memtable/pgcache/
+   layer_map/cursor/next_layer_id become `shard->...`); behavior identical,
+   116/116 unchanged.  De-risks everything below.
+3. **Partition channels + client-side routing**, still `nshards = 1` (routing is
+   identity) — proves the routing path without parallelism.
+4. **`nshards > 1` + one worker thread per shard** (POSIX first).  Per-shard
+   manifest files + shard-namespaced layer/segment files.  This is where real
+   parallelism lands.
+5. **SPDK per-thread qpairs** so the async path scales per core.
+6. **Branch-create coordination** for the shared timeline tree.
+
+Each step is independently testable; step 2 is the big mechanical change and is
+behavior-preserving, so the risky parallelism (step 4) sits on a proven refactor.
+
+## Invariants
+
+- Every version/timeline/block of a given key lives on exactly one shard.
+- No layer spans shards; no manifest entry is shared.
+- Hot path (read/write/flush/compact/GC of a shard) takes no global lock.
+- Only branch-create touches cross-shard (timeline) state.

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1329,8 +1329,16 @@ ps_core_maintenance(void)
 		if ((tl == 0 || timelines[tl].defined) &&
 			count_image_layers(tl) > (uint32_t) compact_layers)
 		{
-			compact_timeline(tl);
-			return 1;
+			uint32_t	before = count_image_layers(tl);
+
+			/* Report progress (so the caller skips its idle sleep) only if the
+			 * compaction actually reduced the layer count.  A timeline that can't
+			 * make progress -- nothing mergeable (e.g. compact_layers=0 with a
+			 * single layer) or a failing compaction (ENOSPC / corrupt layer) --
+			 * must not keep the daemon spinning; try the next timeline, and if
+			 * none progress fall through to return 0 so the caller backs off. */
+			if (compact_timeline(tl) == 0 && count_image_layers(tl) < before)
+				return 1;
 		}
 	return 0;
 }

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "pagestore_core.h"
 #include "pagestore_layer_store.h"
@@ -109,6 +110,11 @@ record_layer(void *ctx, const PsLayerDesc *desc)
  * bounded I/O (a "nonblocking slice") instead of rewriting a whole timeline and
  * stalling the serve loop; successive idle calls finish the rest. */
 #define COMPACT_BATCH	8
+
+/* Seconds an idle daemon waits before re-attempting a compaction that made no
+ * progress (corrupt layer / ENOSPC), so it doesn't spin re-reading failing
+ * layers; a flush/compaction that changes layer state clears the backoff early. */
+#define MAINT_COOLDOWN_SECS 5
 
 static uint32_t
 count_image_layers(uint32_t timeline)
@@ -1313,13 +1319,23 @@ ps_core_close(void)
 		ps_memtable_destroy(g_memtable);
 		g_memtable = NULL;
 		/* the shutdown flush can push a timeline over the compaction threshold;
-		 * run the same compaction/GC append_page does so repeated short-lived
-		 * runs don't accumulate one image layer per clean shutdown (each of which
-		 * every read would then scan) */
+		 * compact it back under so repeated short-lived runs don't accumulate
+		 * image layers (each of which every read would then scan).  compaction is
+		 * capped at COMPACT_BATCH per call, so loop per timeline until it is under
+		 * the threshold or stops making progress (corrupt layer / ENOSPC). */
 		for (uint32_t ct = 0; ct < MAX_TIMELINES; ct++)
-			if ((ct == 0 || timelines[ct].defined) &&
-				count_image_layers(ct) > (uint32_t) compact_layers)
-				compact_timeline(ct);
+		{
+			if (ct != 0 && !timelines[ct].defined)
+				continue;
+			while (count_image_layers(ct) > (uint32_t) compact_layers)
+			{
+				uint32_t	before = count_image_layers(ct);
+
+				if (compact_timeline(ct) != 0 ||
+					count_image_layers(ct) >= before)
+					break;		/* failed or no progress: stop draining this one */
+			}
+		}
 	}
 	ps_pgcache_free();
 	ps_manifest_close();
@@ -1335,7 +1351,16 @@ ps_core_close(void)
 int
 ps_core_maintenance(void)
 {
+	static time_t cooldown_until = 0;	/* skip attempts until this wall time */
+	int			attempted = 0;
+
 	if (!use_layers)
+		return 0;
+	/* If a recent attempt made no progress (a corrupt layer, or repeated ENOSPC
+	 * while reading/writing the merge), don't re-read the same failing layers on
+	 * every idle tick -- cool down until either new layer state appears or the
+	 * window passes. */
+	if (cooldown_until != 0 && time(NULL) < cooldown_until)
 		return 0;
 	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
 		if ((tl == 0 || timelines[tl].defined) &&
@@ -1347,11 +1372,20 @@ ps_core_maintenance(void)
 			 * compaction actually reduced the layer count.  A timeline that can't
 			 * make progress -- nothing mergeable (e.g. compact_layers=0 with a
 			 * single layer) or a failing compaction (ENOSPC / corrupt layer) --
-			 * must not keep the daemon spinning; try the next timeline, and if
-			 * none progress fall through to return 0 so the caller backs off. */
+			 * must not keep the daemon spinning; try the next timeline. */
+			attempted = 1;
 			if (compact_timeline(tl) == 0 && count_image_layers(tl) < before)
+			{
+				cooldown_until = 0;	/* progress: clear any backoff */
 				return 1;
+			}
 		}
+	/* Over-threshold timeline(s) exist but none could be compacted: back off so an
+	 * otherwise-idle daemon doesn't re-attempt the same failing merge every 20us.
+	 * A later flush/compaction that changes layer state will return 1 and clear
+	 * this; otherwise the window simply expires and we retry. */
+	if (attempted)
+		cooldown_until = time(NULL) + MAINT_COOLDOWN_SECS;
 	return 0;
 }
 

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -105,6 +105,11 @@ record_layer(void *ctx, const PsLayerDesc *desc)
 
 /* ===================== compaction & GC (LSM phase 3) =================== */
 
+/* Max image layers merged in one compact_timeline() call, so a single call does
+ * bounded I/O (a "nonblocking slice") instead of rewriting a whole timeline and
+ * stalling the serve loop; successive idle calls finish the rest. */
+#define COMPACT_BATCH	8
+
 static uint32_t
 count_image_layers(uint32_t timeline)
 {
@@ -189,6 +194,13 @@ compact_timeline(uint32_t timeline)
 		if (d->kind == PS_LAYER_IMAGE && !d->deleting && d->timeline == timeline)
 			old[nold++] = *d;
 	}
+	/* Bound the work per call: merge at most COMPACT_BATCH layers, not the whole
+	 * timeline.  A single all-layers merge can read+rewrite every image layer,
+	 * which would stall the foreground serve loop that triggers maintenance; an
+	 * over-threshold timeline is instead compacted in nonblocking slices across
+	 * successive idle calls (and ps_core_maintenance reports more-to-do). */
+	if (nold > COMPACT_BATCH)
+		nold = COMPACT_BATCH;
 
 	/* gather every version (page bytes) from the old layers */
 	for (uint32_t k = 0; k < nold; k++)

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1023,13 +1023,14 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 						"staged pages (still durable in the segment log)\n");
 				ps_memtable_reset(g_memtable);
 			}
-			/* a flush groups by timeline and can emit a layer for several of
-			 * them, so compact every timeline now over the threshold -- not only
-			 * the one this write belongs to (a colder timeline could otherwise
-			 * grow unbounded until it happens to cross the flush threshold) */
+			/* Normal compaction runs off the write path in ps_core_maintenance()
+			 * when the daemon is idle.  As a backpressure guard, compact inline
+			 * here any timeline whose layer count is running away far past the
+			 * threshold (a flush groups by timeline and can emit layers for
+			 * several, so check them all, not just this write's). */
 			for (uint32_t ct = 0; ct < MAX_TIMELINES; ct++)
 				if ((ct == 0 || timelines[ct].defined) &&
-					count_image_layers(ct) > (uint32_t) compact_layers)
+					count_image_layers(ct) > (uint32_t) compact_layers * 4)
 					compact_timeline(ct);
 		}
 	}
@@ -1310,6 +1311,28 @@ ps_core_close(void)
 	}
 	ps_pgcache_free();
 	ps_manifest_close();
+}
+
+/*
+ * Off-the-write-path background maintenance: compact one timeline whose image
+ * layer count exceeds the (low-water) threshold.  The daemon calls this when it
+ * is otherwise idle; doing at most one compaction per call keeps the serve loop
+ * responsive.  Returns 1 if it compacted (the caller should not sleep), 0 if
+ * nothing was due.
+ */
+int
+ps_core_maintenance(void)
+{
+	if (!use_layers)
+		return 0;
+	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
+		if ((tl == 0 || timelines[tl].defined) &&
+			count_image_layers(tl) > (uint32_t) compact_layers)
+		{
+			compact_timeline(tl);
+			return 1;
+		}
+	return 0;
 }
 
 /*

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -47,6 +47,10 @@ extern int	ps_core_open(const char *store_dir);
 /* Clean-shutdown: flush the memtable into a layer and close the manifest. */
 extern void ps_core_close(void);
 
+/* Off-the-write-path maintenance (compaction).  Call when idle; returns 1 if it
+ * did work (caller should not sleep), 0 if nothing was due. */
+extern int	ps_core_maintenance(void);
+
 /* Number of image layers currently in the layer map (for stats/diagnostics). */
 extern uint32_t ps_core_layer_count(void);
 

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -231,9 +231,13 @@ main(int argc, char **argv)
 
 		if (!did_work)
 		{
-			struct timespec ts = {0, 20000};	/* 20us */
+			/* idle: do one unit of background compaction before sleeping */
+			if (!ps_core_maintenance())
+			{
+				struct timespec ts = {0, 20000};	/* 20us */
 
-			nanosleep(&ts, NULL);
+				nanosleep(&ts, NULL);
+			}
 		}
 	}
 

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -422,9 +422,12 @@ ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 	int			rc = -1;
 
 	/* prune: skip without any IO if this layer cannot hold (key,block) or its
-	 * LSN range does not overlap the requested (lo_lsn, hi_lsn] */
+	 * LSN range does not overlap the requested half-open [lo_lsn, hi_lsn).  Use
+	 * '<'/'>=' so a layer whose newest record is exactly lo_lsn (a delta starting
+	 * at the base LSN, which the scan includes) is not dropped, and one starting
+	 * exactly at hi_lsn (== read_lsn, excluded) is. */
 	if (!layer_covers(layer, key, block) ||
-		layer->lsn_end <= lo_lsn || layer->lsn_start > hi_lsn)
+		layer->lsn_end < lo_lsn || layer->lsn_start >= hi_lsn)
 		return 0;
 	if (!loc || loc->size < sizeof(PsDeltaFooter))
 		return -1;

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -122,6 +122,23 @@ img_sort_cmp(const void *pa, const void *pb)
 	return 0;
 }
 
+/*
+ * Necessary-condition prune: can layer 'd' possibly hold (key, block)?  Uses the
+ * layer's key range and global block range (min/max across all its entries).
+ * A 0 means definitely-absent, so the caller can skip the layer without reading
+ * its footer/index/data.  (block range is coarse -- it is the global min/max,
+ * not per-key -- but a block outside it is still definitely absent.)
+ */
+static int
+layer_covers(const PsLayerDesc *d, const PsKey *key, uint32_t block)
+{
+	if (key_cmp(key, &d->start_key) < 0 || key_cmp(key, &d->end_key) > 0)
+		return 0;
+	if (block < d->start_block || block > d->end_block)
+		return 0;
+	return 1;
+}
+
 static const PsLayerLocation *
 img_local_loc(const PsLayerDesc *layer)
 {
@@ -404,6 +421,11 @@ ps_delta_layer_collect(const PsLayerDesc *layer, const PsKey *key,
 	uint64_t	idx_bytes;
 	int			rc = -1;
 
+	/* prune: skip without any IO if this layer cannot hold (key,block) or its
+	 * LSN range does not overlap the requested (lo_lsn, hi_lsn] */
+	if (!layer_covers(layer, key, block) ||
+		layer->lsn_end <= lo_lsn || layer->lsn_start > hi_lsn)
+		return 0;
 	if (!loc || loc->size < sizeof(PsDeltaFooter))
 		return -1;
 	if (ps_layer_store->read_layer_block(layer, loc->size - sizeof(foot),
@@ -766,6 +788,10 @@ ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 	int			found = 0;
 	int			rc = -1;
 
+	/* prune: skip without any IO if this layer cannot hold (key,block) or has no
+	 * version at/below read_lsn */
+	if (!layer_covers(layer, key, block) || read_lsn < layer->lsn_start)
+		return 0;
 	if (!loc || loc->size < sizeof(PsImgFooter))
 		return -1;
 	if (ps_layer_store->read_layer_block(layer, loc->size - sizeof(foot),

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -164,6 +164,14 @@ main(void)
 		r = ps_delta_layer_collect(&dd, &k5, 1, 0, 1000, &outs, &ocap, &dn);
 		check(r == 0 && dn == 1 && outs[0].lsn == 150, "delta collect other block");
 
+		/* boundary: lo == the layer's newest record (300).  [300,400) must still
+		 * return that record -- the early layer-level prune must use lsn_end < lo,
+		 * not <= lo, or a delta starting exactly at the base LSN is dropped. */
+		dn = 0;
+		r = ps_delta_layer_collect(&dd, &k5, 0, 300, 400, &outs, &ocap, &dn);
+		check(r == 0 && dn == 1 && outs[0].lsn == 300,
+			  "delta collect [300,400) keeps record at lo (lsn_end==lo)");
+
 		/* a small starting buffer must grow to hold all matches (no fixed cap):
 		 * collect into a fresh NULL/0 buffer and expect all 3, not an overflow */
 		{


### PR DESCRIPTION
ScyllaDB-informed engine prep for sharding: SHARDING.md (shard-by-key share-nothing design + migration) and the "follow ScyllaDB, stay lean" principle; layer min/max+LSN pruning so reads skip non-covering layers (read amplification); and moving compaction off the write path into idle background maintenance with high-water backpressure. POSIX+SPDK 116/116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)