### PR TITLE
contrib/pagestore: object-tier storage primitives (LSM phase 4, slice 1)

### DIFF
--- a/contrib/pagestore/pagestore_layer_store.c
+++ b/contrib/pagestore/pagestore_layer_store.c
@@ -11,14 +11,95 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "pagestore_layer_store.h"
 
 static char layer_dir[2048];
 
+/*
+ * Object tier (LSM phase 4).  A configured object store is, for now, a local
+ * directory standing in for a remote bucket: "upload" copies a sealed layer file
+ * into it keyed by layer id, "download" copies it back, keyed the same way.  A
+ * real provider (S3, ...) drops in behind these same four ops.  Empty until
+ * ps_layer_store_set_object_dir() configures it; the remote ops then return
+ * ENOTSUP, so a daemon without an object tier behaves exactly as before.
+ */
+static char object_dir[2048];
+
 const PsLayerStore *ps_layer_store = &PsLayerStoreLocal;
+
+void
+ps_layer_store_set_object_dir(const char *dir)
+{
+	if (dir == NULL)
+		object_dir[0] = '\0';
+	else
+		snprintf(object_dir, sizeof(object_dir), "%s", dir);
+}
+
+static int
+object_path(uint64_t layer_id, char *buf, size_t buflen)
+{
+	int			n;
+
+	if (object_dir[0] == '\0')
+		return -1;				/* no object tier configured */
+	n = snprintf(buf, buflen, "%s/obj_%016llx",
+				 object_dir, (unsigned long long) layer_id);
+	if (n < 0 || (size_t) n >= buflen)
+		return -1;
+	return 0;
+}
+
+/* Copy src -> dst (whole file) and fsync dst.  Used for upload/download, since
+ * the object store is a local directory here. */
+static int
+copy_file(const char *src, const char *dst)
+{
+	int			in,
+				out,
+				rc = 0;
+	char		buf[1 << 16];
+	ssize_t		r;
+
+	in = open(src, O_RDONLY);
+	if (in < 0)
+		return -1;
+	out = open(dst, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (out < 0)
+	{
+		close(in);
+		return -1;
+	}
+	while ((r = read(in, buf, sizeof(buf))) > 0)
+	{
+		ssize_t		off = 0;
+
+		while (off < r)
+		{
+			ssize_t		w = write(out, buf + off, (size_t) (r - off));
+
+			if (w <= 0)
+			{
+				rc = -1;
+				goto done;
+			}
+			off += w;
+		}
+	}
+	if (r < 0)
+		rc = -1;
+done:
+	if (rc == 0 && fsync(out) != 0)
+		rc = -1;
+	close(in);
+	close(out);
+	return rc;
+}
 
 static int
 local_open(const char *store_dir)
@@ -171,11 +252,71 @@ local_read_layer_block(const PsLayerDesc *layer, uint64_t off,
 }
 
 static int
-local_unsupported_layer_op(const PsLayerDesc *layer)
+object_fsync_dir(void)
 {
-	(void) layer;
-	errno = ENOTSUP;
-	return -1;
+	int			fd;
+	int			rc;
+
+	fd = open(object_dir, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	rc = fsync(fd);
+	close(fd);
+	return rc;
+}
+
+/* Upload the sealed local layer into the object store (copy + durable). */
+static int
+local_upload_layer(const PsLayerDesc *layer)
+{
+	char		local[4096],
+				obj[4096];
+
+	if (local_layer_path(layer->layer_id, local, sizeof(local)) != 0)
+		return -1;
+	if (object_path(layer->layer_id, obj, sizeof(obj)) != 0)
+	{
+		errno = ENOTSUP;		/* no object tier configured */
+		return -1;
+	}
+	if (copy_file(local, obj) != 0)
+		return -1;
+	return object_fsync_dir();
+}
+
+/* Download a remote-durable layer back to its canonical local path. */
+static int
+local_download_layer(const PsLayerDesc *layer)
+{
+	char		local[4096],
+				obj[4096];
+
+	if (local_layer_path(layer->layer_id, local, sizeof(local)) != 0)
+		return -1;
+	if (object_path(layer->layer_id, obj, sizeof(obj)) != 0)
+	{
+		errno = ENOTSUP;
+		return -1;
+	}
+	if (copy_file(obj, local) != 0)
+		return -1;
+	return local_fsync_dir();
+}
+
+/* Remove the layer's object-store copy (idempotent). */
+static int
+local_delete_remote_layer(const PsLayerDesc *layer)
+{
+	char		obj[4096];
+
+	if (object_path(layer->layer_id, obj, sizeof(obj)) != 0)
+	{
+		errno = ENOTSUP;
+		return -1;
+	}
+	if (unlink(obj) != 0 && errno != ENOENT)
+		return -1;
+	return object_fsync_dir();
 }
 
 static int
@@ -206,11 +347,16 @@ local_delete_local_layer(const PsLayerDesc *layer)
 	return rc;
 }
 
+/* 1 if the layer has an object-store copy, 0 if not (or no tier configured). */
 static int
 local_layer_exists_remote(const PsLayerDesc *layer)
 {
-	(void) layer;
-	return 0;
+	char		obj[4096];
+	struct stat st;
+
+	if (object_path(layer->layer_id, obj, sizeof(obj)) != 0)
+		return 0;
+	return stat(obj, &st) == 0 ? 1 : 0;
 }
 
 const PsLayerStore PsLayerStoreLocal = {
@@ -221,9 +367,9 @@ const PsLayerStore PsLayerStoreLocal = {
 	.write_local_layer = local_write_local_layer,
 	.seal_local_layer = local_seal_local_layer,
 	.read_layer_block = local_read_layer_block,
-	.upload_layer = local_unsupported_layer_op,
-	.download_layer = local_unsupported_layer_op,
+	.upload_layer = local_upload_layer,
+	.download_layer = local_download_layer,
 	.delete_local_layer = local_delete_local_layer,
-	.delete_remote_layer = local_unsupported_layer_op,
+	.delete_remote_layer = local_delete_remote_layer,
 	.layer_exists_remote = local_layer_exists_remote,
 };

--- a/contrib/pagestore/pagestore_layer_store.c
+++ b/contrib/pagestore/pagestore_layer_store.c
@@ -32,13 +32,21 @@ static char object_dir[2048];
 
 const PsLayerStore *ps_layer_store = &PsLayerStoreLocal;
 
-void
+int
 ps_layer_store_set_object_dir(const char *dir)
 {
 	if (dir == NULL)
+	{
 		object_dir[0] = '\0';
-	else
-		snprintf(object_dir, sizeof(object_dir), "%s", dir);
+		return 0;
+	}
+	if ((size_t) snprintf(object_dir, sizeof(object_dir), "%s", dir)
+		>= sizeof(object_dir))
+	{
+		object_dir[0] = '\0';	/* reject rather than store a truncated path */
+		return -1;
+	}
+	return 0;
 }
 
 static int
@@ -55,21 +63,29 @@ object_path(uint64_t layer_id, char *buf, size_t buflen)
 	return 0;
 }
 
-/* Copy src -> dst (whole file) and fsync dst.  Used for upload/download, since
- * the object store is a local directory here. */
+/*
+ * Copy src -> dst durably.  Layer copies are immutable, so never truncate an
+ * existing dst in place: write to "<dst>.tmp", fsync it, then atomically rename
+ * it over dst (single writer per layer id, so a fixed temp suffix is safe).  A
+ * crash leaves either the old complete copy or a stale .tmp, never a truncated
+ * dst.  Used for upload/download (the object store is a local directory here).
+ */
 static int
 copy_file(const char *src, const char *dst)
 {
 	int			in,
 				out,
 				rc = 0;
+	char		tmp[4096];
 	char		buf[1 << 16];
 	ssize_t		r;
 
+	if ((size_t) snprintf(tmp, sizeof(tmp), "%s.tmp", dst) >= sizeof(tmp))
+		return -1;
 	in = open(src, O_RDONLY);
 	if (in < 0)
 		return -1;
-	out = open(dst, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	out = open(tmp, O_WRONLY | O_CREAT | O_TRUNC, 0600);
 	if (out < 0)
 	{
 		close(in);
@@ -98,6 +114,10 @@ done:
 		rc = -1;
 	close(in);
 	close(out);
+	if (rc == 0 && rename(tmp, dst) != 0)
+		rc = -1;
+	if (rc != 0)
+		unlink(tmp);			/* don't leave a partial temp behind */
 	return rc;
 }
 
@@ -221,6 +241,7 @@ local_read_layer_block(const PsLayerDesc *layer, uint64_t off,
 					   void *buf, uint32_t len)
 {
 	const char *path = NULL;
+	char		canon[4096];
 	int			fd;
 	ssize_t		n;
 	uint32_t	nlocs;
@@ -239,6 +260,18 @@ local_read_layer_block(const PsLayerDesc *layer, uint64_t off,
 			break;
 		}
 	}
+
+	/*
+	 * No available local location, but a just-downloaded layer lives at the
+	 * canonical local path even when the descriptor still marks its local copy
+	 * evicted (download takes a const desc and cannot flip the flag).  Fall back
+	 * to that path when the file is actually present, so a downloaded
+	 * remote-durable layer is readable through the layer store.
+	 */
+	if (path == NULL &&
+		local_layer_path(layer->layer_id, canon, sizeof(canon)) == 0 &&
+		access(canon, R_OK) == 0)
+		path = canon;
 
 	if (path == NULL)
 		return -1;

--- a/contrib/pagestore/pagestore_layer_store.c
+++ b/contrib/pagestore/pagestore_layer_store.c
@@ -241,7 +241,6 @@ local_read_layer_block(const PsLayerDesc *layer, uint64_t off,
 					   void *buf, uint32_t len)
 {
 	const char *path = NULL;
-	char		canon[4096];
 	int			fd;
 	ssize_t		n;
 	uint32_t	nlocs;
@@ -260,18 +259,6 @@ local_read_layer_block(const PsLayerDesc *layer, uint64_t off,
 			break;
 		}
 	}
-
-	/*
-	 * No available local location, but a just-downloaded layer lives at the
-	 * canonical local path even when the descriptor still marks its local copy
-	 * evicted (download takes a const desc and cannot flip the flag).  Fall back
-	 * to that path when the file is actually present, so a downloaded
-	 * remote-durable layer is readable through the layer store.
-	 */
-	if (path == NULL &&
-		local_layer_path(layer->layer_id, canon, sizeof(canon)) == 0 &&
-		access(canon, R_OK) == 0)
-		path = canon;
 
 	if (path == NULL)
 		return -1;
@@ -317,15 +304,26 @@ local_upload_layer(const PsLayerDesc *layer)
 	return object_fsync_dir();
 }
 
-/* Download a remote-durable layer back to its canonical local path. */
+/*
+ * Download a remote-durable layer back to its canonical local path and restore a
+ * usable local location, so readers (which require an available local location,
+ * with its size) can find it even after a durable eviction marked the old local
+ * copy unavailable.  Reuses an existing local-tier slot if present, else appends
+ * one; size comes from the downloaded file.
+ */
 static int
-local_download_layer(const PsLayerDesc *layer)
+local_download_layer(PsLayerDesc *layer)
 {
 	char		local[4096],
 				obj[4096];
+	struct stat st;
+	PsLayerLocation *loc = NULL;
+	bool		appended = false;
 
 	if (local_layer_path(layer->layer_id, local, sizeof(local)) != 0)
 		return -1;
+	if (strlen(local) >= PS_LAYER_URI_MAX)
+		return -1;				/* would not fit a location uri */
 	if (object_path(layer->layer_id, obj, sizeof(obj)) != 0)
 	{
 		errno = ENOTSUP;
@@ -333,7 +331,37 @@ local_download_layer(const PsLayerDesc *layer)
 	}
 	if (copy_file(obj, local) != 0)
 		return -1;
-	return local_fsync_dir();
+	if (local_fsync_dir() != 0 || stat(local, &st) != 0)
+		return -1;
+
+	/* find an existing local-tier slot to restore, else append one */
+	for (uint32_t i = 0; i < layer->location_count &&
+		 i < PS_LAYER_MAX_LOCATIONS; i++)
+		if (layer->locations[i].tier == PS_LAYER_TIER_LOCAL_HOT ||
+			layer->locations[i].tier == PS_LAYER_TIER_LOCAL_COLD)
+		{
+			loc = &layer->locations[i];
+			break;
+		}
+	if (loc == NULL)
+	{
+		if (layer->location_count >= PS_LAYER_MAX_LOCATIONS)
+			return -1;
+		loc = &layer->locations[layer->location_count++];
+		loc->tier = PS_LAYER_TIER_LOCAL_HOT;
+		loc->generation = 0;
+		appended = true;
+	}
+	if ((size_t) snprintf(loc->uri, sizeof(loc->uri), "%s", local)
+		>= sizeof(loc->uri))
+	{
+		if (appended)
+			layer->location_count--;
+		return -1;
+	}
+	loc->size = (uint64_t) st.st_size;
+	loc->available = true;
+	return 0;
 }
 
 /* Remove the layer's object-store copy (idempotent). */

--- a/contrib/pagestore/pagestore_layer_store.h
+++ b/contrib/pagestore/pagestore_layer_store.h
@@ -30,7 +30,9 @@ typedef struct PsLayerStore
 	int			(*read_layer_block) (const PsLayerDesc *layer, uint64_t off,
 									 void *buf, uint32_t len);
 	int			(*upload_layer) (const PsLayerDesc *layer);
-	int			(*download_layer) (const PsLayerDesc *layer);
+	/* downloads to the canonical local path and, on success, restores (or adds)
+	 * a usable available local location in *layer so readers can find it */
+	int			(*download_layer) (PsLayerDesc *layer);
 	int			(*delete_local_layer) (const PsLayerDesc *layer);
 	int			(*delete_remote_layer) (const PsLayerDesc *layer);
 	int			(*layer_exists_remote) (const PsLayerDesc *layer);

--- a/contrib/pagestore/pagestore_layer_store.h
+++ b/contrib/pagestore/pagestore_layer_store.h
@@ -43,7 +43,8 @@ extern const PsLayerStore *ps_layer_store;
  * Configure the object tier (LSM phase 4): 'dir' is the object store (a local
  * directory standing in for a remote bucket).  NULL/unset disables it, and the
  * upload/download/delete-remote ops then return ENOTSUP.  Call before open.
+ * Returns -1 (and disables the tier) if 'dir' is too long to store.
  */
-extern void ps_layer_store_set_object_dir(const char *dir);
+extern int	ps_layer_store_set_object_dir(const char *dir);
 
 #endif							/* PAGESTORE_LAYER_STORE_H */

--- a/contrib/pagestore/pagestore_layer_store.h
+++ b/contrib/pagestore/pagestore_layer_store.h
@@ -39,4 +39,11 @@ typedef struct PsLayerStore
 extern const PsLayerStore PsLayerStoreLocal;
 extern const PsLayerStore *ps_layer_store;
 
+/*
+ * Configure the object tier (LSM phase 4): 'dir' is the object store (a local
+ * directory standing in for a remote bucket).  NULL/unset disables it, and the
+ * upload/download/delete-remote ops then return ENOTSUP.  Call before open.
+ */
+extern void ps_layer_store_set_object_dir(const char *dir);
+
 #endif							/* PAGESTORE_LAYER_STORE_H */

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -392,6 +392,43 @@ main(void)
 		ps_layer_map_free(&map);
 	}
 
+	/* --- object tier (phase 4): upload / exists / evict-local / download --- */
+	{
+		char		objdir[] = "/tmp/psobjtestXXXXXX";
+		PsLayerDesc od;
+		PsImgRec	orecs[1] = {{k5, 0, 900, pg[2]}};	/* 0xA3 */
+
+		check(ps_image_layer_write(31, 0, orecs, 1, psz, &od) == 0,
+			  "obj: write layer");
+
+		/* with no object tier configured, the remote ops are unsupported */
+		check(ps_layer_store->upload_layer(&od) == -1, "obj: upload unsupported off");
+		check(ps_layer_store->layer_exists_remote(&od) == 0, "obj: not remote off");
+
+		check(mkdtemp(objdir) != NULL, "obj: mkdtemp");
+		ps_layer_store_set_object_dir(objdir);
+
+		check(ps_layer_store->layer_exists_remote(&od) == 0, "obj: absent before upload");
+		check(ps_layer_store->upload_layer(&od) == 0, "obj: upload");
+		check(ps_layer_store->layer_exists_remote(&od) == 1, "obj: present after upload");
+
+		/* drop the local copy, then download it back from the object store */
+		check(ps_layer_store->delete_local_layer(&od) == 0, "obj: drop local");
+		check(ps_image_layer_lookup(&od, &k5, 0, 1000, out, psz, NULL, NULL, NULL)
+			  == -1, "obj: read fails with no local copy");
+		check(ps_layer_store->download_layer(&od) == 0, "obj: download");
+		check(ps_image_layer_lookup(&od, &k5, 0, 1000, out, psz, NULL, NULL, NULL)
+			  == 1 && out[0] == 0xA3, "obj: read after download matches");
+
+		/* remote delete is idempotent and clears existence */
+		check(ps_layer_store->delete_remote_layer(&od) == 0, "obj: delete remote");
+		check(ps_layer_store->layer_exists_remote(&od) == 0, "obj: gone after delete");
+		check(ps_layer_store->delete_remote_layer(&od) == 0, "obj: delete remote idempotent");
+
+		ps_layer_store_set_object_dir(NULL);
+		rmdir(objdir);			/* empty after delete_remote (best-effort cleanup) */
+	}
+
 	fprintf(stderr, "%d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;
 }

--- a/contrib/pagestore/pagestore_layer_test.c
+++ b/contrib/pagestore/pagestore_layer_test.c
@@ -412,13 +412,23 @@ main(void)
 		check(ps_layer_store->upload_layer(&od) == 0, "obj: upload");
 		check(ps_layer_store->layer_exists_remote(&od) == 1, "obj: present after upload");
 
-		/* drop the local copy, then download it back from the object store */
-		check(ps_layer_store->delete_local_layer(&od) == 0, "obj: drop local");
+		/*
+		 * Simulate a durable local eviction: remove the file AND mark the local
+		 * location unavailable (as manifest replay of PS_MANIFEST_DROP_LOCAL
+		 * would).  The read path then bails on the missing available location
+		 * before any IO, so download must restore that location to make the
+		 * layer readable again -- not merely recreate the file.
+		 */
+		check(ps_layer_store->delete_local_layer(&od) == 0, "obj: drop local file");
+		for (uint32_t i = 0; i < od.location_count; i++)
+			if (od.locations[i].tier == PS_LAYER_TIER_LOCAL_HOT ||
+				od.locations[i].tier == PS_LAYER_TIER_LOCAL_COLD)
+				od.locations[i].available = false;
 		check(ps_image_layer_lookup(&od, &k5, 0, 1000, out, psz, NULL, NULL, NULL)
-			  == -1, "obj: read fails with no local copy");
+			  == -1, "obj: read fails after eviction (no available local loc)");
 		check(ps_layer_store->download_layer(&od) == 0, "obj: download");
 		check(ps_image_layer_lookup(&od, &k5, 0, 1000, out, psz, NULL, NULL, NULL)
-			  == 1 && out[0] == 0xA3, "obj: read after download matches");
+			  == 1 && out[0] == 0xA3, "obj: read after download (location restored)");
 
 		/* remote delete is idempotent and clears existence */
 		check(ps_layer_store->delete_remote_layer(&od) == 0, "obj: delete remote");


### PR DESCRIPTION
First slice of the **object tier** (LSM_OBJECT_STORAGE_PLAN phase 4): implement the layer store's remote ops, until now stubbed `local_unsupported_layer_op`. The object store is for now a **local directory standing in for a remote bucket** — `upload` copies a sealed layer file into it keyed by layer id, `download` copies it back; a real provider (S3, …) drops in behind these same four ops. Based on the merged sharding mainline.

## What
- `ps_layer_store_set_object_dir()` configures the tier (NULL/unset disables it — a daemon without an object tier is unchanged; the ops return `ENOTSUP`).
- `upload_layer` / `download_layer` / `delete_remote_layer` / `layer_exists_remote` now work against `<object_dir>/obj_<id>`, keyed by `layer_id` (symmetric with the local `layer_<id>` path), each durable (copy + fsync of the file and its dir).
- Layer unit test adds an object round-trip: upload → exists → drop the local copy (read then fails) → download → read matches → delete-remote (idempotent), plus the ops correctly report unsupported when no tier is configured.

The core does **not** upload yet — wiring sealed-layer upload + `remote_durable` marking into off-path maintenance is the next slice — so the daemon path is unchanged.

## Test
- Image-layer unit test **74/0** (+14 object-tier checks); standalone **297/0** (POSIX). SPDK unaffected (object tier not wired into the daemon yet; the new ops aren't called unless a dir is configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)