### PR TITLE
contrib/pagestore: per-shard manifest + layer map + id namespace (sharding step 4a)

### DIFF
--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -135,9 +135,19 @@ timeline tree under a brief coordination point, not on the read/write hot path.
    helpers for `nshards` up to 8).  The in-engine client (`backend_localsvc`)
    keeps its single channel — correct at `nshards = 1` (the sole pool) — and
    adopts per-key routing in step 4 when `nshards > 1` requires it.
-4. **`nshards > 1` + one worker thread per shard** (POSIX first).  Per-shard
-   manifest files + shard-namespaced layer/segment files; `backend_localsvc`
-   per-shard channel pool + routing.  This is where real parallelism lands.
+4. **`nshards > 1` + one worker thread per shard** (POSIX first), in sub-slices:
+   - **4a — per-shard manifest + layer map + id namespace** (still `nshards = 1`,
+     single thread). ✅ The manifest is now a `PsManifest` handle (durable log +
+     layer map) owned per shard; each shard has its own `layers.<shard>.manifest`
+     and its own `next_local_id`, and `layer_id` is shard-namespaced (high bits =
+     shard) so the id-named layer files never collide across shards in the one
+     store dir.  Compaction/GC/lookup are parameterized by `Shard *`.  Behavior
+     identical at one shard (ids 1,2,3…; one manifest) — de-risks the threading
+     slice like step 2 did.
+   - **4b** — runtime `nshards > 1`, still single-threaded serve loop over all
+     pools (proves multi-shard data partitioning end-to-end before threads).
+   - **4c** — one POSIX worker thread per shard; `backend_localsvc` per-shard
+     channel pool + routing.  This is where real parallelism lands.
 5. **SPDK per-thread qpairs** so the async path scales per core.
 6. **Branch-create coordination** for the shared timeline tree.
 

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -82,6 +82,9 @@ typedef struct Shard
 	struct ForkEnt *fork_idx[IDX_BUCKETS];	/* (timeline,key) -> fork size */
 	struct WalIdxEnt *walidx[IDX_BUCKETS];	/* (timeline,key,block) -> WAL lsns */
 	PsMemtable *memtable;		/* staging -> image layers */
+	uint32_t	index;			/* this shard's id (0 .. NSHARDS-1) */
+	PsManifest	manifest;		/* per-shard durable layer log + layer map */
+	uint64_t	next_local_id;	/* next layer id within this shard (low bits) */
 	uint64_t	rr_mem,			/* read-source counters */
 				rr_layer,
 				rr_seg;
@@ -98,12 +101,24 @@ shard_for(const PsKey *key)
 	return &g_shards[ps_shard_for_key(key, NSHARDS)];
 }
 
-static uint64_t g_next_layer_id = 1;	/* global for now (per-shard in step 4) */
+/*
+ * layer_id namespacing: the high LAYER_ID_SHARD_SHIFT bits hold the shard id and
+ * the low bits a per-shard counter, so ids (and the layer files named by them)
+ * never collide across shards while each shard allocates independently.  At
+ * NSHARDS == 1, shard 0's ids are 1, 2, 3, ... -- identical to the old global
+ * allocator.
+ */
+#define LAYER_ID_SHARD_SHIFT	48
+#define LAYER_ID_LOCAL_MASK		(((uint64_t) 1 << LAYER_ID_SHARD_SHIFT) - 1)
 
 uint32_t
 ps_core_layer_count(void)
 {
-	return ps_layer_map.nlayers;
+	uint32_t	n = 0;
+
+	for (uint32_t i = 0; i < NSHARDS; i++)
+		n += g_shards[i].manifest.map.nlayers;
+	return n;
 }
 
 /* read-path source counters (memtable / image layer / segment fallback),
@@ -129,20 +144,24 @@ ps_core_read_stats(uint64_t *mem, uint64_t *layer, uint64_t *seg)
 		*seg = s;
 }
 
+/* ctx is the owning Shard* (passed through the memtable flush / compaction
+ * callbacks), so id allocation and the manifest write stay on that shard. */
 static uint64_t
 alloc_layer_id(void *ctx)
 {
-	(void) ctx;
-	return g_next_layer_id++;
+	Shard	   *s = ctx;
+
+	return ((uint64_t) s->index << LAYER_ID_SHARD_SHIFT) | s->next_local_id++;
 }
 
 static int
 record_layer(void *ctx, const PsLayerDesc *desc)
 {
-	(void) ctx;
+	Shard	   *s = ctx;
+
 	/* ps_manifest_add_layer persists the ADD event *and* adds it to the layer
 	 * map (idempotently); do not add to the map a second time. */
-	return ps_manifest_add_layer(desc);
+	return ps_manifest_add_layer(&s->manifest, desc);
 }
 
 /* ===================== compaction & GC (LSM phase 3) =================== */
@@ -175,13 +194,14 @@ layer_size_cmp(const void *a, const void *b)
 }
 
 static uint32_t
-count_image_layers(uint32_t timeline)
+count_image_layers(Shard *s, uint32_t timeline)
 {
+	const PsLayerMap *map = &s->manifest.map;
 	uint32_t	c = 0;
 
-	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)
+	for (uint32_t i = 0; i < map->nlayers; i++)
 	{
-		const PsLayerDesc *d = &ps_layer_map.layers[i];
+		const PsLayerDesc *d = &map->layers[i];
 
 		if (d->kind == PS_LAYER_IMAGE && !d->deleting && d->timeline == timeline)
 			c++;
@@ -195,13 +215,14 @@ count_image_layers(uint32_t timeline)
  * recorded.  Reads already skip 'deleting' layers, so this only reclaims space.
  */
 static void
-gc_resume(void)
+gc_resume(Shard *s)
 {
+	const PsLayerMap *map = &s->manifest.map;
 	PsLayerDesc *dead;
 	uint32_t	m = 0;
 
-	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)
-		if (ps_layer_map.layers[i].deleting)
+	for (uint32_t i = 0; i < map->nlayers; i++)
+		if (map->layers[i].deleting)
 			m++;
 	if (m == 0)
 		return;
@@ -209,15 +230,15 @@ gc_resume(void)
 	if (!dead)
 		return;
 	m = 0;
-	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)
-		if (ps_layer_map.layers[i].deleting)
-			dead[m++] = ps_layer_map.layers[i];
+	for (uint32_t i = 0; i < map->nlayers; i++)
+		if (map->layers[i].deleting)
+			dead[m++] = map->layers[i];
 	for (uint32_t k = 0; k < m; k++)
 	{
 		/* record removal only once the file is gone; a failed unlink keeps the
 		 * layer 'deleting' for the next gc_resume rather than orphaning it */
 		if (ps_layer_store->delete_local_layer(&dead[k]) == 0)
-			ps_manifest_remove_layer(dead[k].layer_id);
+			ps_manifest_remove_layer(&s->manifest, dead[k].layer_id);
 	}
 	free(dead);
 }
@@ -232,10 +253,11 @@ gc_resume(void)
  * horizon is a later step.
  */
 static int
-compact_timeline(uint32_t timeline)
+compact_timeline(Shard *s, uint32_t timeline)
 {
+	const PsLayerMap *map = &s->manifest.map;
 	PsLayerDesc *old;
-	uint32_t	nold = count_image_layers(timeline);
+	uint32_t	nold = count_image_layers(s, timeline);
 	PsImgRec   *recs = NULL;
 	unsigned char **pages = NULL;
 	uint32_t	nrec = 0,
@@ -251,9 +273,9 @@ compact_timeline(uint32_t timeline)
 	if (!old)
 		return -1;
 	nold = 0;
-	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)
+	for (uint32_t i = 0; i < map->nlayers; i++)
 	{
-		const PsLayerDesc *d = &ps_layer_map.layers[i];
+		const PsLayerDesc *d = &map->layers[i];
 
 		if (d->kind == PS_LAYER_IMAGE && !d->deleting && d->timeline == timeline)
 			old[nold++] = *d;
@@ -367,10 +389,10 @@ compact_timeline(uint32_t timeline)
 		goto cleanup;
 
 	/* install the new merged layer durably, THEN delete the old ones */
-	nid = alloc_layer_id(NULL);
+	nid = alloc_layer_id(s);
 	if (ps_image_layer_write(nid, timeline, recs, nrec, page_size, &newdesc) != 0)
 		goto cleanup;			/* write failed: it removed its own file */
-	if (record_layer(NULL, &newdesc) != 0)
+	if (record_layer(s, &newdesc) != 0)
 	{
 		/* written + sealed but not recorded in the manifest: delete it so its
 		 * reused layer id can't later wedge create_local_layer's O_EXCL (the same
@@ -385,13 +407,13 @@ compact_timeline(uint32_t timeline)
 		 * gone, so later reads/compactions hit a missing file.  If REMOVE_LAYER
 		 * then fails the layer stays 'deleting' -- reads skip it and gc_resume()
 		 * finishes the removal on the next start. */
-		if (ps_manifest_mark_delete(old[k].layer_id) != 0)
+		if (ps_manifest_mark_delete(&s->manifest, old[k].layer_id) != 0)
 			continue;
 		/* record the removal only after the file is actually gone; if unlink
 		 * fails, leave the layer 'deleting' so gc_resume() retries it instead of
 		 * orphaning the file with a dropped manifest entry */
 		if (ps_layer_store->delete_local_layer(&old[k]) == 0)
-			ps_manifest_remove_layer(old[k].layer_id);
+			ps_manifest_remove_layer(&s->manifest, old[k].layer_id);
 	}
 	rc = 0;
 
@@ -1125,7 +1147,7 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 			 * memtable grow without bound across retries: drop the staging (it is
 			 * reconstructable) instead of keeping it at/over the threshold. */
 			if (ps_memtable_flush(s->memtable, alloc_layer_id, record_layer,
-								  NULL) != 0)
+								  s) != 0)
 			{
 				fprintf(stderr, "pagestore_core: memtable flush failed; dropping "
 						"staged pages (still durable in the segment log)\n");
@@ -1135,11 +1157,12 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 			 * when the daemon is idle.  As a backpressure guard, compact inline
 			 * here any timeline whose layer count is running away far past the
 			 * threshold (a flush groups by timeline and can emit layers for
-			 * several, so check them all, not just this write's). */
+			 * several, so check them all, not just this write's).  This shard only:
+			 * the flush added layers to this shard's map. */
 			for (uint32_t ct = 0; ct < MAX_TIMELINES; ct++)
 				if ((ct == 0 || timelines[ct].defined) &&
-					count_image_layers(ct) > (uint32_t) compact_layers * 4)
-					compact_timeline(ct);
+					count_image_layers(s, ct) > (uint32_t) compact_layers * 4)
+					compact_timeline(s, ct);
 		}
 	}
 	return 0;
@@ -1162,18 +1185,19 @@ read_version(const PageVer *v, unsigned char *out)
  * of that timeline (key-range/bloom pruning is a later optimization).
  */
 static int
-layer_map_lookup(uint32_t timeline, const PsKey *key, uint32_t block,
+layer_map_lookup(Shard *s, uint32_t timeline, const PsKey *key, uint32_t block,
 				 uint64_t read_lsn, uint64_t *out_lsn, unsigned char *out)
 {
+	const PsLayerMap *map = &s->manifest.map;
 	unsigned char *tmp = malloc(page_size);
 	int			found = 0;
 	uint64_t	best = 0;
 
 	if (!tmp)
 		return 0;
-	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)
+	for (uint32_t i = 0; i < map->nlayers; i++)
 	{
-		const PsLayerDesc *d = &ps_layer_map.layers[i];
+		const PsLayerDesc *d = &map->layers[i];
 		uint64_t	l;
 
 		if (d->kind != PS_LAYER_IMAGE || d->timeline != timeline || d->deleting)
@@ -1237,7 +1261,7 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 				served = 1;		/* served from the memtable */
 			}
 			else if (!ambig &&
-					 layer_map_lookup(tl, key, block, rl, &l, out) &&
+					 layer_map_lookup(s, tl, key, block, rl, &l, out) &&
 					 l == pv->lsn)
 			{
 				s->rr_layer++;
@@ -1410,7 +1434,7 @@ ps_core_close(void)
 
 		if (s->memtable)
 		{
-			ps_memtable_flush(s->memtable, alloc_layer_id, record_layer, NULL);
+			ps_memtable_flush(s->memtable, alloc_layer_id, record_layer, s);
 			ps_memtable_destroy(s->memtable);
 			s->memtable = NULL;
 		}
@@ -1418,26 +1442,32 @@ ps_core_close(void)
 	/* the shutdown flush can push a timeline over the compaction threshold;
 	 * compact it back under so repeated short-lived runs don't accumulate image
 	 * layers (each of which every read would then scan).  compaction is capped at
-	 * COMPACT_BATCH per call, so loop per timeline until it is under the threshold
-	 * or stops making progress (corrupt layer / ENOSPC).  Only in the layer mode:
-	 * a segment-path-only daemon (use_layers == 0, e.g. SPDK) has no memtable and
-	 * must stay layer-free, like ps_core_maintenance(). */
+	 * COMPACT_BATCH per call, so loop per (shard, timeline) until it is under the
+	 * threshold or stops making progress (corrupt layer / ENOSPC).  Only in the
+	 * layer mode: a segment-path-only daemon (use_layers == 0, e.g. SPDK) has no
+	 * memtable and must stay layer-free, like ps_core_maintenance(). */
 	if (use_layers)
-		for (uint32_t ct = 0; ct < MAX_TIMELINES; ct++)
+		for (uint32_t i = 0; i < NSHARDS; i++)
 		{
-			if (ct != 0 && !timelines[ct].defined)
-				continue;
-			while (count_image_layers(ct) > (uint32_t) compact_layers)
-			{
-				uint32_t	before = count_image_layers(ct);
+			Shard	   *s = &g_shards[i];
 
-				if (compact_timeline(ct) != 0 ||
-					count_image_layers(ct) >= before)
-					break;		/* failed or no progress: stop draining this one */
+			for (uint32_t ct = 0; ct < MAX_TIMELINES; ct++)
+			{
+				if (ct != 0 && !timelines[ct].defined)
+					continue;
+				while (count_image_layers(s, ct) > (uint32_t) compact_layers)
+				{
+					uint32_t	before = count_image_layers(s, ct);
+
+					if (compact_timeline(s, ct) != 0 ||
+						count_image_layers(s, ct) >= before)
+						break;	/* failed or no progress: stop draining this one */
+				}
 			}
 		}
 	ps_pgcache_free();
-	ps_manifest_close();
+	for (uint32_t i = 0; i < NSHARDS; i++)
+		ps_manifest_close(&g_shards[i].manifest);
 }
 
 /*
@@ -1461,24 +1491,30 @@ ps_core_maintenance(void)
 	 * window passes. */
 	if (cooldown_until != 0 && time(NULL) < cooldown_until)
 		return 0;
-	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
-		if ((tl == 0 || timelines[tl].defined) &&
-			count_image_layers(tl) > (uint32_t) compact_layers)
-		{
-			uint32_t	before = count_image_layers(tl);
+	for (uint32_t i = 0; i < NSHARDS; i++)
+	{
+		Shard	   *s = &g_shards[i];
 
-			/* Report progress (so the caller skips its idle sleep) only if the
-			 * compaction actually reduced the layer count.  A timeline that can't
-			 * make progress -- nothing mergeable (e.g. compact_layers=0 with a
-			 * single layer) or a failing compaction (ENOSPC / corrupt layer) --
-			 * must not keep the daemon spinning; try the next timeline. */
-			attempted = 1;
-			if (compact_timeline(tl) == 0 && count_image_layers(tl) < before)
+		for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
+			if ((tl == 0 || timelines[tl].defined) &&
+				count_image_layers(s, tl) > (uint32_t) compact_layers)
 			{
-				cooldown_until = 0;	/* progress: clear any backoff */
-				return 1;
+				uint32_t	before = count_image_layers(s, tl);
+
+				/* Report progress (so the caller skips its idle sleep) only if the
+				 * compaction actually reduced the layer count.  A timeline that
+				 * can't make progress -- nothing mergeable (e.g. compact_layers=0
+				 * with a single layer) or a failing compaction (ENOSPC / corrupt
+				 * layer) -- must not keep the daemon spinning; try the next one. */
+				attempted = 1;
+				if (compact_timeline(s, tl) == 0 &&
+					count_image_layers(s, tl) < before)
+				{
+					cooldown_until = 0;	/* progress: clear any backoff */
+					return 1;
+				}
 			}
-		}
+	}
 	/* Over-threshold timeline(s) exist but none could be compacted: back off so an
 	 * otherwise-idle daemon doesn't re-attempt the same failing merge every 20us.
 	 * A later flush/compaction that changes layer state will return 1 and clear
@@ -1506,29 +1542,15 @@ ps_core_open(const char *store_dir)
 	/* layer_ids are unique only within a store; drop any blooms cached from a
 	 * previously-opened store so a reused id can't return a stale "absent" */
 	ps_image_bloom_reset();
-	if (ps_manifest_open(store_dir) != 0)
-		return -1;
-	if (ps_manifest_replay(&ps_layer_map) != 0)
-		return -1;
-	if (use_layers)
-		gc_resume();			/* finish any GC interrupted by a crash */
-
-	/* layer ids continue past the highest one the manifest restored */
-	g_next_layer_id = 1;
-	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)
-		if (ps_layer_map.layers[i].layer_id >= g_next_layer_id)
-			g_next_layer_id = ps_layer_map.layers[i].layer_id + 1;
 
 	/* the LSM write side (memtable/flush/compaction) runs only when layers are
-	 * the read path; the SPDK daemon stays on the segment path for now.  One
-	 * memtable per shard. */
+	 * the read path; the SPDK daemon stays on the segment path for now.  Reject
+	 * non-positive thresholds before their unsigned casts: a negative
+	 * --flush-pages would become a huge flush threshold (memtable never flushes
+	 * -> unbounded RAM), and a negative --compact-layers a huge compaction
+	 * threshold (compaction never runs -> layers grow without bound). */
 	if (use_layers)
 	{
-		/* reject non-positive thresholds before their unsigned casts: a negative
-		 * --flush-pages would become a huge flush threshold (memtable never
-		 * flushes -> unbounded RAM), and a negative --compact-layers a huge
-		 * compaction threshold (compaction never runs -> layers grow without
-		 * bound, every read scanning an ever-larger map) */
 		if (flush_pages <= 0)
 		{
 			fprintf(stderr, "pagestore_core: --flush-pages must be positive "
@@ -1541,11 +1563,35 @@ ps_core_open(const char *store_dir)
 					"(got %d)\n", compact_layers);
 			return -1;
 		}
-		for (uint32_t i = 0; i < NSHARDS; i++)
+	}
+
+	/* per-shard: open + replay its manifest, finish any interrupted GC, continue
+	 * layer ids past the highest the manifest restored (low bits only -- the
+	 * shard id is OR'd in at allocation), and create the shard's memtable */
+	for (uint32_t i = 0; i < NSHARDS; i++)
+	{
+		Shard	   *s = &g_shards[i];
+
+		s->index = i;
+		if (ps_manifest_open(&s->manifest, store_dir, i) != 0)
+			return -1;
+		if (ps_manifest_replay(&s->manifest) != 0)
+			return -1;
+		if (use_layers)
+			gc_resume(s);
+		s->next_local_id = 1;
+		for (uint32_t j = 0; j < s->manifest.map.nlayers; j++)
 		{
-			g_shards[i].memtable = ps_memtable_create(page_size,
-													  (uint32_t) flush_pages);
-			if (!g_shards[i].memtable)
+			uint64_t	local = s->manifest.map.layers[j].layer_id &
+				LAYER_ID_LOCAL_MASK;
+
+			if (local >= s->next_local_id)
+				s->next_local_id = local + 1;
+		}
+		if (use_layers)
+		{
+			s->memtable = ps_memtable_create(page_size, (uint32_t) flush_pages);
+			if (!s->memtable)
 				return -1;
 		}
 	}
@@ -1560,9 +1606,8 @@ ps_core_open(const char *store_dir)
 		return -1;
 	}
 	ps_pgcache_init((uint32_t) cache_pages, page_size);
-	fprintf(stderr, "pagestore_core: %u image layer(s) in map after manifest "
-			"replay (next layer id %llu)\n", ps_layer_map.nlayers,
-			(unsigned long long) g_next_layer_id);
+	fprintf(stderr, "pagestore_core: %u image layer(s) across %u shard(s) after "
+			"manifest replay\n", ps_core_layer_count(), (uint32_t) NSHARDS);
 
 	/* timeline 0 is the root; load any persisted branches, then rebuild data */
 	timeline_define(0, -1, 0);

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -83,17 +83,13 @@ typedef struct PsManifestLayerDisk
 	uint8_t		pad;
 } PsManifestLayerDisk;
 
-static char manifest_path[4096];
-static char manifest_dir[2048];
-PsLayerMap ps_layer_map;
-
 static int
-manifest_fsync_dir(void)
+manifest_fsync_dir(PsManifest *m)
 {
 	int			fd;
 	int			rc;
 
-	fd = open(manifest_dir, O_RDONLY);
+	fd = open(m->dir, O_RDONLY);
 	if (fd < 0)
 		return -1;
 	rc = fsync(fd);
@@ -102,14 +98,14 @@ manifest_fsync_dir(void)
 }
 
 static int
-manifest_append(uint32_t type, const void *payload, uint32_t len)
+manifest_append(PsManifest *m, uint32_t type, const void *payload, uint32_t len)
 {
 	PsManifestRecord rec;
 	int			fd;
 	int			rc = 0;
 	int			created = 0;
 
-	fd = open(manifest_path, O_WRONLY | O_APPEND | O_CREAT, 0600);
+	fd = open(m->path, O_WRONLY | O_APPEND | O_CREAT, 0600);
 	if (fd < 0)
 		return -1;
 	if (lseek(fd, 0, SEEK_END) == 0)
@@ -125,7 +121,7 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 		rc = -1;
 	if (fsync(fd) != 0)
 		rc = -1;
-	if (created && manifest_fsync_dir() != 0)
+	if (created && manifest_fsync_dir(m) != 0)
 		rc = -1;
 	close(fd);
 	return rc;
@@ -255,37 +251,41 @@ manifest_remove_from_map(PsLayerMap *map, uint64_t layer_id)
 }
 
 int
-ps_manifest_open(const char *store_dir)
+ps_manifest_open(PsManifest *m, const char *store_dir, uint32_t shard)
 {
 	int			n;
 
-	n = snprintf(manifest_dir, sizeof(manifest_dir), "%s", store_dir);
-	if (n < 0 || (size_t) n >= sizeof(manifest_dir))
+	n = snprintf(m->dir, sizeof(m->dir), "%s", store_dir);
+	if (n < 0 || (size_t) n >= sizeof(m->dir))
 		return -1;
-	n = snprintf(manifest_path, sizeof(manifest_path), "%s/layers.manifest", store_dir);
-	if (n < 0 || (size_t) n >= sizeof(manifest_path))
+	/* one manifest file per shard; the shard id keeps them distinct in the one
+	 * store directory (layer files are likewise shard-namespaced via layer_id) */
+	n = snprintf(m->path, sizeof(m->path), "%s/layers.%u.manifest", store_dir,
+				 shard);
+	if (n < 0 || (size_t) n >= sizeof(m->path))
 		return -1;
-	ps_layer_map_init(&ps_layer_map);
+	ps_layer_map_init(&m->map);
 	return 0;
 }
 
 void
-ps_manifest_close(void)
+ps_manifest_close(PsManifest *m)
 {
-	ps_layer_map_free(&ps_layer_map);
-	manifest_path[0] = '\0';
+	ps_layer_map_free(&m->map);
+	m->path[0] = '\0';
 }
 
 int
-ps_manifest_replay(PsLayerMap *map)
+ps_manifest_replay(PsManifest *m)
 {
+	PsLayerMap *map = &m->map;
 	int			fd;
 	off_t		good_off = 0;
 	int			truncate_tail = 0;
 	off_t		file_size;
 	struct stat st;
 
-	fd = open(manifest_path, O_RDWR);
+	fd = open(m->path, O_RDWR);
 	if (fd < 0)
 	{
 		if (errno == ENOENT)
@@ -484,34 +484,35 @@ done:
 }
 
 int
-ps_manifest_add_layer(const PsLayerDesc *desc)
+ps_manifest_add_layer(PsManifest *m, const PsLayerDesc *desc)
 {
 	PsManifestLayerDisk disk;
 
 	if (!manifest_layer_desc_valid(desc))
 		return -1;
-	if (manifest_layer_exists(&ps_layer_map, desc->layer_id))
+	if (manifest_layer_exists(&m->map, desc->layer_id))
 		return 0;
-	if (ps_layer_map_reserve(&ps_layer_map, ps_layer_map_count(&ps_layer_map) + 1) != 0)
+	if (ps_layer_map_reserve(&m->map, ps_layer_map_count(&m->map) + 1) != 0)
 		return -1;
 	if (manifest_encode_layer(&disk, desc) != 0)
 		return -1;
-	if (manifest_append(PS_MANIFEST_ADD_LAYER, &disk, sizeof(disk)) != 0)
+	if (manifest_append(m, PS_MANIFEST_ADD_LAYER, &disk, sizeof(disk)) != 0)
 		return -1;
-	return ps_layer_map_add(&ps_layer_map, desc);
+	return ps_layer_map_add(&m->map, desc);
 }
 
 int
-ps_manifest_set_remote_durable(uint64_t layer_id, uint64_t uploaded_lsn)
+ps_manifest_set_remote_durable(PsManifest *m, uint64_t layer_id,
+							   uint64_t uploaded_lsn)
 {
 	PsManifestLayerIdEvent ev;
 	PsLayerDesc *layer;
 
 	ev.layer_id = layer_id;
 	ev.value = uploaded_lsn;
-	if (manifest_append(PS_MANIFEST_SET_REMOTE_DURABLE, &ev, sizeof(ev)) != 0)
+	if (manifest_append(m, PS_MANIFEST_SET_REMOTE_DURABLE, &ev, sizeof(ev)) != 0)
 		return -1;
-	layer = manifest_find_layer(&ps_layer_map, layer_id);
+	layer = manifest_find_layer(&m->map, layer_id);
 	if (layer != NULL)
 	{
 		layer->remote_durable = true;
@@ -521,30 +522,30 @@ ps_manifest_set_remote_durable(uint64_t layer_id, uint64_t uploaded_lsn)
 }
 
 int
-ps_manifest_mark_delete(uint64_t layer_id)
+ps_manifest_mark_delete(PsManifest *m, uint64_t layer_id)
 {
 	PsManifestLayerIdEvent ev;
 	PsLayerDesc *layer;
 
 	ev.layer_id = layer_id;
 	ev.value = 0;
-	if (manifest_append(PS_MANIFEST_MARK_DELETE, &ev, sizeof(ev)) != 0)
+	if (manifest_append(m, PS_MANIFEST_MARK_DELETE, &ev, sizeof(ev)) != 0)
 		return -1;
-	layer = manifest_find_layer(&ps_layer_map, layer_id);
+	layer = manifest_find_layer(&m->map, layer_id);
 	if (layer != NULL)
 		layer->deleting = true;
 	return 0;
 }
 
 int
-ps_manifest_remove_layer(uint64_t layer_id)
+ps_manifest_remove_layer(PsManifest *m, uint64_t layer_id)
 {
 	PsManifestLayerIdEvent ev;
 
 	ev.layer_id = layer_id;
 	ev.value = 0;
-	if (manifest_append(PS_MANIFEST_REMOVE_LAYER, &ev, sizeof(ev)) != 0)
+	if (manifest_append(m, PS_MANIFEST_REMOVE_LAYER, &ev, sizeof(ev)) != 0)
 		return -1;
-	manifest_remove_from_map(&ps_layer_map, layer_id);
+	manifest_remove_from_map(&m->map, layer_id);
 	return 0;
 }

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -258,10 +258,20 @@ ps_manifest_open(PsManifest *m, const char *store_dir, uint32_t shard)
 	n = snprintf(m->dir, sizeof(m->dir), "%s", store_dir);
 	if (n < 0 || (size_t) n >= sizeof(m->dir))
 		return -1;
-	/* one manifest file per shard; the shard id keeps them distinct in the one
-	 * store directory (layer files are likewise shard-namespaced via layer_id) */
-	n = snprintf(m->path, sizeof(m->path), "%s/layers.%u.manifest", store_dir,
-				 shard);
+	/*
+	 * One manifest file per shard; the shard id keeps them distinct in the one
+	 * store directory (layer files are likewise shard-namespaced via layer_id).
+	 * Shard 0 keeps the historical unsuffixed name "layers.manifest": its ids are
+	 * 0<<shift | local == the pre-sharding ids, so a store created before sharding
+	 * reopens cleanly at nshards == 1 -- its layers replay into shard 0 and seed
+	 * next_local_id past them, with no migration and no O_EXCL id collision on the
+	 * next flush.
+	 */
+	if (shard == 0)
+		n = snprintf(m->path, sizeof(m->path), "%s/layers.manifest", store_dir);
+	else
+		n = snprintf(m->path, sizeof(m->path), "%s/layers.%u.manifest",
+					 store_dir, shard);
 	if (n < 0 || (size_t) n >= sizeof(m->path))
 		return -1;
 	ps_layer_map_init(&m->map);

--- a/contrib/pagestore/pagestore_manifest.h
+++ b/contrib/pagestore/pagestore_manifest.h
@@ -12,15 +12,27 @@
 
 #include "pagestore_layer.h"
 
-extern PsLayerMap ps_layer_map;
+/*
+ * A manifest is a durable event log plus the in-memory layer map it rebuilds.
+ * One per shard (sharding step 4): each shard owns a separate manifest file and
+ * layer map, so its compaction/GC touch no shared state.  layer_ids are
+ * shard-namespaced (high bits = shard), so the layer files -- named by id -- never
+ * collide across shards even though they share one directory.
+ */
+typedef struct PsManifest
+{
+	char		path[4096];
+	char		dir[2048];
+	PsLayerMap	map;
+} PsManifest;
 
-extern int	ps_manifest_open(const char *store_dir);
-extern void ps_manifest_close(void);
-extern int	ps_manifest_replay(PsLayerMap *map);
-extern int	ps_manifest_add_layer(const PsLayerDesc *desc);
-extern int	ps_manifest_set_remote_durable(uint64_t layer_id,
+extern int	ps_manifest_open(PsManifest *m, const char *store_dir, uint32_t shard);
+extern void ps_manifest_close(PsManifest *m);
+extern int	ps_manifest_replay(PsManifest *m);
+extern int	ps_manifest_add_layer(PsManifest *m, const PsLayerDesc *desc);
+extern int	ps_manifest_set_remote_durable(PsManifest *m, uint64_t layer_id,
 										   uint64_t uploaded_lsn);
-extern int	ps_manifest_mark_delete(uint64_t layer_id);
-extern int	ps_manifest_remove_layer(uint64_t layer_id);
+extern int	ps_manifest_mark_delete(PsManifest *m, uint64_t layer_id);
+extern int	ps_manifest_remove_layer(PsManifest *m, uint64_t layer_id);
 
 #endif							/* PAGESTORE_MANIFEST_H */


### PR DESCRIPTION
First sub-slice of **step 4** (SHARDING.md). Make the durable layer metadata per-shard so each shard's compaction/GC/reads touch no shared state — **still `nshards == 1`, single-threaded, behavior identical**, de-risking the threading slice the way step 2's `Shard` refactor did. Stacked on #17.

## What
- **`pagestore_manifest.{c,h}`:** the manifest is now a `PsManifest` handle (durable event-log path + dir + the `PsLayerMap` it rebuilds) instead of file-scope globals; every entry point takes `PsManifest *`. `ps_manifest_open()` names the file `layers.<shard>.manifest` so shards stay distinct in one store dir.
- **`pagestore_core.c`:** `Shard` gains `{index, manifest, next_local_id}`. `layer_id` is **shard-namespaced** — high bits = shard index, low 48 = per-shard counter — via `alloc_layer_id()` (ctx = owning `Shard*`), so ids *and the id-named layer files* never collide across shards while each shard allocates independently; at shard 0 the ids are `1,2,3…` exactly as before. `count_image_layers`/`gc_resume`/`compact_timeline`/`layer_map_lookup` take `Shard*` and use `s->manifest.map`; `record_layer` writes `s->manifest`. `ps_core_open` opens+replays each shard's manifest, resumes its GC, seeds `next_local_id` from the restored ids; `close`/`maintenance` iterate shards × timelines; `ps_core_layer_count` sums across shards.

## Compatibility
Manifest filename changes (`layers.manifest` → `layers.0.manifest`). Dev stores are recreated by the test suite, so no migration is needed.

## Test
- Standalone **166/0** (POSIX, incl. crash + clean-restart recovery through the new per-shard manifest), **166/0** (SPDK, nvme2), image-layer unit test **57/0**.

Next sub-slices: 4b (runtime `nshards>1`, single-threaded) → 4c (per-shard POSIX worker threads — real parallelism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)