### PR TITLE
contrib/pagestore: runtime nshards > 1, single-threaded serve (sharding step 4b)

### DIFF
--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -144,8 +144,14 @@ timeline tree under a brief coordination point, not on the read/write hot path.
      store dir.  Compaction/GC/lookup are parameterized by `Shard *`.  Behavior
      identical at one shard (ids 1,2,3…; one manifest) — de-risks the threading
      slice like step 2 did.
-   - **4b** — runtime `nshards > 1`, still single-threaded serve loop over all
-     pools (proves multi-shard data partitioning end-to-end before threads).
+   - **4b — runtime `nshards > 1`, still single-threaded** serve loop over all
+     pools. ✅ Shard count is chosen at startup (`--nshards`, default 1, capped by
+     compile-time `PS_MAX_SHARDS`) and published in the shm header; `ps_nshards`
+     replaces the old compile-time constant in routing/loops, the array is sized
+     to the cap.  The one serve loop already scans every channel, so it drives all
+     shards' pools with no threads yet — proving multi-shard data partitioning
+     (and per-shard manifests/recovery) end-to-end.  The standalone battery runs
+     at `nshards = 1` and `nshards = 4`.
    - **4c** — one POSIX worker thread per shard; `backend_localsvc` per-shard
      channel pool + routing.  This is where real parallelism lands.
 5. **SPDK per-thread qpairs** so the async path scales per core.

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -58,16 +58,14 @@ int			use_layers = 1;
 const PsStorage *ps_storage = &PsStoragePosix;
 
 /*
- * Per-shard state (LSM phase 9, sharding step 2).  One thread per shard will own
- * its index / staging / cache lock-free; the shard is chosen from the logical
- * key only (block- and timeline-independent), so a key's blocks and all its
- * timelines live on one shard.  NSHARDS == 1 for now -- behavior identical to
- * the old single global state -- and shard_for() hashes the key once NSHARDS > 1.
- *
- * Each shard's memtable stages recent page versions and flushes them into
- * immutable image layers (writes still also go to the segment log, the source of
- * truth).  (The segment append cursor and layer-id allocator stay global for now;
- * they become per-shard with per-shard segment namespaces / manifests in step 4.)
+ * Per-shard state (LSM phase 9).  One thread per shard will own its index /
+ * staging / cache lock-free; the shard is chosen from the logical key only
+ * (block- and timeline-independent), so a key's blocks and all its timelines live
+ * on one shard.  The live count ps_nshards is chosen at startup (--nshards) and
+ * shard_for() hashes the key into it; at ps_nshards == 1 behavior is identical to
+ * the old single global state.  Each shard has its own manifest + layer map (step
+ * 4a) and a shard-namespaced layer-id allocator.  Step 4c gives each its own
+ * thread; for now a single serve loop drives every shard's channel pool.
  */
 #define IDX_BUCKETS		(1 << 16)
 #define IDX_MASK		(IDX_BUCKETS - 1)
@@ -82,7 +80,7 @@ typedef struct Shard
 	struct ForkEnt *fork_idx[IDX_BUCKETS];	/* (timeline,key) -> fork size */
 	struct WalIdxEnt *walidx[IDX_BUCKETS];	/* (timeline,key,block) -> WAL lsns */
 	PsMemtable *memtable;		/* staging -> image layers */
-	uint32_t	index;			/* this shard's id (0 .. NSHARDS-1) */
+	uint32_t	index;			/* this shard's id (0 .. ps_nshards-1) */
 	PsManifest	manifest;		/* per-shard durable layer log + layer map */
 	uint64_t	next_local_id;	/* next layer id within this shard (low bits) */
 	uint64_t	rr_mem,			/* read-source counters */
@@ -90,22 +88,24 @@ typedef struct Shard
 				rr_seg;
 } Shard;
 
-#define NSHARDS PS_NSHARDS		/* shared with clients via pagestore_ipc.h */
-static Shard g_shards[NSHARDS];
+/* live shard count (1..PS_MAX_SHARDS); the frontend sets it before ps_core_open.
+ * The array is sized to the compile-time cap; only [0, ps_nshards) are used. */
+uint32_t	ps_nshards = 1;
+static Shard g_shards[PS_MAX_SHARDS];
 
 static Shard *
 shard_for(const PsKey *key)
 {
 	/* same hash clients route with, so a request always lands on the shard that
-	 * owns the key (identity at NSHARDS == 1) */
-	return &g_shards[ps_shard_for_key(key, NSHARDS)];
+	 * owns the key (identity at ps_nshards == 1) */
+	return &g_shards[ps_shard_for_key(key, ps_nshards)];
 }
 
 /*
  * layer_id namespacing: the high LAYER_ID_SHARD_SHIFT bits hold the shard id and
  * the low bits a per-shard counter, so ids (and the layer files named by them)
  * never collide across shards while each shard allocates independently.  At
- * NSHARDS == 1, shard 0's ids are 1, 2, 3, ... -- identical to the old global
+ * ps_nshards == 1, shard 0's ids are 1, 2, 3, ... -- identical to the old global
  * allocator.
  */
 #define LAYER_ID_SHARD_SHIFT	48
@@ -116,7 +116,7 @@ ps_core_layer_count(void)
 {
 	uint32_t	n = 0;
 
-	for (uint32_t i = 0; i < NSHARDS; i++)
+	for (uint32_t i = 0; i < ps_nshards; i++)
 		n += g_shards[i].manifest.map.nlayers;
 	return n;
 }
@@ -130,7 +130,7 @@ ps_core_read_stats(uint64_t *mem, uint64_t *layer, uint64_t *seg)
 				l = 0,
 				s = 0;
 
-	for (uint32_t i = 0; i < NSHARDS; i++)
+	for (uint32_t i = 0; i < ps_nshards; i++)
 	{
 		m += g_shards[i].rr_mem;
 		l += g_shards[i].rr_layer;
@@ -1428,7 +1428,7 @@ ps_handle_meta(PsChannel *ch)
 void
 ps_core_close(void)
 {
-	for (uint32_t i = 0; i < NSHARDS; i++)
+	for (uint32_t i = 0; i < ps_nshards; i++)
 	{
 		Shard	   *s = &g_shards[i];
 
@@ -1447,7 +1447,7 @@ ps_core_close(void)
 	 * layer mode: a segment-path-only daemon (use_layers == 0, e.g. SPDK) has no
 	 * memtable and must stay layer-free, like ps_core_maintenance(). */
 	if (use_layers)
-		for (uint32_t i = 0; i < NSHARDS; i++)
+		for (uint32_t i = 0; i < ps_nshards; i++)
 		{
 			Shard	   *s = &g_shards[i];
 
@@ -1466,7 +1466,7 @@ ps_core_close(void)
 			}
 		}
 	ps_pgcache_free();
-	for (uint32_t i = 0; i < NSHARDS; i++)
+	for (uint32_t i = 0; i < ps_nshards; i++)
 		ps_manifest_close(&g_shards[i].manifest);
 }
 
@@ -1491,7 +1491,7 @@ ps_core_maintenance(void)
 	 * window passes. */
 	if (cooldown_until != 0 && time(NULL) < cooldown_until)
 		return 0;
-	for (uint32_t i = 0; i < NSHARDS; i++)
+	for (uint32_t i = 0; i < ps_nshards; i++)
 	{
 		Shard	   *s = &g_shards[i];
 
@@ -1568,7 +1568,7 @@ ps_core_open(const char *store_dir)
 	/* per-shard: open + replay its manifest, finish any interrupted GC, continue
 	 * layer ids past the highest the manifest restored (low bits only -- the
 	 * shard id is OR'd in at allocation), and create the shard's memtable */
-	for (uint32_t i = 0; i < NSHARDS; i++)
+	for (uint32_t i = 0; i < ps_nshards; i++)
 	{
 		Shard	   *s = &g_shards[i];
 
@@ -1607,7 +1607,7 @@ ps_core_open(const char *store_dir)
 	}
 	ps_pgcache_init((uint32_t) cache_pages, page_size);
 	fprintf(stderr, "pagestore_core: %u image layer(s) across %u shard(s) after "
-			"manifest replay\n", ps_core_layer_count(), (uint32_t) NSHARDS);
+			"manifest replay\n", ps_core_layer_count(), ps_nshards);
 
 	/* timeline 0 is the root; load any persisted branches, then rebuild data */
 	timeline_define(0, -1, 0);

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -39,6 +39,7 @@ extern int	flush_pages;		/* memtable flush threshold in pages */
 extern int	compact_layers;		/* compact a timeline past this many image layers */
 extern int	cache_pages;		/* materialized-page cache size (pages; 0=off) */
 extern int	use_layers;			/* rebuild read state from layers (vs segments) */
+extern uint32_t ps_nshards;		/* live shard count (1..PS_MAX_SHARDS); set before open */
 extern const PsStorage *ps_storage;
 
 /* Open the store and rebuild all in-memory state (timelines, indexes, WAL). */

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -129,6 +129,8 @@ main(int argc, char **argv)
 			compact_layers = atoi(argv[++i]);
 		else if (strcmp(argv[i], "--cache-pages") == 0 && i + 1 < argc)
 			cache_pages = atoi(argv[++i]);
+		else if (strcmp(argv[i], "--nshards") == 0 && i + 1 < argc)
+			ps_nshards = (uint32_t) strtoul(argv[++i], NULL, 10);
 		else if (strcmp(argv[i], "--storage") == 0 && i + 1 < argc)
 		{
 			const char *name = argv[++i];
@@ -156,8 +158,14 @@ main(int argc, char **argv)
 	if (!shm_name || !store_dir || page_size == 0 || page_size > PS_IO_UNIT)
 	{
 		fprintf(stderr, "usage: %s --shm NAME --store DIR "
-				"[--page-size N] [--segment-size N] [--storage NAME]\n",
+				"[--page-size N] [--segment-size N] [--nshards N] [--storage NAME]\n",
 				argv[0]);
+		return 2;
+	}
+	if (ps_nshards < 1 || ps_nshards > PS_MAX_SHARDS)
+	{
+		fprintf(stderr, "--nshards must be in [1, %d] (got %u)\n",
+				PS_MAX_SHARDS, ps_nshards);
 		return 2;
 	}
 
@@ -202,7 +210,7 @@ main(int argc, char **argv)
 	hdr->page_size = page_size;
 	hdr->io_unit = PS_IO_UNIT;
 	hdr->nchannels = PS_MAX_CHANNELS;
-	hdr->nshards = PS_NSHARDS;	/* clients route to the same shard pools */
+	hdr->nshards = ps_nshards;	/* clients route to the same shard pools */
 	hdr->channel_stride = PS_CHANNEL_STRIDE;
 	hdr->channels_off = PS_CHANNELS_OFF;
 	/* publish magic with a release store so the readers' acquire-load of it has a

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -274,17 +274,25 @@ main(int argc, char **argv)
 			compact_layers = atoi(argv[++i]);
 		else if (strcmp(argv[i], "--cache-pages") == 0 && i + 1 < argc)
 			cache_pages = atoi(argv[++i]);
+		else if (strcmp(argv[i], "--nshards") == 0 && i + 1 < argc)
+			ps_nshards = (uint32_t) strtoul(argv[++i], NULL, 10);
 		else
 		{
 			fprintf(stderr, "usage: %s --shm NAME --store DIR --pci ADDR "
-					"[--page-size N] [--segment-size N]\n", argv[0]);
+					"[--page-size N] [--segment-size N] [--nshards N]\n", argv[0]);
 			return 2;
 		}
 	}
 	if (!shm_name || !store_dir || page_size == 0 || page_size > PS_IO_UNIT)
 	{
 		fprintf(stderr, "usage: %s --shm NAME --store DIR --pci ADDR "
-				"[--page-size N] [--segment-size N]\n", argv[0]);
+				"[--page-size N] [--segment-size N] [--nshards N]\n", argv[0]);
+		return 2;
+	}
+	if (ps_nshards < 1 || ps_nshards > PS_MAX_SHARDS)
+	{
+		fprintf(stderr, "--nshards must be in [1, %d] (got %u)\n",
+				PS_MAX_SHARDS, ps_nshards);
 		return 2;
 	}
 	if (pci_addr)
@@ -324,7 +332,7 @@ main(int argc, char **argv)
 	hdr->page_size = page_size;
 	hdr->io_unit = PS_IO_UNIT;
 	hdr->nchannels = PS_MAX_CHANNELS;
-	hdr->nshards = PS_NSHARDS;	/* clients route to the same shard pools */
+	hdr->nshards = ps_nshards;	/* clients route to the same shard pools */
 	hdr->channel_stride = PS_CHANNEL_STRIDE;
 	hdr->channels_off = PS_CHANNELS_OFF;
 	/* publish magic with a release store so the readers' acquire-load of it has a

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -46,19 +46,20 @@
 #define PS_MAX_CHANNELS		128
 
 /*
- * Shard count (LSM phase 9 / sharding).  The daemon owns one Shard per core and
- * publishes this in the shm header (PsShmHeader.nshards) so clients route the
- * same way.  PS_NSHARDS == 1 keeps behavior identical to the single-owner daemon;
- * real per-shard worker threads arrive in a later step.  The channel array is
- * partitioned into nshards contiguous pools (see ps_shard_channel_range), and a
- * request for 'key' is routed to ps_shard_for_key(key)'s pool.
+ * Sharding (LSM phase 9).  The daemon owns one Shard per core; the actual count
+ * is chosen at startup (--nshards, default 1) and published in the shm header
+ * (PsShmHeader.nshards) so clients route the same way.  PS_MAX_SHARDS only caps
+ * the compile-time array sizing on both sides; the live count is runtime.  The
+ * channel array is partitioned into nshards contiguous pools (see
+ * ps_shard_channel_range), and a request for 'key' goes to ps_shard_for_key()'s
+ * pool.  nshards == 1 is identical to the old single-owner daemon.
  */
-#define PS_NSHARDS			1
+#define PS_MAX_SHARDS		64
 
-/* Each shard owns a non-empty channel pool, so there must be at least as many
- * channels as shards (see ps_shard_channel_range). */
-_Static_assert(PS_NSHARDS >= 1 && PS_NSHARDS <= PS_MAX_CHANNELS,
-			   "PS_NSHARDS must be in [1, PS_MAX_CHANNELS]");
+/* Each shard owns a non-empty channel pool, so there can't be more shards than
+ * channels (see ps_shard_channel_range). */
+_Static_assert(PS_MAX_SHARDS >= 1 && PS_MAX_SHARDS <= PS_MAX_CHANNELS,
+			   "PS_MAX_SHARDS must be in [1, PS_MAX_CHANNELS]");
 
 /* Mailbox state (atomic uint32) */
 #define PS_STATE_IDLE		0
@@ -196,8 +197,8 @@ ps_shard_for_key(const PsKey *key, uint32_t nshards)
  * Proportional boundaries (shard*nchannels/nshards) spread any remainder evenly
  * instead of dumping it all on the last shard, so every shard's pool size (its
  * available concurrency) is within one of the others.  Requires
- * nshards <= nchannels so no pool is empty (enforced for PS_NSHARDS by the
- * _Static_assert above and clamped by the daemon at startup).
+ * nshards <= nchannels so no pool is empty (PS_MAX_SHARDS <= PS_MAX_CHANNELS by
+ * the _Static_assert above; the daemon validates --nshards at startup).
  */
 static inline void
 ps_shard_channel_range(uint32_t shard, uint32_t nshards, uint32_t nchannels,

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -73,9 +73,10 @@ rm_rf(const char *path)
 
 static void *cl_shm;
 static int	cl_shm_fd;
-static int	cl_pool[PS_NSHARDS];	/* channel claimed in each shard pool, -1 = none */
+static int	cl_pool[PS_MAX_SHARDS]; /* channel claimed in each shard pool, -1 = none */
 static uint32_t cl_nshards;			/* shard count published by the daemon */
 static uint32_t cl_nchannels;		/* channel count published by the daemon */
+static uint32_t g_nshards = 1;		/* --nshards to spawn the daemon with */
 static uint32_t cl_page_size;
 
 static void
@@ -107,16 +108,15 @@ client_attach(const char *shm_name, uint32_t expect_page_size)
 		  "header page_size=%u expected %u", hdr->page_size, expect_page_size);
 	cl_page_size = hdr->page_size;
 
-	/* The client is built with the same PS_NSHARDS as the daemon (version-gated),
-	 * so the channel-pool partition lines up.  Reject a mismatch rather than
-	 * clamp: a smaller client nshards would route keys to fewer pools than the
-	 * daemon serves, misrouting once each shard polls only its own pool. */
+	/* Adopt the daemon's published shard count and route to match.  It must fit
+	 * the client's compile-time cap (both build from PS_MAX_SHARDS); reject an
+	 * out-of-range count rather than mis-size the pool array. */
 	cl_nchannels = hdr->nchannels;
 	cl_nshards = hdr->nshards ? hdr->nshards : 1;
-	if (cl_nshards != PS_NSHARDS)
+	if (cl_nshards > PS_MAX_SHARDS)
 	{
-		fprintf(stderr, "daemon nshards=%u != client PS_NSHARDS=%u\n",
-				cl_nshards, PS_NSHARDS);
+		fprintf(stderr, "daemon nshards=%u exceeds client PS_MAX_SHARDS=%u\n",
+				cl_nshards, (uint32_t) PS_MAX_SHARDS);
 		exit(2);
 	}
 	for (uint32_t s = 0; s < cl_nshards; s++)
@@ -538,13 +538,16 @@ spawn_daemon(const char *daemon_path, const char *shm, const char *store,
 	if (pid == 0)
 	{
 		char		psbuf[16];
+		char		nsbuf[16];
 
 		snprintf(psbuf, sizeof(psbuf), "%u", page_size);
+		snprintf(nsbuf, sizeof(nsbuf), "%u", g_nshards);
 		/* small segments exercise rollover; a small flush threshold makes the
 		 * tests flush into image layers so the layer read path is exercised */
 		execl(daemon_path, daemon_path, "--shm", shm, "--store", store,
 			  "--page-size", psbuf, "--segment-size", "65536",
-			  "--flush-pages", "8", "--compact-layers", "3", (char *) NULL);
+			  "--flush-pages", "8", "--compact-layers", "3",
+			  "--nshards", nsbuf, (char *) NULL);
 		perror("execl daemon");
 		_exit(127);
 	}
@@ -1192,24 +1195,38 @@ main(int argc, char **argv)
 	/* shard-routing contract (pure helpers; no daemon) */
 	run_sharding_contract();
 
-	/* run the whole suite once per page size: proves page-size independence */
-	for (size_t i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++)
-		run_suite(daemon_path, tmpbase, sizes[i]);
+	/*
+	 * Run the whole daemon-driven battery once single-shard and once multi-shard.
+	 * At nshards > 1 the client routes each key to its shard's channel pool and
+	 * the (still single-threaded) daemon serves every pool; identical results
+	 * prove the data partitions correctly across shards end-to-end.
+	 */
+	uint32_t	shard_cases[] = {1, 4};
 
-	/* branch / snapshot isolation (page-size independent, run once) */
-	run_branch_suite(daemon_path, tmpbase);
+	for (uint32_t si = 0; si < sizeof(shard_cases) / sizeof(shard_cases[0]); si++)
+	{
+		g_nshards = shard_cases[si];
+		fprintf(stderr, "\n#### nshards=%u ####\n", g_nshards);
 
-	/* shipped-WAL durability */
-	run_wal_suite(daemon_path, tmpbase);
+		/* run the whole suite once per page size: proves page-size independence */
+		for (size_t i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++)
+			run_suite(daemon_path, tmpbase, sizes[i]);
 
-	/* per-page WAL index */
-	run_walidx_suite(daemon_path, tmpbase);
+		/* branch / snapshot isolation (page-size independent, run once) */
+		run_branch_suite(daemon_path, tmpbase);
 
-	/* vectored multi-page I/O */
-	run_vectored_suite(daemon_path, tmpbase);
+		/* shipped-WAL durability */
+		run_wal_suite(daemon_path, tmpbase);
 
-	/* many concurrent clients */
-	run_concurrency_suite(daemon_path, tmpbase);
+		/* per-page WAL index */
+		run_walidx_suite(daemon_path, tmpbase);
+
+		/* vectored multi-page I/O */
+		run_vectored_suite(daemon_path, tmpbase);
+
+		/* many concurrent clients */
+		run_concurrency_suite(daemon_path, tmpbase);
+	}
 
 	rmdir(tmpbase);
 


### PR DESCRIPTION
Second sub-slice of **step 4** (SHARDING.md). Make the shard count a runtime value so a daemon can actually run multi-shard — still **one serve loop, no per-shard threads yet**. The loop already scans every channel, so it drives all shards' pools; this proves multi-shard data partitioning (and the per-shard manifests/recovery from #18/4a) end-to-end before threading lands in 4c. Stacked on #18.

## What
- **`pagestore_ipc.h`:** `PS_NSHARDS` (compile-time 1) → `PS_MAX_SHARDS` (compile-time cap, 64) used only for array sizing + the channel-fit static assert; the live count travels in the shm header's `nshards`.
- **`pagestore_core.{c,h}`:** new runtime `ps_nshards` (1..`PS_MAX_SHARDS`, set by the frontend before open, default 1). `shard_for()` and every per-shard loop use it; `g_shards` is sized to the cap.
- **both daemons:** parse `--nshards N`, validate `[1, PS_MAX_SHARDS]`, publish it.
- **`pagestore_test.c`:** adopt the daemon's published `nshards` (reject only `> cap`), size `cl_pool` to the cap, and run the whole daemon-driven battery twice — **nshards = 1 and nshards = 4** — so multi-shard routing/partitioning (incl. crash + clean-restart recovery across 4 manifests) is exercised.

## Test
- Standalone **297/0** (POSIX) and **297/0** (SPDK, nvme2), each covering nshards 1 and 4; image-layer unit test **60/0**.

Next: **4c** — one POSIX worker thread per shard (real parallelism) + `backend_localsvc` per-shard routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)