### PR TITLE
contrib/pagestore: per-shard materialized-page cache (sharding step 4c-ii)

### DIFF
--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -166,8 +166,12 @@ timeline tree under a brief coordination point, not on the read/write hot path.
        device offset, single current-segment buffer) runs a single shard until
        step 5; the POSIX file backend handles the per-shard sparse id space
        directly.
-     - **4c-ii** — per-shard materialized-page cache (`ps_pgcache_*` → per-shard
-       handle).
+     - **4c-ii — per-shard materialized-page cache.** ✅ `ps_pgcache_*` is now a
+       `PsPgcache` handle held by value in each `Shard` (no file-scope globals);
+       `read_resolve` uses `&s->pgcache`, and the SPDK async path reaches the right
+       shard's cache via `ps_core_pgcache_for(key)`.  `--cache-pages` is the total
+       budget, split evenly across shards (total RAM independent of nshards; whole
+       budget to shard 0 at `nshards == 1`).  Stats sum across shards.
      - **4c-iii** — timeline-tree coordination (`timelines[]` is read on every
        ancestry walk; branch-create writes it).
      - **4c-iv** — spawn one POSIX worker thread per shard, each polling only its

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -87,6 +87,7 @@ typedef struct Shard
 	uint64_t	next_local_id;	/* next layer id within this shard (low bits) */
 	int			cur_seg;		/* segment being appended (-1: none yet) */
 	uint64_t	cur_off;		/* append cursor within cur_seg */
+	PsPgcache	pgcache;		/* per-shard materialized-page cache */
 	uint64_t	rr_mem,			/* read-source counters */
 				rr_layer,
 				rr_seg;
@@ -168,6 +169,44 @@ ps_core_read_stats(uint64_t *mem, uint64_t *layer, uint64_t *seg)
 		*layer = l;
 	if (seg)
 		*seg = s;
+}
+
+/*
+ * The materialized-page cache for 'key' -- i.e. its shard's.  A frontend (the
+ * SPDK async path) that caches pages outside read_resolve uses this to reach the
+ * right per-shard cache; routing by the key matches read_resolve.
+ */
+PsPgcache *
+ps_core_pgcache_for(const PsKey *key)
+{
+	return &shard_for(key)->pgcache;
+}
+
+/* materialized-page cache counters, summed across shards */
+void
+ps_core_pgcache_stats(uint64_t *hits, uint64_t *misses, uint64_t *evictions)
+{
+	uint64_t	h = 0,
+				m = 0,
+				e = 0;
+
+	for (uint32_t i = 0; i < ps_nshards; i++)
+	{
+		uint64_t	sh,
+					sm,
+					se;
+
+		ps_pgcache_stats(&g_shards[i].pgcache, &sh, &sm, &se);
+		h += sh;
+		m += sm;
+		e += se;
+	}
+	if (hits)
+		*hits = h;
+	if (misses)
+		*misses = m;
+	if (evictions)
+		*evictions = e;
 }
 
 /* ctx is the owning Shard* (passed through the memtable flush / compaction
@@ -1279,7 +1318,8 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 			 * from the segment (pv's exact location). */
 			int			ambig = page_lsn_ambiguous(e, pv->lsn);
 
-			if (!ambig && ps_pgcache_lookup(tl, key, block, pv->lsn, out))
+			if (!ambig && ps_pgcache_lookup(&s->pgcache, tl, key, block,
+											pv->lsn, out))
 				return 1;
 
 			if (!ambig && s->memtable &&
@@ -1302,7 +1342,7 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 				served = (read_version(pv, out) == 0);	/* segment fallback */
 			}
 			if (served && !ambig)
-				ps_pgcache_insert(tl, key, block, pv->lsn, out);
+				ps_pgcache_insert(&s->pgcache, tl, key, block, pv->lsn, out);
 			return served ? 1 : 0;
 		}
 		if (!timeline_has_parent(tl))
@@ -1511,9 +1551,11 @@ ps_core_close(void)
 				}
 			}
 		}
-	ps_pgcache_free();
 	for (uint32_t i = 0; i < ps_nshards; i++)
+	{
+		ps_pgcache_free(&g_shards[i].pgcache);
 		ps_manifest_close(&g_shards[i].manifest);
+	}
 }
 
 /*
@@ -1675,6 +1717,15 @@ ps_core_open(const char *store_dir)
 			return -1;
 		}
 	}
+	/* reject a negative --cache-pages before the unsigned cast below (it would
+	 * become a huge per-shard capacity and make ps_pgcache_init attempt an
+	 * enormous allocation); 0 disables the cache */
+	if (cache_pages < 0)
+	{
+		fprintf(stderr, "pagestore_core: --cache-pages must be >= 0 (got %d)\n",
+				cache_pages);
+		return -1;
+	}
 
 	/* per-shard: open + replay its manifest, finish any interrupted GC, continue
 	 * layer ids past the highest the manifest restored (low bits only -- the
@@ -1706,18 +1757,14 @@ ps_core_open(const char *store_dir)
 			if (!s->memtable)
 				return -1;
 		}
+		/* The materialized-page cache helps both read paths (read_resolve and the
+		 * SPDK async path), so it is not gated on use_layers.  --cache-pages is the
+		 * total budget across shards; split it evenly so total RAM is independent
+		 * of nshards (each shard's cache stays single-owner).  At nshards == 1 the
+		 * shard gets the whole budget -- identical to before. */
+		ps_pgcache_init(&s->pgcache, (uint32_t) cache_pages / ps_nshards,
+						page_size);
 	}
-	/* the materialized-page cache helps both read paths (read_resolve and the
-	 * SPDK async path), so it is not gated on use_layers.  Reject a negative
-	 * --cache-pages before the unsigned cast (it would become a huge capacity and
-	 * make ps_pgcache_init attempt an enormous allocation); 0 disables the cache. */
-	if (cache_pages < 0)
-	{
-		fprintf(stderr, "pagestore_core: --cache-pages must be >= 0 (got %d)\n",
-				cache_pages);
-		return -1;
-	}
-	ps_pgcache_init((uint32_t) cache_pages, page_size);
 	fprintf(stderr, "pagestore_core: %u image layer(s) across %u shard(s) after "
 			"manifest replay\n", ps_core_layer_count(), ps_nshards);
 

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1759,11 +1759,18 @@ ps_core_open(const char *store_dir)
 		}
 		/* The materialized-page cache helps both read paths (read_resolve and the
 		 * SPDK async path), so it is not gated on use_layers.  --cache-pages is the
-		 * total budget across shards; split it evenly so total RAM is independent
-		 * of nshards (each shard's cache stays single-owner).  At nshards == 1 the
-		 * shard gets the whole budget -- identical to before. */
-		ps_pgcache_init(&s->pgcache, (uint32_t) cache_pages / ps_nshards,
-						page_size);
+		 * total budget across shards; split it so total RAM is independent of
+		 * nshards (each shard's cache stays single-owner).  Hand the division
+		 * remainder to the first shards rather than flooring it away, so a small
+		 * positive budget (e.g. cache_pages < nshards) still caches its pages
+		 * instead of disabling every shard's cache.  At nshards == 1 the shard gets
+		 * the whole budget -- identical to before. */
+		{
+			uint32_t	budget = (uint32_t) cache_pages;
+			uint32_t	per = budget / ps_nshards + (i < budget % ps_nshards ? 1 : 0);
+
+			ps_pgcache_init(&s->pgcache, per, page_size);
+		}
 	}
 	fprintf(stderr, "pagestore_core: %u image layer(s) across %u shard(s) after "
 			"manifest replay\n", ps_core_layer_count(), ps_nshards);

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -23,6 +23,7 @@
 
 #include "pagestore_ipc.h"
 #include "pagestore_storage.h"
+#include "pagestore_pgcache.h"
 
 /* One stored version of a page: its LSN and where the bytes live in the store. */
 typedef struct PageVer
@@ -57,6 +58,14 @@ extern uint32_t ps_core_layer_count(void);
 
 /* Read-path source counts: served from memtable / image layer / segment. */
 extern void ps_core_read_stats(uint64_t *mem, uint64_t *layer, uint64_t *seg);
+
+/* The per-shard materialized-page cache that owns 'key' (for a frontend caching
+ * pages outside read_resolve, e.g. the SPDK async path). */
+extern PsPgcache *ps_core_pgcache_for(const PsKey *key);
+
+/* Materialized-page cache hit/miss/eviction counts, summed across shards. */
+extern void ps_core_pgcache_stats(uint64_t *hits, uint64_t *misses,
+								  uint64_t *evictions);
 
 /*
  * Handle every request that is NOT page byte I/O and return 1.  The four

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -265,7 +265,7 @@ main(int argc, char **argv)
 					ce;
 
 		ps_core_read_stats(&rm, &rl, &rs);
-		ps_pgcache_stats(&ch, &cm, &ce);
+		ps_core_pgcache_stats(&ch, &cm, &ce);
 		fprintf(stderr, "pagestore_daemon: shutting down (%u image layers; reads "
 				"mem=%llu layer=%llu seg=%llu; pgcache hit=%llu miss=%llu evict=%llu)\n",
 				ps_core_layer_count(),

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -79,7 +79,8 @@ read_done(void *arg, int ok)
 	ReqState   *rs = bc->rs;
 
 	if (ok && bc->cacheable)	/* the engine delivered the page into bc->dst */
-		ps_pgcache_insert(bc->tl, &bc->key, bc->block, bc->lsn, bc->dst);
+		ps_pgcache_insert(ps_core_pgcache_for(&bc->key), bc->tl, &bc->key,
+						  bc->block, bc->lsn, bc->dst);
 	if (--rs->pending == 0)
 	{
 		rs->active = 0;			/* clear before publishing DONE */
@@ -171,7 +172,9 @@ begin(uint32_t i, PsChannel *ch)
 					/* cache by the resolved source timeline; bypass the cache for
 					 * same-lsn-ambiguous versions (the lsn key can't tell them
 					 * apart), matching read_resolve() on the POSIX path */
-					if (!ambig && ps_pgcache_lookup(stl, &ch->key, blk, v->lsn, dst))
+					if (!ambig &&
+						ps_pgcache_lookup(ps_core_pgcache_for(&ch->key), stl,
+										  &ch->key, blk, v->lsn, dst))
 						continue;	/* RAM hit -> no device read */
 					bc = &rs->blk[nsub++];
 					bc->rs = rs;
@@ -213,8 +216,9 @@ begin(uint32_t i, PsChannel *ch)
 				}
 				/* cache by the resolved source timeline; bypass for ambiguous
 				 * same-lsn versions (see READV above) */
-				if (!ambig && ps_pgcache_lookup(stl, &ch->key, ch->blocknum,
-												v->lsn, ch->data))
+				if (!ambig &&
+					ps_pgcache_lookup(ps_core_pgcache_for(&ch->key), stl,
+									  &ch->key, ch->blocknum, v->lsn, ch->data))
 				{
 					ps_store_release(&ch->state, PS_STATE_DONE);	/* RAM hit */
 					return;
@@ -401,7 +405,7 @@ main(int argc, char **argv)
 					cm,
 					ce;
 
-		ps_pgcache_stats(&ch, &cm, &ce);
+		ps_core_pgcache_stats(&ch, &cm, &ce);
 		fprintf(stderr, "pagestore_daemon_spdk: shutting down (pgcache hit=%llu "
 				"miss=%llu evict=%llu)\n", (unsigned long long) ch,
 				(unsigned long long) cm, (unsigned long long) ce);

--- a/contrib/pagestore/pagestore_pgcache.c
+++ b/contrib/pagestore/pagestore_pgcache.c
@@ -3,6 +3,9 @@
  * pagestore_pgcache.c
  *	  Scan-resistant CLOCK materialized-page cache.  See pagestore_pgcache.h.
  *
+ * One instance per shard (PsPgcache), so a shard's cache is single-owner and
+ * lock-free; all state lives in the handle, no file-scope globals.
+ *
  *-------------------------------------------------------------------------
  */
 #include <stdlib.h>
@@ -18,25 +21,13 @@ typedef struct PgKey
 	PsKey		key;
 } PgKey;
 
-typedef struct Slot
+struct PgcSlot
 {
 	int			valid;
 	uint8_t		ref;			/* CLOCK reference bit */
 	PgKey		k;
 	int			hnext;			/* next slot in its hash bucket, or -1 */
-} Slot;
-
-static uint32_t cache_max;		/* capacity in pages (0 = disabled) */
-static uint32_t cache_psz;
-static Slot *slots;
-static unsigned char *pages;	/* cache_max * cache_psz, slot i at i*psz */
-static int *buckets;			/* nbuckets heads (slot index or -1) */
-static uint32_t nbuckets;
-static uint32_t nused;			/* slots populated so far (<= cache_max) */
-static uint32_t hand;			/* CLOCK hand */
-static uint64_t st_hits,
-			st_misses,
-			st_evict;
+};
 
 static uint32_t
 key_hash(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
@@ -66,139 +57,138 @@ key_eq(const PgKey *a, uint32_t tl, const PsKey *key, uint32_t block,
 }
 
 void
-ps_pgcache_init(uint32_t max_pages, uint32_t page_size)
+ps_pgcache_init(PsPgcache *c, uint32_t max_pages, uint32_t page_size)
 {
-	cache_max = max_pages;
-	cache_psz = page_size;
-	st_hits = st_misses = st_evict = 0;
-	nused = hand = 0;
+	memset(c, 0, sizeof(*c));
+	c->max = max_pages;
+	c->psz = page_size;
 	if (max_pages == 0)
 		return;
-	nbuckets = max_pages * 2 + 1;
-	slots = calloc(max_pages, sizeof(Slot));
-	pages = malloc((size_t) max_pages * page_size);
-	buckets = malloc((size_t) nbuckets * sizeof(int));
-	if (!slots || !pages || !buckets)
+	c->nbuckets = max_pages * 2 + 1;
+	c->slots = calloc(max_pages, sizeof(struct PgcSlot));
+	c->pages = malloc((size_t) max_pages * page_size);
+	c->buckets = malloc((size_t) c->nbuckets * sizeof(int));
+	if (!c->slots || !c->pages || !c->buckets)
 	{
-		ps_pgcache_free();
-		cache_max = 0;
+		ps_pgcache_free(c);
 		return;
 	}
-	for (uint32_t i = 0; i < nbuckets; i++)
-		buckets[i] = -1;
+	for (uint32_t i = 0; i < c->nbuckets; i++)
+		c->buckets[i] = -1;
 }
 
 void
-ps_pgcache_free(void)
+ps_pgcache_free(PsPgcache *c)
 {
-	free(slots);
-	free(pages);
-	free(buckets);
-	slots = NULL;
-	pages = NULL;
-	buckets = NULL;
-	cache_max = 0;
+	free(c->slots);
+	free(c->pages);
+	free(c->buckets);
+	c->slots = NULL;
+	c->pages = NULL;
+	c->buckets = NULL;
+	c->max = 0;
 }
 
 static int
-find_slot(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn,
-		  uint32_t *out_bucket)
+find_slot(PsPgcache *c, uint32_t tl, const PsKey *key, uint32_t block,
+		  uint64_t lsn, uint32_t *out_bucket)
 {
-	uint32_t	b = key_hash(tl, key, block, lsn) % nbuckets;
+	uint32_t	b = key_hash(tl, key, block, lsn) % c->nbuckets;
 
 	if (out_bucket)
 		*out_bucket = b;
-	for (int i = buckets[b]; i >= 0; i = slots[i].hnext)
-		if (slots[i].valid && key_eq(&slots[i].k, tl, key, block, lsn))
+	for (int i = c->buckets[b]; i >= 0; i = c->slots[i].hnext)
+		if (c->slots[i].valid && key_eq(&c->slots[i].k, tl, key, block, lsn))
 			return i;
 	return -1;
 }
 
 int
-ps_pgcache_lookup(uint32_t tl, const PsKey *key, uint32_t block,
+ps_pgcache_lookup(PsPgcache *c, uint32_t tl, const PsKey *key, uint32_t block,
 				  uint64_t version_lsn, void *out)
 {
 	int			s;
 
-	if (cache_max == 0)
+	if (c->max == 0)
 		return 0;
-	s = find_slot(tl, key, block, version_lsn, NULL);
+	s = find_slot(c, tl, key, block, version_lsn, NULL);
 	if (s < 0)
 	{
-		st_misses++;
+		c->misses++;
 		return 0;
 	}
-	slots[s].ref = 1;			/* re-reference: survives the next sweep */
-	memcpy(out, pages + (size_t) s * cache_psz, cache_psz);
-	st_hits++;
+	c->slots[s].ref = 1;		/* re-reference: survives the next sweep */
+	memcpy(out, c->pages + (size_t) s * c->psz, c->psz);
+	c->hits++;
 	return 1;
 }
 
 /* unlink slot s from its hash bucket chain */
 static void
-bucket_remove(int s)
+bucket_remove(PsPgcache *c, int s)
 {
-	uint32_t	b = key_hash(slots[s].k.timeline, &slots[s].k.key,
-							 slots[s].k.block, slots[s].k.lsn) % nbuckets;
-	int		   *pp = &buckets[b];
+	uint32_t	b = key_hash(c->slots[s].k.timeline, &c->slots[s].k.key,
+							 c->slots[s].k.block, c->slots[s].k.lsn) % c->nbuckets;
+	int		   *pp = &c->buckets[b];
 
 	while (*pp >= 0 && *pp != s)
-		pp = &slots[*pp].hnext;
+		pp = &c->slots[*pp].hnext;
 	if (*pp == s)
-		*pp = slots[s].hnext;
+		*pp = c->slots[s].hnext;
 }
 
 void
-ps_pgcache_insert(uint32_t tl, const PsKey *key, uint32_t block,
+ps_pgcache_insert(PsPgcache *c, uint32_t tl, const PsKey *key, uint32_t block,
 				  uint64_t version_lsn, const void *page)
 {
 	uint32_t	b;
 	int			s;
 
-	if (cache_max == 0)
+	if (c->max == 0)
 		return;
-	s = find_slot(tl, key, block, version_lsn, &b);
+	s = find_slot(c, tl, key, block, version_lsn, &b);
 	if (s >= 0)
 	{							/* already present: refresh bytes + reference */
-		memcpy(pages + (size_t) s * cache_psz, page, cache_psz);
-		slots[s].ref = 1;
+		memcpy(c->pages + (size_t) s * c->psz, page, c->psz);
+		c->slots[s].ref = 1;
 		return;
 	}
 
-	if (nused < cache_max)
-		s = (int) nused++;		/* still filling */
+	if (c->nused < c->max)
+		s = (int) c->nused++;	/* still filling */
 	else
 	{
 		/* CLOCK: advance over referenced slots (clearing), evict first ref=0 */
-		while (slots[hand].ref)
+		while (c->slots[c->hand].ref)
 		{
-			slots[hand].ref = 0;
-			hand = (hand + 1) % cache_max;
+			c->slots[c->hand].ref = 0;
+			c->hand = (c->hand + 1) % c->max;
 		}
-		s = (int) hand;
-		hand = (hand + 1) % cache_max;
-		bucket_remove(s);
-		st_evict++;
+		s = (int) c->hand;
+		c->hand = (c->hand + 1) % c->max;
+		bucket_remove(c, s);
+		c->evict++;
 	}
 
-	slots[s].valid = 1;
-	slots[s].ref = 0;			/* scan-resistant: new entries start unreferenced */
-	slots[s].k.timeline = tl;
-	slots[s].k.key = *key;
-	slots[s].k.block = block;
-	slots[s].k.lsn = version_lsn;
-	memcpy(pages + (size_t) s * cache_psz, page, cache_psz);
-	slots[s].hnext = buckets[b];
-	buckets[b] = s;
+	c->slots[s].valid = 1;
+	c->slots[s].ref = 0;		/* scan-resistant: new entries start unreferenced */
+	c->slots[s].k.timeline = tl;
+	c->slots[s].k.key = *key;
+	c->slots[s].k.block = block;
+	c->slots[s].k.lsn = version_lsn;
+	memcpy(c->pages + (size_t) s * c->psz, page, c->psz);
+	c->slots[s].hnext = c->buckets[b];
+	c->buckets[b] = s;
 }
 
 void
-ps_pgcache_stats(uint64_t *hits, uint64_t *misses, uint64_t *evictions)
+ps_pgcache_stats(const PsPgcache *c, uint64_t *hits, uint64_t *misses,
+				 uint64_t *evictions)
 {
 	if (hits)
-		*hits = st_hits;
+		*hits = c->hits;
 	if (misses)
-		*misses = st_misses;
+		*misses = c->misses;
 	if (evictions)
-		*evictions = st_evict;
+		*evictions = c->evict;
 }

--- a/contrib/pagestore/pagestore_pgcache.h
+++ b/contrib/pagestore/pagestore_pgcache.h
@@ -24,21 +24,43 @@
 
 #include "pagestore_ipc.h"
 
+/*
+ * One cache instance.  Held by value in each shard (sharding step 4c-ii) so a
+ * shard's cache is single-owner and lock-free; the pointer members are owned by
+ * ps_pgcache_init/free.  Treat the fields as private to pagestore_pgcache.c.
+ */
+struct PgcSlot;					/* defined in pagestore_pgcache.c */
+
+typedef struct PsPgcache
+{
+	uint32_t	max;			/* capacity in pages (0 = disabled) */
+	uint32_t	psz;
+	struct PgcSlot *slots;
+	unsigned char *pages;		/* max * psz, slot i at i*psz */
+	int		   *buckets;		/* nbuckets heads (slot index or -1) */
+	uint32_t	nbuckets;
+	uint32_t	nused;			/* slots populated so far (<= max) */
+	uint32_t	hand;			/* CLOCK hand */
+	uint64_t	hits,
+				misses,
+				evict;
+} PsPgcache;
+
 /* Initialize with a capacity in pages (0 disables the cache). */
-extern void ps_pgcache_init(uint32_t max_pages, uint32_t page_size);
-extern void ps_pgcache_free(void);
+extern void ps_pgcache_init(PsPgcache *c, uint32_t max_pages, uint32_t page_size);
+extern void ps_pgcache_free(PsPgcache *c);
 
 /* Look up (timeline, key, block, version_lsn); on hit copy page_size bytes into
  * out and return 1, else 0. */
-extern int	ps_pgcache_lookup(uint32_t timeline, const PsKey *key,
+extern int	ps_pgcache_lookup(PsPgcache *c, uint32_t timeline, const PsKey *key,
 							  uint32_t block, uint64_t version_lsn, void *out);
 
 /* Insert/refresh (timeline, key, block, version_lsn) -> page. */
-extern void ps_pgcache_insert(uint32_t timeline, const PsKey *key,
+extern void ps_pgcache_insert(PsPgcache *c, uint32_t timeline, const PsKey *key,
 							  uint32_t block, uint64_t version_lsn,
 							  const void *page);
 
-extern void ps_pgcache_stats(uint64_t *hits, uint64_t *misses,
-							 uint64_t *evictions);
+extern void ps_pgcache_stats(const PsPgcache *c, uint64_t *hits,
+							 uint64_t *misses, uint64_t *evictions);
 
 #endif							/* PAGESTORE_PGCACHE_H */

--- a/contrib/pagestore/pagestore_pgcache_test.c
+++ b/contrib/pagestore/pagestore_pgcache_test.c
@@ -42,53 +42,54 @@ main(void)
 	uint64_t	hits,
 				misses,
 				evict;
+	PsPgcache	pc;
 
-	ps_pgcache_init(4, PSZ);
+	ps_pgcache_init(&pc, 4, PSZ);
 
 	/* basic insert + hit */
 	fill(in, 0xAA);
-	ps_pgcache_insert(0, &k, 7, 100, in);
-	check(ps_pgcache_lookup(0, &k, 7, 100, out) == 1 && out[0] == 0xAA,
+	ps_pgcache_insert(&pc, 0, &k, 7, 100, in);
+	check(ps_pgcache_lookup(&pc, 0, &k, 7, 100, out) == 1 && out[0] == 0xAA,
 		  "insert then hit");
 
 	/* miss on absent block / lsn */
-	check(ps_pgcache_lookup(0, &k, 8, 100, out) == 0, "miss on other block");
-	check(ps_pgcache_lookup(0, &k, 7, 200, out) == 0, "miss on other version_lsn");
+	check(ps_pgcache_lookup(&pc, 0, &k, 8, 100, out) == 0, "miss on other block");
+	check(ps_pgcache_lookup(&pc, 0, &k, 7, 200, out) == 0, "miss on other version_lsn");
 
 	/* version_lsn keying: two versions of the same (key,block) coexist */
 	fill(in, 0xBB);
-	ps_pgcache_insert(0, &k, 7, 200, in);
-	check(ps_pgcache_lookup(0, &k, 7, 100, out) == 1 && out[0] == 0xAA &&
-		  ps_pgcache_lookup(0, &k, 7, 200, out) == 1 && out[0] == 0xBB,
+	ps_pgcache_insert(&pc, 0, &k, 7, 200, in);
+	check(ps_pgcache_lookup(&pc, 0, &k, 7, 100, out) == 1 && out[0] == 0xAA &&
+		  ps_pgcache_lookup(&pc, 0, &k, 7, 200, out) == 1 && out[0] == 0xBB,
 		  "two versions keyed by lsn");
 
 	/* --- scan resistance: a hot page re-referenced each round survives a
 	 * stream of one-shot scan pages; the scan pages churn through the rest --- */
-	ps_pgcache_free();
-	ps_pgcache_init(4, PSZ);
+	ps_pgcache_free(&pc);
+	ps_pgcache_init(&pc, 4, PSZ);
 	fill(in, 0x11);
-	ps_pgcache_insert(0, &k, 1, 1, in);	/* hot page H = (block 1, lsn 1) */
-	ps_pgcache_lookup(0, &k, 1, 1, out);	/* reference it */
+	ps_pgcache_insert(&pc, 0, &k, 1, 1, in);	/* hot page H = (block 1, lsn 1) */
+	ps_pgcache_lookup(&pc, 0, &k, 1, 1, out);	/* reference it */
 	for (uint32_t i = 0; i < 3; i++)	/* fillers to capacity */
 	{
 		fill(in, (unsigned char) (0x20 + i));
-		ps_pgcache_insert(0, &k, 100 + i, 1, in);
+		ps_pgcache_insert(&pc, 0, &k, 100 + i, 1, in);
 	}
 	for (uint32_t i = 0; i < 16; i++)	/* long one-shot scan, re-touching H */
 	{
 		fill(in, 0x80);
-		ps_pgcache_insert(0, &k, 1000 + i, 1, in);
-		ps_pgcache_lookup(0, &k, 1, 1, out);	/* H stays hot */
+		ps_pgcache_insert(&pc, 0, &k, 1000 + i, 1, in);
+		ps_pgcache_lookup(&pc, 0, &k, 1, 1, out);	/* H stays hot */
 	}
-	check(ps_pgcache_lookup(0, &k, 1, 1, out) == 1 && out[0] == 0x11,
+	check(ps_pgcache_lookup(&pc, 0, &k, 1, 1, out) == 1 && out[0] == 0x11,
 		  "hot page survives a long scan (scan-resistant)");
-	check(ps_pgcache_lookup(0, &k, 1000, 1, out) == 0,
+	check(ps_pgcache_lookup(&pc, 0, &k, 1000, 1, out) == 0,
 		  "early scan page evicted");
 
-	ps_pgcache_stats(&hits, &misses, &evict);
+	ps_pgcache_stats(&pc, &hits, &misses, &evict);
 	check(evict > 0, "evictions occurred under pressure");
 
-	ps_pgcache_free();
+	ps_pgcache_free(&pc);
 	fprintf(stderr, "%d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;
 }


### PR DESCRIPTION
Second sub-slice of **step 4c** (per-shard threads). Make the materialized-page cache per-shard so it's single-owner and lock-free under threads, instead of one global LRU all shards contend on. Behaviour-identical at `nshards = 1`. Stacked on #20.

## What
- **`pagestore_pgcache.{c,h}`:** the cache is now a `PsPgcache` handle (all state in the struct, no file-scope globals); every entry point takes `PsPgcache *`.
- **`pagestore_core.c`:** `Shard` holds a `PsPgcache` by value; `read_resolve` uses `&s->pgcache`. `ps_core_open` splits `--cache-pages` evenly across shards (total RAM independent of nshards; whole budget to shard 0 at `nshards == 1`) and inits each; `ps_core_close` frees each. New `ps_core_pgcache_for(key)` returns the owning shard's cache; `ps_core_pgcache_stats()` sums per-shard counters.
- **frontends:** the SPDK async path caches/looks up via `ps_core_pgcache_for(&key)` (routing by key, matching `read_resolve`); both daemons report stats via `ps_core_pgcache_stats()`.
- Also corrects the 4c-i note in SHARDING.md (segment ids are **interleaved**, not high-bit-namespaced — the dense layout the SPDK device map needs).

## Test
- Standalone **297/0** (POSIX) and **297/0** (SPDK, nvme2), each covering nshards 1 and 4; image-layer unit test **60/0**.

Next: 4c-iii timeline-tree coordination → 4c-iv spawn per-shard threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)