### PR TITLE
contrib/pagestore: per-shard bloom cache (sharding step 4c-iv prep)

### DIFF
--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -180,6 +180,15 @@ timeline tree under a brief coordination point, not on the read/write hot path.
        Single-threaded here writes peer copies directly; 4c-iv delivers the branch
        to each shard's thread via a per-shard queue instead.  (`wal_end[]` stays a
        single copy -- WAL ops are shard-0-only.)
+     - **4c-iv-prep — per-shard bloom cache.** ✅ The per-layer (key,block) bloom
+       cache moves from a file-scope global into a `PsLayerBloom` held per shard
+       (`s->bloom`, passed to `ps_image_layer_lookup`).  As a global it raced under
+       threads -- shard-namespaced layer ids collide mod the slot count, so two
+       shard threads thrash + concurrently write one slot, and a half-built bloom
+       could yield a false "absent" (a wrong result).  Per shard it is single-owner
+       and lock-free.  (Remaining shared hot-path state for the threads: the POSIX
+       segment fd cache -- a brief mutex -- and the timeline `defined` flag -- an
+       atomic release/acquire -- land with 4c-iv.)
      - **4c-iv** — spawn one POSIX worker thread per shard, each polling only its
        channel pool; `backend_localsvc` per-shard channel pool + routing.  Real
        parallelism lands here.

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -106,6 +106,7 @@ typedef struct Shard
 	int			cur_seg;		/* segment being appended (-1: none yet) */
 	uint64_t	cur_off;		/* append cursor within cur_seg */
 	PsPgcache	pgcache;		/* per-shard materialized-page cache */
+	PsLayerBloom bloom;			/* per-shard per-layer (key,block) bloom cache */
 	TimelineMeta timelines[MAX_TIMELINES];	/* replicated timeline tree */
 	uint64_t	rr_mem,			/* read-source counters */
 				rr_layer,
@@ -1304,7 +1305,7 @@ layer_map_lookup(Shard *s, uint32_t timeline, const PsKey *key, uint32_t block,
 		if (d->kind != PS_LAYER_IMAGE || d->timeline != timeline || d->deleting)
 			continue;
 		if (ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size,
-								  &l, NULL) == 1 && (!found || l > best))
+								  &l, NULL, &s->bloom) == 1 && (!found || l > best))
 		{
 			best = l;
 			memcpy(out, tmp, page_size);
@@ -1728,9 +1729,6 @@ ps_core_open(const char *store_dir)
 		return -1;
 	if (validate_store_nshards(store_dir) != 0)
 		return -1;
-	/* layer_ids are unique only within a store; drop any blooms cached from a
-	 * previously-opened store so a reused id can't return a stale "absent" */
-	ps_image_bloom_reset();
 
 	/* the LSM write side (memtable/flush/compaction) runs only when layers are
 	 * the read path; the SPDK daemon stays on the segment path for now.  Reject
@@ -1772,6 +1770,9 @@ ps_core_open(const char *store_dir)
 
 		s->index = i;
 		s->cur_seg = -1;		/* recover() positions the append cursor */
+		/* layer_ids are unique only within a store; drop blooms cached from a
+		 * previously-opened store so a reused id can't return a stale "absent" */
+		ps_image_bloom_reset(&s->bloom);
 		if (ps_manifest_open(&s->manifest, store_dir, i) != 0)
 			return -1;
 		if (ps_manifest_replay(&s->manifest) != 0)

--- a/contrib/pagestore/pagestore_layer.c
+++ b/contrib/pagestore/pagestore_layer.c
@@ -111,18 +111,9 @@ key_cmp(const PsKey *a, const PsKey *b)
  * Single-threaded with the daemon's serve loop; per-shard worker threads (a
  * later sharding step) would shard this cache or guard it with a lock.
  */
-#define PS_LAYER_BLOOM_BYTES	512			/* 4096 bits per layer */
 #define PS_LAYER_BLOOM_BITS		(PS_LAYER_BLOOM_BYTES * 8)
-#define PS_LAYER_BLOOM_SLOTS	1024		/* direct-mapped by layer_id */
-
-typedef struct LayerBloom
-{
-	uint64_t	layer_id;
-	int			valid;
-	uint8_t		bits[PS_LAYER_BLOOM_BYTES];
-} LayerBloom;
-
-static LayerBloom layer_bloom_cache[PS_LAYER_BLOOM_SLOTS];
+/* PS_LAYER_BLOOM_BYTES / _SLOTS and the cache types live in pagestore_layer.h;
+ * the cache is owned per shard by the caller (no file-scope global). */
 
 /* two independent hashes of (key,block) -> bit positions (FNV-1a variants) */
 static void
@@ -171,10 +162,10 @@ bloom_test(const uint8_t *bits, const PsKey *key, uint32_t block)
 
 /* the direct-mapped cache slot for a layer; caller checks ->valid && ->layer_id
  * to know whether it already holds THIS layer's bloom */
-static LayerBloom *
-bloom_slot(uint64_t layer_id)
+static PsLayerBloomSlot *
+bloom_slot(PsLayerBloom *bc, uint64_t layer_id)
 {
-	return &layer_bloom_cache[layer_id % PS_LAYER_BLOOM_SLOTS];
+	return &bc->slots[layer_id % PS_LAYER_BLOOM_SLOTS];
 }
 
 /*
@@ -185,9 +176,9 @@ bloom_slot(uint64_t layer_id)
  * starts with an empty cache.
  */
 void
-ps_image_bloom_reset(void)
+ps_image_bloom_reset(PsLayerBloom *bc)
 {
-	memset(layer_bloom_cache, 0, sizeof(layer_bloom_cache));
+	memset(bc, 0, sizeof(*bc));
 }
 
 /* internal sort record: on-disk index entry plus its source page index */
@@ -688,7 +679,7 @@ ps_read_plan_build(const PsLayerMap *map, uint32_t timeline, const PsKey *key,
 			if (plan->has_base && d->lsn_end < plan->base_lsn)
 				break;
 			r = ps_image_layer_lookup(d, key, block, read_lsn, tmp, page_size,
-									  &l, &amb);
+									  &l, &amb, NULL);
 			if (r < 0)
 			{
 				base_ok = 0;	/* a covering candidate is corrupt/unavailable */
@@ -870,7 +861,7 @@ int
 ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 					  uint32_t block, uint64_t read_lsn,
 					  void *out, uint32_t page_size, uint64_t *out_lsn,
-					  int *out_ambiguous)
+					  int *out_ambiguous, PsLayerBloom *bc)
 {
 	const PsLayerLocation *loc = img_local_loc(layer);
 	PsImgFooter foot;
@@ -882,8 +873,8 @@ ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 	int			found = 0;
 	int			rc = -1;
 
-	LayerBloom *be = bloom_slot(layer->layer_id);
-	int			cached = (be->valid && be->layer_id == layer->layer_id);
+	PsLayerBloomSlot *be = bc ? bloom_slot(bc, layer->layer_id) : NULL;
+	int			cached = (be && be->valid && be->layer_id == layer->layer_id);
 
 	/* prune: skip without any IO if this layer cannot hold (key,block) or has no
 	 * version at/below read_lsn */
@@ -916,8 +907,8 @@ ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 		goto out;				/* corrupt index */
 
 	/* first read of this layer: build its bloom from the verified index so later
-	 * reads can skip it without this index read */
-	if (!cached)
+	 * reads can skip it without this index read (only when a cache was given) */
+	if (be && !cached)
 	{
 		memset(be->bits, 0, sizeof(be->bits));
 		for (uint32_t i = 0; i < foot.nrecs; i++)

--- a/contrib/pagestore/pagestore_layer.h
+++ b/contrib/pagestore/pagestore_layer.h
@@ -133,17 +133,39 @@ extern int	ps_image_layer_write(uint64_t layer_id, uint32_t timeline,
 								 uint32_t page_size, PsLayerDesc *out);
 
 /*
+ * Per-layer (key,block) bloom cache: lets a lookup answer "definitely absent"
+ * for a layer without re-reading its index.  One instance per shard (held by the
+ * caller) so it is single-owner and lock-free under per-shard threads; built
+ * lazily from the index, direct-mapped + validated by layer_id.  ~537 KiB.
+ */
+#define PS_LAYER_BLOOM_BYTES	512			/* 4096 bits per layer */
+#define PS_LAYER_BLOOM_SLOTS	1024		/* direct-mapped by layer_id */
+
+typedef struct PsLayerBloomSlot
+{
+	uint64_t	layer_id;
+	int			valid;
+	uint8_t		bits[PS_LAYER_BLOOM_BYTES];
+} PsLayerBloomSlot;
+
+typedef struct PsLayerBloom
+{
+	PsLayerBloomSlot slots[PS_LAYER_BLOOM_SLOTS];
+} PsLayerBloom;
+
+/*
  * Look up the newest version of (key, block) with lsn <= read_lsn in image
  * layer 'layer'.  On a hit copies page_size bytes into out, stores that
  * version's lsn in *out_lsn (if non-NULL), sets *out_ambiguous (if non-NULL) to
  * 1 when more than one version shares that lsn (a same-lsn rewrite the lsn can't
  * disambiguate), and returns 1; 0 if the layer has no such page; -1 on
- * read/format error.
+ * read/format error.  'bc' is the caller's bloom cache (NULL to skip caching).
  */
 extern int	ps_image_layer_lookup(const PsLayerDesc *layer, const PsKey *key,
 								  uint32_t block, uint64_t read_lsn,
 								  void *out, uint32_t page_size,
-								  uint64_t *out_lsn, int *out_ambiguous);
+								  uint64_t *out_lsn, int *out_ambiguous,
+								  PsLayerBloom *bc);
 
 /*
  * Read an image layer's full index (every (key, block, lsn) entry), for
@@ -158,9 +180,9 @@ extern int	ps_image_layer_read_index(const PsLayerDesc *layer,
  * read page bytes directly (compaction) validate them against idx[].crc. */
 extern uint32_t ps_image_page_crc(const void *page, uint32_t len);
 
-/* Drop the in-memory per-layer bloom cache (layer_ids are store-local, so the
- * cache must be cleared when the process switches stores). */
-extern void ps_image_bloom_reset(void);
+/* Drop a bloom cache (layer_ids are store-local, so clear it when the process
+ * switches stores). */
+extern void ps_image_bloom_reset(PsLayerBloom *bc);
 
 /* ---------------------------------------------------------------------------
  * Delta layer file format (phase 7).

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -22,6 +22,8 @@
 static int	run = 0,
 			failed = 0;
 
+static PsLayerBloom tb;		/* the test's bloom cache (mirrors a shard's) */
+
 static void
 check(int cond, const char *msg)
 {
@@ -77,29 +79,29 @@ main(void)
 	check(d.lsn_start == 100 && d.lsn_end == 300, "layer lsn range");
 
 	/* newest version <= read_lsn */
-	r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, NULL, &tb);
 	check(r == 1 && out[0] == 0xA2, "(5,0)@<=250 -> version 200");
-	r = ps_image_layer_lookup(&d, &k5, 0, 1000, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 1000, out, psz, NULL, NULL, &tb);
 	check(r == 1 && out[0] == 0xA3, "(5,0)@<=1000 -> version 300");
-	r = ps_image_layer_lookup(&d, &k5, 0, 100, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 100, out, psz, NULL, NULL, &tb);
 	check(r == 1 && out[0] == 0xA1, "(5,0)@<=100 -> version 100 (exact)");
-	r = ps_image_layer_lookup(&d, &k5, 0, 50, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 50, out, psz, NULL, NULL, &tb);
 	check(r == 0, "(5,0)@<=50 -> no version (older than oldest)");
-	r = ps_image_layer_lookup(&d, &k5, 1, 1000, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 1, 1000, out, psz, NULL, NULL, &tb);
 	check(r == 1 && out[0] == 0xB1, "(5,1) -> version 150");
-	r = ps_image_layer_lookup(&d, &k6, 0, 1000, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k6, 0, 1000, out, psz, NULL, NULL, &tb);
 	check(r == 1 && out[0] == 0xC1, "(6,0) -> version 250");
-	r = ps_image_layer_lookup(&d, &k9, 0, 1000, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k9, 0, 1000, out, psz, NULL, NULL, &tb);
 	check(r == 0, "absent key -> no version");
 
 	/* bloom read cache: the lookups above built this layer's bloom from its
 	 * index; present keys must still be found (no false negative) and absent keys
 	 * still rejected via the cached bloom */
-	r = ps_image_layer_lookup(&d, &k5, 0, 1000, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k5, 0, 1000, out, psz, NULL, NULL, &tb);
 	check(r == 1 && out[0] == 0xA3, "bloom-cached: (5,0) still found");
-	r = ps_image_layer_lookup(&d, &k6, 0, 1000, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k6, 0, 1000, out, psz, NULL, NULL, &tb);
 	check(r == 1 && out[0] == 0xC1, "bloom-cached: (6,0) still found");
-	r = ps_image_layer_lookup(&d, &k9, 0, 1000, out, psz, NULL, NULL);
+	r = ps_image_layer_lookup(&d, &k9, 0, 1000, out, psz, NULL, NULL, &tb);
 	check(r == 0, "bloom-cached: absent key still rejected");
 	{
 		int			ok = 1;
@@ -108,7 +110,7 @@ main(void)
 		{
 			PsKey		ka = {1, 1, rel, 0};
 
-			if (ps_image_layer_lookup(&d, &ka, 0, 1000, out, psz, NULL, NULL) != 0)
+			if (ps_image_layer_lookup(&d, &ka, 0, 1000, out, psz, NULL, NULL, &tb) != 0)
 				ok = 0;
 		}
 		check(ok, "bloom-cached: 300 absent keys all rejected");
@@ -116,7 +118,7 @@ main(void)
 
 	/* bloom cache reset: layer_ids are unique only within a store, so a process
 	 * that opens a second store can see a new layer reuse an id whose slot still
-	 * holds the old store's bloom.  ps_image_bloom_reset() (called by ps_core_open)
+	 * holds the old store's bloom.  ps_image_bloom_reset(&tb) (called by ps_core_open)
 	 * must clear it.  Simulate: build the bloom for d's id (holds rel 5/6), then a
 	 * different layer that reuses that id but holds rel 7 -- after a reset its
 	 * absent-from-the-old-bloom key must still be found, not masked. */
@@ -125,18 +127,18 @@ main(void)
 		PsKey		k7 = {1, 1, 7, 0};	/* not in d's bloom */
 		PsImgRec	rr[1] = {{k7, 0, 100, pg[2]}};	/* 0xA3 */
 
-		r = ps_image_layer_lookup(&d, &k5, 0, 1000, out, psz, NULL, NULL);
+		r = ps_image_layer_lookup(&d, &k5, 0, 1000, out, psz, NULL, NULL, &tb);
 		check(r == 1, "bloom-reset: prime old bloom for the id");
 		check(ps_image_layer_write(21, 0, rr, 1, psz, &reuse) == 0,
 			  "bloom-reset: write reuse layer");
 		reuse.layer_id = d.layer_id;	/* force the id (slot) collision */
-		ps_image_bloom_reset();
-		r = ps_image_layer_lookup(&reuse, &k7, 0, 1000, out, psz, NULL, NULL);
+		ps_image_bloom_reset(&tb);
+		r = ps_image_layer_lookup(&reuse, &k7, 0, 1000, out, psz, NULL, NULL, &tb);
 		check(r == 1 && out[0] == 0xA3,
 			  "bloom-reset: reused-id layer found after reset (not masked)");
 		/* that lookup cached reuse's bloom under d's id; clear it so the checks
 		 * below that read d again rebuild d's own bloom */
-		ps_image_bloom_reset();
+		ps_image_bloom_reset(&tb);
 	}
 
 	/* same-lsn duplicate versions of one (key,block): ambiguous only when the
@@ -151,16 +153,16 @@ main(void)
 
 		check(ps_image_layer_write(11, 0, dup, 2, psz, &da) == 0,
 			  "write same-lsn differing-bytes layer");
-		r = ps_image_layer_lookup(&da, &k5, 0, 400, out, psz, NULL, &amb);
+		r = ps_image_layer_lookup(&da, &k5, 0, 400, out, psz, NULL, &amb, &tb);
 		check(r == 1 && amb == 1, "same-lsn differing bytes -> ambiguous");
 		amb = -1;
 		check(ps_image_layer_write(19, 0, idup, 2, psz, &di) == 0,
 			  "write same-lsn identical-bytes layer");
-		r = ps_image_layer_lookup(&di, &k5, 0, 400, out, psz, NULL, &amb);
+		r = ps_image_layer_lookup(&di, &k5, 0, 400, out, psz, NULL, &amb, &tb);
 		check(r == 1 && amb == 0 && out[0] == 0xA3,
 			  "same-lsn identical bytes -> not ambiguous (compaction overlap)");
 		amb = -1;
-		r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, &amb);
+		r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, &amb, &tb);
 		check(r == 1 && amb == 0, "distinct lsn -> not ambiguous");
 	}
 
@@ -173,9 +175,9 @@ main(void)
 		check(fd >= 0 && pwrite(fd, &bad, 1, 0) == 1, "corrupt a page byte");
 		if (fd >= 0)
 			close(fd);
-		r = ps_image_layer_lookup(&d, &k5, 0, 100, out, psz, NULL, NULL);
+		r = ps_image_layer_lookup(&d, &k5, 0, 100, out, psz, NULL, NULL, &tb);
 		check(r == -1, "corrupted page -> lookup rejects (data crc)");
-		r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, NULL);
+		r = ps_image_layer_lookup(&d, &k5, 0, 250, out, psz, NULL, NULL, &tb);
 		check(r == 1 && out[0] == 0xA2, "uncorrupted page still served");
 	}
 


### PR DESCRIPTION
The last shared read-path state to split before spawning per-shard threads. The per-layer (key,block) bloom cache (the read optimization from #17) was a **file-scope global** — under threads it races: layer ids are shard-namespaced, so two shards' ids collide modulo the slot count, making two shard threads thrash and concurrently write the same slot, and a half-built bloom can yield a false "absent" (a **wrong read result**). Make it per-shard (single-owner, lock-free). Behaviour-identical at `nshards = 1`. Stacked on #22.

## What
- **`pagestore_layer.{c,h}`:** the cache becomes a `PsLayerBloom` handle (slot array + types in the header); `ps_image_layer_lookup()` takes a `PsLayerBloom *` (NULL skips caching), `ps_image_bloom_reset()` takes the handle. No global.
- **`pagestore_core.c`:** `Shard` holds a `PsLayerBloom` by value; `layer_map_lookup` passes `&s->bloom`; `ps_core_open` resets each shard's cache. `read_plan_build` (no shard in scope) passes NULL.
- **`pagestore_layer_test.c`:** drives lookups through a local `PsLayerBloom`.

## Test
- Standalone **297/0** (POSIX) and **297/0** (SPDK, nvme2), each covering nshards 1 and 4; image-layer unit test **60/0**.

Remaining shared hot-path state for the threads (lands with 4c-iv): the POSIX segment fd cache (brief mutex) and the timeline `defined` flag (atomic release/acquire). Then **4c-iv** spawns the per-shard worker threads + `backend_localsvc` routing — verified with ThreadSanitizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)