### PR TITLE
contrib/pagestore: per-shard POSIX worker threads (sharding step 4c-iv)

### DIFF
--- a/.github/workflows/pagestore-test.yml
+++ b/.github/workflows/pagestore-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Compile daemon and test harness
         working-directory: contrib/pagestore
         run: |
-          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c pagestore_core.c storage_posix.c pagestore_layer.c pagestore_layer_store.c pagestore_manifest.c pagestore_memtable.c pagestore_pgcache.c -lrt
+          cc -O2 -Wall -Wextra -Werror -o pagestore_daemon pagestore_daemon.c pagestore_core.c storage_posix.c pagestore_layer.c pagestore_layer_store.c pagestore_manifest.c pagestore_memtable.c pagestore_pgcache.c -lrt -lpthread
           cc -O2 -Wall -Wextra -Werror -o pagestore_test   pagestore_test.c   -lrt
           cc -O2 -Wall -Wextra -Werror -o pagestore_layer_test pagestore_layer_test.c pagestore_layer.c pagestore_layer_store.c -lrt
           cc -O2 -Wall -Wextra -Werror -o pagestore_pgcache_test pagestore_pgcache_test.c pagestore_pgcache.c -lrt

--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -189,9 +189,18 @@ timeline tree under a brief coordination point, not on the read/write hot path.
        and lock-free.  (Remaining shared hot-path state for the threads: the POSIX
        segment fd cache -- a brief mutex -- and the timeline `defined` flag -- an
        atomic release/acquire -- land with 4c-iv.)
-     - **4c-iv** — spawn one POSIX worker thread per shard, each polling only its
-       channel pool; `backend_localsvc` per-shard channel pool + routing.  Real
-       parallelism lands here.
+     - **4c-iv — per-shard POSIX worker threads.** ✅ The POSIX daemon spawns one
+       worker thread per shard, each polling only its channel pool and running its
+       own compaction (`ps_core_maintenance_shard`), so requests on different
+       shards run in parallel with no shared per-shard state.  The remaining shared
+       state is synchronized: the segment fd cache takes a brief mutex (the
+       `pread`/`pwrite` stay concurrent), the timeline `defined` flag is published
+       release / read acquire (branch-create on shard 0 writes peers' replicas),
+       and branch/WAL ops route to shard 0.  At `nshards == 1` it is a single
+       worker == the old loop.  Verified race-free under ThreadSanitizer at
+       nshards 1 and 4.  (`backend_localsvc` still requires `nshards == 1`; its
+       per-shard routing -- needed to enable `nshards > 1` with the real engine,
+       and testable only by the integration suite -- is a focused follow-up.)
 5. **SPDK per-thread qpairs** so the async path scales per core.
 6. **Branch-create coordination** for the shared timeline tree.
 

--- a/contrib/pagestore/meson.build
+++ b/contrib/pagestore/meson.build
@@ -24,6 +24,7 @@ pagestore_daemon = executable('pagestore_daemon',
   files('pagestore_daemon.c', 'pagestore_core.c', 'storage_posix.c',
         'pagestore_layer.c', 'pagestore_layer_store.c', 'pagestore_manifest.c',
         'pagestore_memtable.c', 'pagestore_pgcache.c'),
+  dependencies: thread_dep,  # per-shard worker threads + segment fd-cache mutex
   kwargs: default_bin_args,
 )
 contrib_targets += pagestore_daemon

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -128,6 +128,34 @@ shard_for(const PsKey *key)
 }
 
 /*
+ * Which shard must serve a request, so a per-shard worker can reject one that was
+ * posted on the wrong channel pool (a non-routing client would otherwise have
+ * worker A mutate shard B's single-owner state).  Keyed ops go to their key's
+ * shard; timeline/shipped-WAL ops are shard-0 global state; a global sync or a
+ * no-op may run on any worker (returns PS_ANY_SHARD).  At ps_nshards == 1 every
+ * request maps to shard 0, so nothing is ever rejected.
+ */
+#define PS_ANY_SHARD	UINT32_MAX
+
+uint32_t
+ps_request_shard(const PsChannel *ch)
+{
+	switch ((PsOpcode) ch->opcode)
+	{
+		case PS_OP_CREATE_BRANCH:
+		case PS_OP_WAL_APPEND:
+		case PS_OP_WAL_SIZE:
+		case PS_OP_WAL_READ:
+			return 0;			/* timeline / shipped-WAL: shard-0 global state */
+		case PS_OP_IMMEDSYNC:
+		case PS_OP_NONE:
+			return PS_ANY_SHARD;	/* global sync / no-op: safe on any worker */
+		default:
+			return ps_shard_for_key(&ch->key, ps_nshards);
+	}
+}
+
+/*
  * layer_id namespacing: the high LAYER_ID_SHARD_SHIFT bits hold the shard id and
  * the low bits a per-shard counter, so ids (and the layer files named by them)
  * never collide across shards while each shard allocates independently.  At
@@ -964,12 +992,12 @@ typedef struct TimelineRec
 	uint64_t	branch_lsn;
 } TimelineRec;
 
-static void
+static int
 timeline_persist(uint32_t id, int parent, uint64_t branch_lsn)
 {
 	TimelineRec rec = {id, (int32_t) parent, branch_lsn};
 
-	ps_storage->meta_append(&rec, sizeof(rec));		/* best-effort */
+	return ps_storage->meta_append(&rec, sizeof(rec));
 }
 
 static void
@@ -1511,17 +1539,19 @@ ps_handle_meta(PsChannel *ch)
 			 * until it writes (copy-on-write).
 			 */
 			/* branch-create is routed to shard 0, so validate against shard 0's
-			 * copy; timeline_define then broadcasts to every shard */
-			if (branch_request_ok(&g_shards[0], ch->timeline,
-								  (int) ch->parent_timeline))
-			{
+			 * copy.  Persist the branch durably BEFORE timeline_define publishes
+			 * its 'defined' flag to every shard: under per-shard threads a peer
+			 * shard that observes 'defined' could acknowledge writes on the branch,
+			 * which must not outlive a crash before the metadata is durable. */
+			if (!branch_request_ok(&g_shards[0], ch->timeline,
+								   (int) ch->parent_timeline))
+				ch->status = PS_STATUS_ERROR;
+			else if (timeline_persist(ch->timeline, (int) ch->parent_timeline,
+									  ch->req_lsn) != 0)
+				ch->status = PS_STATUS_ERROR;
+			else
 				timeline_define(ch->timeline, (int) ch->parent_timeline,
 								ch->req_lsn);
-				timeline_persist(ch->timeline, (int) ch->parent_timeline,
-								 ch->req_lsn);
-			}
-			else
-				ch->status = PS_STATUS_ERROR;
 			break;
 
 		case PS_OP_WAL_APPEND:

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -107,6 +107,7 @@ typedef struct Shard
 	uint64_t	cur_off;		/* append cursor within cur_seg */
 	PsPgcache	pgcache;		/* per-shard materialized-page cache */
 	PsLayerBloom bloom;			/* per-shard per-layer (key,block) bloom cache */
+	time_t		maint_cooldown;	/* skip compaction attempts until this wall time */
 	TimelineMeta timelines[MAX_TIMELINES];	/* replicated timeline tree */
 	uint64_t	rr_mem,			/* read-source counters */
 				rr_layer,
@@ -784,15 +785,27 @@ timeline_define(uint32_t id, int parent, uint64_t branch_lsn)
 
 		t->parent = parent;
 		t->branch_lsn = branch_lsn;
-		t->defined = 1;
+		/* publish 'defined' last with a release store: branch-create (shard 0)
+		 * writes peer shards' copies while their threads read them, so the
+		 * acquire-load in tl_defined() pairs with this to make parent/branch_lsn
+		 * visible.  The tree is append-only, so a slot only ever flips 0 -> 1. */
+		__atomic_store_n(&t->defined, 1, __ATOMIC_RELEASE);
 	}
+}
+
+/* acquire-load of a timeline slot's 'defined' flag (pairs with timeline_define's
+ * release store; the slot's other fields are valid once this reads 1) */
+static int
+tl_defined(const Shard *s, uint32_t timeline)
+{
+	return timeline < MAX_TIMELINES &&
+		__atomic_load_n(&s->timelines[timeline].defined, __ATOMIC_ACQUIRE);
 }
 
 static int
 timeline_has_parent(const Shard *s, uint32_t timeline)
 {
-	return timeline < MAX_TIMELINES && s->timelines[timeline].defined &&
-		s->timelines[timeline].parent >= 0;
+	return tl_defined(s, timeline) && s->timelines[timeline].parent >= 0;
 }
 
 /*
@@ -810,15 +823,15 @@ timeline_has_parent(const Shard *s, uint32_t timeline)
 static int
 branch_request_ok(const Shard *s, uint32_t new_tl, int parent)
 {
-	if (new_tl == 0 || new_tl >= MAX_TIMELINES || s->timelines[new_tl].defined)
+	if (new_tl == 0 || new_tl >= MAX_TIMELINES || tl_defined(s, new_tl))
 		return 0;
-	if (parent < 0 || parent >= MAX_TIMELINES || !s->timelines[parent].defined)
+	if (parent < 0 || parent >= MAX_TIMELINES || !tl_defined(s, (uint32_t) parent))
 		return 0;
 	for (int t = parent; t >= 0 && t < MAX_TIMELINES; t = s->timelines[t].parent)
 	{
 		if ((uint32_t) t == new_tl)
 			return 0;			/* cycle */
-		if (!s->timelines[t].defined)
+		if (!tl_defined(s, (uint32_t) t))
 			return 0;			/* broken chain: refuse rather than risk a loop */
 	}
 	return 1;
@@ -1262,7 +1275,7 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 			 * several, so check them all, not just this write's).  This shard only:
 			 * the flush added layers to this shard's map. */
 			for (uint32_t ct = 0; ct < MAX_TIMELINES; ct++)
-				if ((ct == 0 || s->timelines[ct].defined) &&
+				if ((ct == 0 || tl_defined(s, ct)) &&
 					count_image_layers(s, ct) > (uint32_t) compact_layers * 4)
 					compact_timeline(s, ct);
 		}
@@ -1576,7 +1589,7 @@ ps_core_close(void)
 
 			for (uint32_t ct = 0; ct < MAX_TIMELINES; ct++)
 			{
-				if (ct != 0 && !s->timelines[ct].defined)
+				if (ct != 0 && !tl_defined(s, ct))
 					continue;
 				while (count_image_layers(s, ct) > (uint32_t) compact_layers)
 				{
@@ -1596,16 +1609,15 @@ ps_core_close(void)
 }
 
 /*
- * Off-the-write-path background maintenance: compact one timeline whose image
- * layer count exceeds the (low-water) threshold.  The daemon calls this when it
- * is otherwise idle; doing at most one compaction per call keeps the serve loop
- * responsive.  Returns 1 if it compacted (the caller should not sleep), 0 if
- * nothing was due.
+ * One unit of off-the-write-path background maintenance for a single shard:
+ * compact one of its timelines whose image-layer count exceeds the (low-water)
+ * threshold.  Per shard so each worker thread (sharding step 4c) runs its own
+ * maintenance with no shared state.  Returns 1 if it compacted (caller should not
+ * sleep), 0 if nothing was due.
  */
-int
-ps_core_maintenance(void)
+static int
+maintain_shard(Shard *s)
 {
-	static time_t cooldown_until = 0;	/* skip attempts until this wall time */
 	int			attempted = 0;
 
 	if (!use_layers)
@@ -1614,38 +1626,53 @@ ps_core_maintenance(void)
 	 * while reading/writing the merge), don't re-read the same failing layers on
 	 * every idle tick -- cool down until either new layer state appears or the
 	 * window passes. */
-	if (cooldown_until != 0 && time(NULL) < cooldown_until)
+	if (s->maint_cooldown != 0 && time(NULL) < s->maint_cooldown)
 		return 0;
-	for (uint32_t i = 0; i < ps_nshards; i++)
-	{
-		Shard	   *s = &g_shards[i];
+	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
+		if ((tl == 0 || tl_defined(s, tl)) &&
+			count_image_layers(s, tl) > (uint32_t) compact_layers)
+		{
+			uint32_t	before = count_image_layers(s, tl);
 
-		for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
-			if ((tl == 0 || s->timelines[tl].defined) &&
-				count_image_layers(s, tl) > (uint32_t) compact_layers)
+			/* Report progress (so the caller skips its idle sleep) only if the
+			 * compaction actually reduced the layer count.  A timeline that can't
+			 * make progress -- nothing mergeable (e.g. compact_layers=0 with a
+			 * single layer) or a failing compaction (ENOSPC / corrupt layer) --
+			 * must not keep the daemon spinning; try the next one. */
+			attempted = 1;
+			if (compact_timeline(s, tl) == 0 &&
+				count_image_layers(s, tl) < before)
 			{
-				uint32_t	before = count_image_layers(s, tl);
-
-				/* Report progress (so the caller skips its idle sleep) only if the
-				 * compaction actually reduced the layer count.  A timeline that
-				 * can't make progress -- nothing mergeable (e.g. compact_layers=0
-				 * with a single layer) or a failing compaction (ENOSPC / corrupt
-				 * layer) -- must not keep the daemon spinning; try the next one. */
-				attempted = 1;
-				if (compact_timeline(s, tl) == 0 &&
-					count_image_layers(s, tl) < before)
-				{
-					cooldown_until = 0;	/* progress: clear any backoff */
-					return 1;
-				}
+				s->maint_cooldown = 0;	/* progress: clear any backoff */
+				return 1;
 			}
-	}
+		}
 	/* Over-threshold timeline(s) exist but none could be compacted: back off so an
-	 * otherwise-idle daemon doesn't re-attempt the same failing merge every 20us.
-	 * A later flush/compaction that changes layer state will return 1 and clear
-	 * this; otherwise the window simply expires and we retry. */
+	 * otherwise-idle shard doesn't re-attempt the same failing merge every 20us. */
 	if (attempted)
-		cooldown_until = time(NULL) + MAINT_COOLDOWN_SECS;
+		s->maint_cooldown = time(NULL) + MAINT_COOLDOWN_SECS;
+	return 0;
+}
+
+/* Maintenance for one shard by index (the per-shard worker threads call this). */
+int
+ps_core_maintenance_shard(uint32_t shard)
+{
+	if (shard >= ps_nshards)
+		return 0;
+	return maintain_shard(&g_shards[shard]);
+}
+
+/*
+ * Maintenance across all shards (the single-threaded frontends, e.g. SPDK, call
+ * this).  Returns 1 if any shard compacted.
+ */
+int
+ps_core_maintenance(void)
+{
+	for (uint32_t i = 0; i < ps_nshards; i++)
+		if (maintain_shard(&g_shards[i]))
+			return 1;
 	return 0;
 }
 
@@ -1832,7 +1859,7 @@ ps_core_open(const char *store_dir)
 	/* rebuild each timeline's shipped-WAL end LSN from its log (WAL is shard-0,
 	 * single-threaded here; all shards' timeline copies are identical) */
 	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
-		if (tl == 0 || g_shards[0].timelines[tl].defined)
+		if (tl == 0 || tl_defined(&g_shards[0], tl))
 			wal_recover_one(tl);
 
 	return 0;

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1578,7 +1578,8 @@ ps_handle_meta(PsChannel *ch)
 			break;
 
 		case PS_OP_IMMEDSYNC:
-			ps_storage->sync();
+			if (ps_storage->sync() != 0)
+				ch->status = PS_STATUS_ERROR;	/* report a failed durable sync */
 			break;
 
 		default:

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -50,8 +50,11 @@ extern int	ps_core_open(const char *store_dir);
 extern void ps_core_close(void);
 
 /* Off-the-write-path maintenance (compaction).  Call when idle; returns 1 if it
- * did work (caller should not sleep), 0 if nothing was due. */
+ * did work (caller should not sleep), 0 if nothing was due.  The (void) form
+ * sweeps every shard (single-threaded frontends); the per-shard form is for a
+ * worker thread that owns just its shard. */
 extern int	ps_core_maintenance(void);
+extern int	ps_core_maintenance_shard(uint32_t shard);
 
 /* Number of image layers currently in the layer map (for stats/diagnostics). */
 extern uint32_t ps_core_layer_count(void);

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -62,6 +62,12 @@ extern uint32_t ps_core_layer_count(void);
 /* Read-path source counts: served from memtable / image layer / segment. */
 extern void ps_core_read_stats(uint64_t *mem, uint64_t *layer, uint64_t *seg);
 
+/* The shard that must serve a request; PS_ANY_SHARD if any worker may.  A
+ * per-shard worker rejects a request whose shard isn't its own (guards the
+ * single-owner invariant against a client that posts on the wrong channel). */
+#define PS_ANY_SHARD	UINT32_MAX
+extern uint32_t ps_request_shard(const PsChannel *ch);
+
 /* The per-shard materialized-page cache that owns 'key' (for a frontend caching
  * pages outside read_resolve, e.g. the SPDK async path). */
 extern PsPgcache *ps_core_pgcache_for(const PsKey *key);

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -234,6 +234,19 @@ main(int argc, char **argv)
 				PS_MAX_SHARDS, ps_nshards);
 		return 2;
 	}
+	/*
+	 * The SPDK backend keeps a single qpair + current-segment buffer, so multiple
+	 * per-shard worker threads driving it would race/corrupt that state.  Multi-
+	 * shard SPDK needs per-thread qpairs (SHARDING.md step 5); until then run a
+	 * single shard whenever this daemon uses the SPDK storage (the dedicated
+	 * pagestore_daemon_spdk clamps the same way).
+	 */
+	if (strcmp(ps_storage->name, "spdk") == 0 && ps_nshards != 1)
+	{
+		fprintf(stderr, "pagestore_daemon: --storage spdk does not support "
+				"--nshards > 1 yet (SHARDING.md step 5); using --nshards 1\n");
+		ps_nshards = 1;
+	}
 
 	if (ps_core_open(store_dir) != 0)
 	{

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -33,13 +33,17 @@
 #include "pagestore_core.h"
 #include "pagestore_pgcache.h"
 
+/* Set by the signal handler and read by every worker thread, so accesses are
+ * atomic: volatile sig_atomic_t only covers the signal-handler/main case, not
+ * inter-thread visibility.  RELAXED is enough -- it only gates loop exit, and the
+ * channel state machine carries the real ordering. */
 static volatile sig_atomic_t stop_requested = 0;
 
 static void
 on_signal(int sig)
 {
 	(void) sig;
-	stop_requested = 1;
+	__atomic_store_n(&stop_requested, 1, __ATOMIC_RELAXED);
 }
 
 static void handle_request(PsChannel *ch);
@@ -64,17 +68,27 @@ worker_main(void *arg)
 {
 	Worker	   *w = arg;
 
-	while (!stop_requested)
+	while (!__atomic_load_n(&stop_requested, __ATOMIC_RELAXED))
 	{
 		int			did_work = 0;
 
 		for (uint32_t i = w->first; i < w->first + w->count; i++)
 		{
 			PsChannel  *ch = ps_channel(w->shm, i);
+			uint32_t	owner;
 
 			if (ps_load_acquire(&ch->state) != PS_STATE_REQUEST)
 				continue;
-			handle_request(ch);
+			/* Single-owner guard: only serve a request that belongs to this
+			 * shard.  A correctly-routing client always posts on the owning
+			 * shard's pool; a non-routing client (or a stale one) that lands a
+			 * keyed request here is rejected rather than allowed to mutate another
+			 * shard's state from this thread.  PS_ANY_SHARD ops run anywhere. */
+			owner = ps_request_shard(ch);
+			if (owner != PS_ANY_SHARD && owner != w->shard)
+				ch->status = PS_STATUS_ERROR;
+			else
+				handle_request(ch);
 			ps_store_release(&ch->state, PS_STATE_DONE);
 			did_work = 1;
 		}
@@ -255,9 +269,9 @@ main(int argc, char **argv)
 	 */
 	hdr = (PsShmHeader *) shm;
 	memset(shm, 0, PS_SHM_SIZE);
-	/* Fill every descriptive field first, then publish 'magic' last as the
-	 * readiness sentinel (wait_ready / clients gate on it), so a client that
-	 * observes the daemon ready also sees nshards and the channel geometry. */
+	/* Fill every descriptive field now, but publish 'magic' (the readiness
+	 * sentinel clients gate on) only after all workers exist -- otherwise a client
+	 * could attach and post into a pool no thread is serving yet. */
 	hdr->version = PS_SHM_VERSION;
 	hdr->page_size = page_size;
 	hdr->io_unit = PS_IO_UNIT;
@@ -265,20 +279,11 @@ main(int argc, char **argv)
 	hdr->nshards = ps_nshards;	/* clients route to the same shard pools */
 	hdr->channel_stride = PS_CHANNEL_STRIDE;
 	hdr->channels_off = PS_CHANNELS_OFF;
-	/* publish magic with a release store so the readers' acquire-load of it has a
-	 * matching release on the same field, giving a happens-before edge for the
-	 * descriptive fields written above */
-	ps_store_release(&hdr->magic, PS_SHM_MAGIC);
 
 	memset(&sa, 0, sizeof(sa));
 	sa.sa_handler = on_signal;
 	sigaction(SIGINT, &sa, NULL);
 	sigaction(SIGTERM, &sa, NULL);
-
-	fprintf(stderr, "pagestore_daemon: shm=%s store=%s storage=%s page_size=%u "
-			"io_unit=%u channels=%d ready\n",
-			shm_name, store_dir, ps_storage->name, page_size, PS_IO_UNIT,
-			PS_MAX_CHANNELS);
 
 	/*
 	 * One worker thread per shard, each serving only its channel pool (sharding
@@ -305,13 +310,24 @@ main(int argc, char **argv)
 							   &workers[s]) != 0)
 			{
 				perror("pthread_create");
-				stop_requested = 1;
+				/* never published magic, so no client treats the shm as ready;
+				 * stop the workers already started and bail */
+				__atomic_store_n(&stop_requested, 1, __ATOMIC_RELAXED);
 				for (uint32_t j = 0; j < s; j++)
 					pthread_join(workers[j].tid, NULL);
 				free(workers);
 				return 1;
 			}
 		}
+
+		/* all workers exist: publish magic with a release store (the readers'
+		 * acquire-load of it pairs with this), making the shm ready to serve */
+		ps_store_release(&hdr->magic, PS_SHM_MAGIC);
+		fprintf(stderr, "pagestore_daemon: shm=%s store=%s storage=%s page_size=%u "
+				"io_unit=%u channels=%d nshards=%u ready\n",
+				shm_name, store_dir, ps_storage->name, page_size, PS_IO_UNIT,
+				PS_MAX_CHANNELS, ps_nshards);
+
 		for (uint32_t s = 0; s < ps_nshards; s++)
 			pthread_join(workers[s].tid, NULL);
 		free(workers);

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -19,6 +19,7 @@
  *-------------------------------------------------------------------------
  */
 #include <fcntl.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -39,6 +40,57 @@ on_signal(int sig)
 {
 	(void) sig;
 	stop_requested = 1;
+}
+
+static void handle_request(PsChannel *ch);
+
+/* one per-shard worker thread (sharding step 4c-iv) */
+typedef struct Worker
+{
+	pthread_t	tid;
+	void	   *shm;
+	uint32_t	shard;			/* this worker's shard index */
+	uint32_t	first;			/* its channel pool: [first, first+count) */
+	uint32_t	count;
+} Worker;
+
+/*
+ * Serve loop for one shard: poll only this shard's channel pool, so two workers
+ * never touch the same channel.  Each request self-routes by key to this shard's
+ * state, and idle time runs this shard's own compaction.
+ */
+static void *
+worker_main(void *arg)
+{
+	Worker	   *w = arg;
+
+	while (!stop_requested)
+	{
+		int			did_work = 0;
+
+		for (uint32_t i = w->first; i < w->first + w->count; i++)
+		{
+			PsChannel  *ch = ps_channel(w->shm, i);
+
+			if (ps_load_acquire(&ch->state) != PS_STATE_REQUEST)
+				continue;
+			handle_request(ch);
+			ps_store_release(&ch->state, PS_STATE_DONE);
+			did_work = 1;
+		}
+
+		if (!did_work)
+		{
+			/* idle: one unit of this shard's background compaction, else sleep */
+			if (!ps_core_maintenance_shard(w->shard))
+			{
+				struct timespec ts = {0, 20000};	/* 20us */
+
+				nanosleep(&ts, NULL);
+			}
+		}
+	}
+	return NULL;
 }
 
 /*
@@ -228,32 +280,41 @@ main(int argc, char **argv)
 			shm_name, store_dir, ps_storage->name, page_size, PS_IO_UNIT,
 			PS_MAX_CHANNELS);
 
-	while (!stop_requested)
+	/*
+	 * One worker thread per shard, each serving only its channel pool (sharding
+	 * step 4c-iv).  Per-shard state is single-owner; the small shared state is
+	 * synchronized (segment fd cache mutex, timeline 'defined' atomics, shard-0
+	 * branch/WAL routing).  At nshards == 1 this is a single worker == the old
+	 * single-threaded loop.  The main thread waits for a signal, then joins.
+	 */
 	{
-		int			did_work = 0;
+		Worker	   *workers = calloc(ps_nshards, sizeof(Worker));
 
-		for (uint32_t i = 0; i < PS_MAX_CHANNELS; i++)
+		if (!workers)
 		{
-			PsChannel  *ch = ps_channel(shm, i);
-
-			if (ps_load_acquire(&ch->state) != PS_STATE_REQUEST)
-				continue;
-
-			handle_request(ch);
-			ps_store_release(&ch->state, PS_STATE_DONE);
-			did_work = 1;
+			perror("calloc workers");
+			return 1;
 		}
-
-		if (!did_work)
+		for (uint32_t s = 0; s < ps_nshards; s++)
 		{
-			/* idle: do one unit of background compaction before sleeping */
-			if (!ps_core_maintenance())
+			workers[s].shm = shm;
+			workers[s].shard = s;
+			ps_shard_channel_range(s, ps_nshards, PS_MAX_CHANNELS,
+								   &workers[s].first, &workers[s].count);
+			if (pthread_create(&workers[s].tid, NULL, worker_main,
+							   &workers[s]) != 0)
 			{
-				struct timespec ts = {0, 20000};	/* 20us */
-
-				nanosleep(&ts, NULL);
+				perror("pthread_create");
+				stop_requested = 1;
+				for (uint32_t j = 0; j < s; j++)
+					pthread_join(workers[j].tid, NULL);
+				free(workers);
+				return 1;
 			}
 		}
+		for (uint32_t s = 0; s < ps_nshards; s++)
+			pthread_join(workers[s].tid, NULL);
+		free(workers);
 	}
 
 	{

--- a/contrib/pagestore/pagestore_import.c
+++ b/contrib/pagestore/pagestore_import.c
@@ -79,6 +79,18 @@ client_attach(const char *shm_name)
 				PS_SHM_VERSION, page_size);
 		exit(2);
 	}
+	/*
+	 * This importer reuses one channel for every key, which a multi-shard daemon
+	 * (per-shard workers serving only their own pool) would reject for keys that
+	 * hash to another shard.  Per-shard routing here is a later step; fail fast so
+	 * an import can't silently abort partway.
+	 */
+	if (hdr->nshards > 1)
+	{
+		fprintf(stderr, "pagestore_import does not support a multi-shard daemon "
+				"(nshards=%u); import against an nshards=1 daemon\n", hdr->nshards);
+		exit(2);
+	}
 	for (uint32_t i = 0; i < hdr->nchannels; i++)
 		if (ps_cas(&ps_channel(shm, i)->claimed, 0, 1))
 		{

--- a/contrib/pagestore/pagestore_walrestore.c
+++ b/contrib/pagestore/pagestore_walrestore.c
@@ -58,13 +58,25 @@ client_attach(const char *shm_name, uint32_t page_size_unused)
 		fprintf(stderr, "bad shm header\n");
 		exit(2);
 	}
-	for (uint32_t i = 0; i < hdr->nchannels; i++)
-		if (ps_cas(&ps_channel(shm, i)->claimed, 0, 1))
-		{
-			chan = (int) i;
-			return;
-		}
-	fprintf(stderr, "no free channel\n");
+	/*
+	 * WAL_READ is a shipped-WAL op, which a multi-shard daemon serves only on
+	 * shard 0; claim from shard 0's channel pool so the request reaches the worker
+	 * that owns it (at nshards == 1 the pool is the whole array).
+	 */
+	{
+		uint32_t	first,
+					cnt,
+					ns = hdr->nshards ? hdr->nshards : 1;
+
+		ps_shard_channel_range(0, ns, hdr->nchannels, &first, &cnt);
+		for (uint32_t i = first; i < first + cnt; i++)
+			if (ps_cas(&ps_channel(shm, i)->claimed, 0, 1))
+			{
+				chan = (int) i;
+				return;
+			}
+	}
+	fprintf(stderr, "no free channel in shard 0\n");
 	exit(2);
 }
 

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -105,10 +105,32 @@ posix_close(void)
 static int
 posix_sync(void)
 {
-	for (int id = 0; id < segs_cap; id++)
-		if (seg_fds[id] >= 0 && fsync(seg_fds[id]) != 0)
-			return -1;
-	return 0;
+	int		   *fds;
+	int			n;
+	int			rc = 0;
+
+	/* Snapshot the fd cache under seg_mtx so a concurrent seg_fd() realloc on
+	 * another shard's worker can't free/move the array under us; fsync the copied
+	 * fds outside the lock so the sync doesn't block other shards' writes.  The
+	 * fds are stable (a segment is opened once and only closed at shutdown, after
+	 * the workers have joined). */
+	pthread_mutex_lock(&seg_mtx);
+	n = segs_cap;
+	fds = n > 0 ? malloc((size_t) n * sizeof(int)) : NULL;
+	if (n > 0 && !fds)
+	{
+		pthread_mutex_unlock(&seg_mtx);
+		return -1;
+	}
+	for (int id = 0; id < n; id++)
+		fds[id] = seg_fds[id];
+	pthread_mutex_unlock(&seg_mtx);
+
+	for (int id = 0; id < n; id++)
+		if (fds[id] >= 0 && fsync(fds[id]) != 0)
+			rc = -1;
+	free(fds);
+	return rc;
 }
 
 static int

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -16,6 +16,7 @@
  */
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -31,9 +32,15 @@ static char posix_dir[2048];
  * One cached OS fd per segment id (opened lazily, never closed during a run).
  * Only the segment log keeps fds; the WAL and metadata logs open per call,
  * matching the original daemon (they are not on the hot path).
+ *
+ * Per-shard worker threads (sharding step 4c) append to disjoint segment ids but
+ * share this fd cache, so seg_mtx guards the lookup/grow.  The cached fd (an int)
+ * is copied out under the lock; the actual pread/pwrite then runs lock-free and
+ * concurrently (positioned I/O on a shared fd is thread-safe).
  */
 static int *seg_fds;
 static int	segs_cap;
+static pthread_mutex_t seg_mtx = PTHREAD_MUTEX_INITIALIZER;
 
 static void
 seg_path(char *buf, size_t buflen, int id)
@@ -48,8 +55,13 @@ seg_fd(int id, int create)
 	char		path[4096];
 	int			fd;
 
+	pthread_mutex_lock(&seg_mtx);
 	if (id < segs_cap && seg_fds[id] >= 0)
-		return seg_fds[id];
+	{
+		fd = seg_fds[id];
+		pthread_mutex_unlock(&seg_mtx);
+		return fd;
+	}
 
 	if (id >= segs_cap)
 	{
@@ -65,6 +77,7 @@ seg_fd(int id, int create)
 	fd = open(path, O_RDWR | (create ? O_CREAT : 0), 0600);
 	if (fd >= 0)
 		seg_fds[id] = fd;
+	pthread_mutex_unlock(&seg_mtx);
 	return fd;
 }
 

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -105,31 +105,19 @@ posix_close(void)
 static int
 posix_sync(void)
 {
-	int		   *fds;
-	int			n;
 	int			rc = 0;
 
-	/* Snapshot the fd cache under seg_mtx so a concurrent seg_fd() realloc on
-	 * another shard's worker can't free/move the array under us; fsync the copied
-	 * fds outside the lock so the sync doesn't block other shards' writes.  The
-	 * fds are stable (a segment is opened once and only closed at shutdown, after
-	 * the workers have joined). */
+	/* Hold seg_mtx across the whole walk so a concurrent seg_fd() realloc on
+	 * another shard's worker can't free/move the array under us.  fsync runs under
+	 * the lock (so seg_fd() briefly blocks during a sync), which is fine: an
+	 * immediate sync is rare, and keeping the path allocation-free means it can't
+	 * fail to report -- a snapshot copy's malloc could fail and leave an
+	 * acknowledged sync that fsynced nothing. */
 	pthread_mutex_lock(&seg_mtx);
-	n = segs_cap;
-	fds = n > 0 ? malloc((size_t) n * sizeof(int)) : NULL;
-	if (n > 0 && !fds)
-	{
-		pthread_mutex_unlock(&seg_mtx);
-		return -1;
-	}
-	for (int id = 0; id < n; id++)
-		fds[id] = seg_fds[id];
-	pthread_mutex_unlock(&seg_mtx);
-
-	for (int id = 0; id < n; id++)
-		if (fds[id] >= 0 && fsync(fds[id]) != 0)
+	for (int id = 0; id < segs_cap; id++)
+		if (seg_fds[id] >= 0 && fsync(seg_fds[id]) != 0)
 			rc = -1;
-	free(fds);
+	pthread_mutex_unlock(&seg_mtx);
 	return rc;
 }
 


### PR DESCRIPTION
**Real parallelism.** The POSIX daemon now runs one worker thread per shard, each polling only its channel pool and doing its own compaction, so requests on different shards run concurrently. Steps 4a–4c-iii made all per-shard state single-owner; this synchronizes the small remaining shared state and spawns the threads. At `nshards == 1` it's a single worker == the old loop. Stacked on #23.

## What
- **`pagestore_daemon.c`:** spawn `ps_nshards` worker threads, each serving its `ps_shard_channel_range()` pool and calling `ps_core_maintenance_shard()` when idle; the main thread installs the signal handler, waits, and joins. The client routes each request to its key's shard pool (#15), so a worker only ever touches its own shard's state.
- **`storage_posix.c`:** the shared segment fd cache (realloc'd, indexed by seg id) takes a mutex around the lookup/grow; the cached fd is copied out under the lock so `pread`/`pwrite` runs lock-free and concurrently.
- **`pagestore_core.c`:** `timeline_define` publishes each replica's `defined` flag with a **release** store and readers **acquire**-load it (`tl_defined`), so a branch-create on shard 0 safely populates peers' replicas while their threads read them; per-shard compaction cooldown; `ps_core_maintenance_shard()` (one shard) beside `ps_core_maintenance()` (sweeps all, for single-threaded frontends like SPDK).
- **`meson.build`:** link the daemon with `thread_dep`.

## Scope
`backend_localsvc` still requires `nshards == 1` (its per-shard routing — needed to *enable* `nshards > 1` with the real engine, and testable only by the integration suite — is a focused follow-up). The SPDK daemon stays single-threaded until step 5.

## Test
- **Race-free under ThreadSanitizer (clang)** at nshards 1 and 4.
- Standalone **297/0** (POSIX, threaded) and **297/0** (SPDK, nvme2); image-layer unit test **60/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)