### PR TITLE
contrib/pagestore: per-shard SPDK worker threads (sharding step 5b)

### DIFF
--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -207,7 +207,21 @@ timeline tree under a brief coordination point, not on the read/write hot path.
        PostgreSQL engine; `pagestore_import` still fails fast on a multi-shard
        daemon (its per-shard routing is a later utility-side step).  Exercised by
        the in-engine integration suite (it is PG-side code, not standalone).
-5. **SPDK per-thread qpairs** so the async path scales per core.
+5. **SPDK per-thread qpairs** so the async path scales per core. ✅
+     - **5a — per-shard SPDK I/O state.** The SPDK backend's single qpair /
+       current-segment buffer / read DMA pool / segment count became a per-shard
+       `SpdkShard` array, indexed by `seg % nshards` (interleaved ids, as the POSIX
+       backend uses), so an op only ever touches its shard's state.  The control
+       device stays shared and read-only after open.  Behavior-preserving at
+       nshards == 1.
+     - **5b — per-shard SPDK worker threads.** The SPDK daemon spawns one worker
+       per shard, each with its own qpair + buffers, running the async
+       cross-channel loop on its own channel pool and draining its own qpair, with
+       the same single-owner guard (`ps_request_shard`) and spawn → publish-magic →
+       join lifecycle as the POSIX daemon (step 4c-iv).  `spdk_super` stores
+       per-shard segment counts; the `nshards == 1` clamp is gone.  Verified on the
+       real NVMe device: `nshards=4` brings up 4 workers and a write/read round-trip
+       across all four shards passes (0 mismatches).
 6. **Branch-create coordination** for the shared timeline tree.
 
 Each step is independently testable; step 2 is the big mechanical change and is

--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -304,5 +304,69 @@ contrib/pagestore/spdk_setup.sh
 - Does the daemon stay one `spdk_app`, or split (control-plane PG contrib +
   data-plane SPDK app)?  Leaning single app for now.
 - Hugepage reservation persistence across reboot (sysctl `vm.nr_hugepages`).
-</content>
-</invoke>
+
+## Why raw NVMe, not the SPDK blobstore
+
+The backend (`storage_spdk.c`) uses the **raw NVMe driver** (`spdk/nvme.h` +
+`spdk/env.h`): `spdk_nvme_probe`/`attach`, one `spdk_nvme_ctrlr_alloc_io_qpair`
+per shard, and `spdk_nvme_ns_cmd_read/write` against the namespace.  It is **not**
+built on the SPDK blobstore (`spdk/blob.h`, `spdk_bs_*`) and does not go through
+the bdev layer.
+
+- Segment id `S`, offset `O` maps **linearly** to device byte `S*segment_size+O`;
+  the current append segment is held in a DMA buffer and flushed on roll-over /
+  sync.  A small superblock `<store>/spdk_super` records each shard's segment
+  count (which segments hold data); `recover()` scans those to rebuild the index.
+- Rationale: the page store's upper half is already an LSM (memtable -> image /
+  delta layers, a persistent manifest, COW branches, an object tier).  It only
+  needs "append immutable segment bytes to a raw device and read them back by
+  offset."  The blobstore's blob allocation, cluster map, and metadata
+  persistence would duplicate — and could fight — our own manifest/layer
+  lifecycle.  The thinnest layer (raw namespace + linear map, all metadata ours)
+  matches the "follow ScyllaDB, stay lean" principle.
+- Cost / assumptions: we own sector alignment, segment-count durability, and space
+  reclamation; segments are fixed-size and laid out linearly, which is why
+  multi-shard uses interleaved seg ids (`shard + k*nshards`) to keep the id space
+  dense (a sparse map would punch large holes at `S*segment_size`).  We assume a
+  **single store owns the raw namespace exclusively**.  Thin provisioning,
+  device-level snapshots, or several stores sharing one disk would argue for the
+  blobstore (or a self-managed extent allocator) later.
+
+## Verification & recovery without a filesystem
+
+On the raw namespace there is no FS to provide file existence, atomic rename,
+directory durability, sparse-zero reads, or fsck.  What we cover ourselves, and
+the gaps that remain on the SPDK path:
+
+Covered:
+- **Which segments are valid** — `spdk_super` per-shard segment counts, written
+  from a post-flush snapshot at IMMEDSYNC (so it never advertises an unflushed
+  segment) and re-derived by `recover()`.  Geometry/`nshards` mismatch or a
+  legacy/foreign superblock is rejected (or migrated when `nshards==1`) instead of
+  treated as fresh.
+- **End-of-log within a segment** — each page record carries `SegRecHdr.magic`
+  (`SEGR`) + `len`; `recover()` replays until the first record that fails
+  `magic == SEG_MAGIC && len == page_size`, and a segment with no valid record is
+  the shard's end-of-log.
+- **Layer integrity** — image/delta layers are checksummed (`img_crc` per page +
+  footer `data_crc`/`index_crc` + `PS_IMG_MAGIC`), and compaction re-verifies a
+  page against its index crc.
+
+Gaps (worth closing before this path is trusted for durability):
+- **No per-record/per-page checksum on the segment path.**  `SegRecHdr` has magic
+  + len but no crc, and the SPDK daemon serves reads straight from segments
+  (`use_layers = 0`), so a torn write, bit rot, or — on a raw device that is *not*
+  zeroed — stale prior-tenant bytes that happen to carry a `SEGR` magic would be
+  replayed/served as a valid page with no detection.  An FS would mask the
+  last case (a never-written extent reads back as zeros); a raw namespace does
+  not.  Plan: add a crc over (header + page) to `SegRecHdr`, verify it in
+  `recover()` and on the SPDK read path, and treat a magic-match-but-crc-fail
+  record as end-of-log.
+- **No torn-write atomicity** beyond the magic sentinel: a partial record mid
+  segment with a plausible header is only caught once the crc above exists.
+- **No cross-structure consistency check (fsck-equivalent)** that the superblock
+  counts, the on-device segment contents, and the manifest's layers agree.
+- **Device hygiene**: nothing zeroes or generation-stamps a freshly claimed
+  namespace, so the stale-magic risk above is real on a reused disk.  Options: a
+  per-store generation/uuid stamped into each `SegRecHdr` (mismatch == end-of-log),
+  or trimming/zeroing the device region a store owns at first open.

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -20,6 +20,7 @@
  *-------------------------------------------------------------------------
  */
 #include <fcntl.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -43,7 +44,7 @@ static void
 on_signal(int sig)
 {
 	(void) sig;
-	stop_requested = 1;
+	__atomic_store_n(&stop_requested, 1, __ATOMIC_RELAXED);	/* seen by all workers */
 }
 
 /* per-block context for one async page read: lets the completion populate the
@@ -246,6 +247,68 @@ begin(uint32_t i, PsChannel *ch)
 	}
 }
 
+/* one per-shard worker thread (sharding step 5b): its own NVMe qpair + buffers */
+typedef struct Worker
+{
+	pthread_t	tid;
+	void	   *shm;
+	uint32_t	shard;			/* this worker's shard index */
+	uint32_t	first;			/* its channel pool: [first, first+count) */
+	uint32_t	count;
+} Worker;
+
+/*
+ * Async serve loop for one shard: scan only this shard's channel pool, begin each
+ * ready request (reads submit to this shard's qpair and stay 'active' until their
+ * completions publish DONE), and drive this shard's qpair completions.  Two
+ * workers never touch the same channel or the same qpair, so shards run the
+ * device concurrently with no shared mutable state.
+ */
+static void *
+spdk_worker_main(void *arg)
+{
+	Worker	   *w = arg;
+
+	while (!__atomic_load_n(&stop_requested, __ATOMIC_RELAXED))
+	{
+		int			work = 0;
+
+		for (uint32_t i = w->first; i < w->first + w->count; i++)
+		{
+			PsChannel  *ch = ps_channel(w->shm, i);
+			uint32_t	owner;
+
+			if (reqstate[i].active ||
+				ps_load_acquire(&ch->state) != PS_STATE_REQUEST)
+				continue;
+			/* single-owner guard (as the POSIX daemon): a keyed request always
+			 * belongs to this shard's pool; reject a misrouted one rather than
+			 * drive another shard's state/qpair from this thread.  PS_ANY_SHARD
+			 * ops (e.g. IMMEDSYNC) run anywhere. */
+			owner = ps_request_shard(ch);
+			if (owner != PS_ANY_SHARD && owner != w->shard)
+			{
+				ch->status = PS_STATUS_ERROR;
+				ps_store_release(&ch->state, PS_STATE_DONE);
+			}
+			else
+				begin(i, ch);	/* publishes DONE (sync) or via read_done (async) */
+			work = 1;
+		}
+
+		if (ps_spdk_poll(w->shard) > 0)
+			work = 1;
+
+		if (!work)
+		{
+			struct timespec ts = {0, 20000};	/* 20us */
+
+			nanosleep(&ts, NULL);
+		}
+	}
+	return NULL;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -299,20 +362,6 @@ main(int argc, char **argv)
 				PS_MAX_SHARDS, ps_nshards);
 		return 2;
 	}
-	/*
-	 * The SPDK backend maps a segment id linearly to a device offset and buffers
-	 * a single current segment, so multiple concurrent per-shard segment streams
-	 * would skew the id space (premature device-end), thrash that buffer, and
-	 * leave recoverable gaps on a reused device.  Multi-shard SPDK needs
-	 * per-thread qpairs + per-shard device regions (SHARDING.md step 5); until
-	 * then the SPDK daemon runs a single shard.
-	 */
-	if (ps_nshards != 1)
-	{
-		fprintf(stderr, "pagestore_daemon_spdk: multi-shard not supported on the "
-				"SPDK backend yet (SHARDING.md step 5); using --nshards 1\n");
-		ps_nshards = 1;
-	}
 	if (pci_addr)
 		setenv("PS_SPDK_PCI", pci_addr, 1);
 
@@ -353,51 +402,57 @@ main(int argc, char **argv)
 	hdr->nshards = ps_nshards;	/* clients route to the same shard pools */
 	hdr->channel_stride = PS_CHANNEL_STRIDE;
 	hdr->channels_off = PS_CHANNELS_OFF;
-	/* publish magic with a release store so the readers' acquire-load of it has a
-	 * matching release on the same field, giving a happens-before edge for the
-	 * descriptive fields written above */
-	ps_store_release(&hdr->magic, PS_SHM_MAGIC);
 
 	memset(&sa, 0, sizeof(sa));
 	sa.sa_handler = on_signal;
 	sigaction(SIGINT, &sa, NULL);
 	sigaction(SIGTERM, &sa, NULL);
 
-	fprintf(stderr, "pagestore_daemon_spdk: shm=%s store=%s storage=%s "
-			"page_size=%u io_unit=%u channels=%d ready\n",
-			shm_name, store_dir, ps_storage->name, page_size, PS_IO_UNIT,
-			PS_MAX_CHANNELS);
-
 	/*
-	 * Cross-channel async loop: start every ready request that is not already in
-	 * flight, then drive NVMe completions.  Read requests stay "active" until
-	 * their completions publish DONE, so many overlap on the queue.
+	 * One worker thread per shard, each with its own NVMe qpair (allocated by
+	 * spdk_open) and channel pool, running the async cross-channel loop on its own
+	 * shard.  Magic is published only after every worker exists, so a client that
+	 * sees the shm ready knows all shards are being served.
 	 */
-	while (!stop_requested)
 	{
-		int			work = 0;
+		Worker	   *workers = calloc(ps_nshards, sizeof(Worker));
 
-		for (uint32_t i = 0; i < PS_MAX_CHANNELS; i++)
+		if (!workers)
 		{
-			PsChannel  *ch = ps_channel(shm, i);
-
-			if (!reqstate[i].active &&
-				ps_load_acquire(&ch->state) == PS_STATE_REQUEST)
+			perror("calloc workers");
+			return 1;
+		}
+		for (uint32_t s = 0; s < ps_nshards; s++)
+		{
+			workers[s].shm = shm;
+			workers[s].shard = s;
+			ps_shard_channel_range(s, ps_nshards, PS_MAX_CHANNELS,
+								   &workers[s].first, &workers[s].count);
+			if (pthread_create(&workers[s].tid, NULL, spdk_worker_main,
+							   &workers[s]) != 0)
 			{
-				begin(i, ch);
-				work = 1;
+				perror("pthread_create");
+				/* magic not yet published, so no client treats the shm as ready;
+				 * stop the workers already started and bail */
+				__atomic_store_n(&stop_requested, 1, __ATOMIC_RELAXED);
+				for (uint32_t j = 0; j < s; j++)
+					pthread_join(workers[j].tid, NULL);
+				free(workers);
+				return 1;
 			}
 		}
 
-		if (ps_spdk_poll(0) > 0)	/* single shard for now (step 5a) */
-			work = 1;
+		/* all workers exist: publish magic with a release store (readers' acquire
+		 * pairs with it), making the shm ready to serve */
+		ps_store_release(&hdr->magic, PS_SHM_MAGIC);
+		fprintf(stderr, "pagestore_daemon_spdk: shm=%s store=%s storage=%s "
+				"page_size=%u io_unit=%u channels=%d nshards=%u ready\n",
+				shm_name, store_dir, ps_storage->name, page_size, PS_IO_UNIT,
+				PS_MAX_CHANNELS, ps_nshards);
 
-		if (!work)
-		{
-			struct timespec ts = {0, 20000};	/* 20us */
-
-			nanosleep(&ts, NULL);
-		}
+		for (uint32_t s = 0; s < ps_nshards; s++)
+			pthread_join(workers[s].tid, NULL);
+		free(workers);
 	}
 
 	{

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -79,26 +79,55 @@ static ReqState reqstate[PS_MAX_CHANNELS];
  * curbuf when it sees its flag set.  g_super_mtx serializes the superblock write
  * so two concurrent syncs can't corrupt it.
  */
-static volatile int g_flush_req[PS_MAX_SHARDS];
+static volatile int g_flush_req[PS_MAX_SHARDS];		/* 1 = flush requested */
+static volatile int g_flush_rc[PS_MAX_SHARDS];		/* 0 ok / -1 failed flush */
+static volatile uint32_t g_flush_snap[PS_MAX_SHARDS];	/* seg count at flush */
 static pthread_mutex_t g_super_mtx = PTHREAD_MUTEX_INITIALIZER;
 
-/* Durability barrier for one IMMEDSYNC, run by the receiving worker 'w'. */
+/* Flush this shard's own buffer, recording the result + post-flush count where
+ * the barrier coordinator collects them. */
 static void
+flush_self(uint32_t shard)
+{
+	uint32_t	cnt = 0;
+	int			rc = ps_spdk_flush(shard, &cnt);
+
+	g_flush_snap[shard] = cnt;
+	g_flush_rc[shard] = rc;
+}
+
+/*
+ * Durability barrier for one IMMEDSYNC, run by the receiving worker for 'shard'.
+ * Each shard can only flush its own qpair, so request every other shard to flush
+ * itself and wait; the persisted superblock uses each shard's post-flush count
+ * snapshot, never a live counter a concurrent writer advanced.  Returns 0 if all
+ * shards flushed durably, -1 if any flush failed or shutdown aborted the wait
+ * (so the client learns the sync did not complete).
+ */
+static int
 immedsync_barrier(uint32_t shard)
 {
-	ps_spdk_flush(shard);		/* this worker's own shard */
+	uint32_t	counts[PS_MAX_SHARDS];
+	int			rc = 0;
+
+	flush_self(shard);			/* this worker's own shard */
 	for (uint32_t s = 0; s < ps_nshards; s++)
 		if (s != shard)
+		{
+			g_flush_rc[s] = 0;
 			__atomic_store_n(&g_flush_req[s], 1, __ATOMIC_RELEASE);
+		}
 	for (;;)
 	{
 		int			pending = 0;
 
+		if (__atomic_load_n(&stop_requested, __ATOMIC_RELAXED))
+			return -1;			/* shutdown: abort rather than spin forever */
 		/* service a request aimed at us too, so two concurrent syncs (each
 		 * waiting on the other) cannot deadlock */
 		if (__atomic_load_n(&g_flush_req[shard], __ATOMIC_ACQUIRE))
 		{
-			ps_spdk_flush(shard);
+			flush_self(shard);
 			__atomic_store_n(&g_flush_req[shard], 0, __ATOMIC_RELEASE);
 		}
 		for (uint32_t s = 0; s < ps_nshards; s++)
@@ -112,10 +141,18 @@ immedsync_barrier(uint32_t shard)
 			nanosleep(&ts, NULL);
 		}
 	}
-	/* persist the per-shard segment counts once, serialized */
+	/* collect each shard's flush result + post-flush count snapshot */
+	for (uint32_t s = 0; s < ps_nshards; s++)
+	{
+		if (g_flush_rc[s] != 0)
+			rc = -1;
+		counts[s] = g_flush_snap[s];
+	}
+	/* persist the snapshot once, serialized against a concurrent sync */
 	pthread_mutex_lock(&g_super_mtx);
-	ps_spdk_super_sync();
+	ps_spdk_super_write_counts(counts);
 	pthread_mutex_unlock(&g_super_mtx);
+	return rc;
 }
 
 /* one page read finished: cache the page, and when the last of a request lands
@@ -337,9 +374,11 @@ spdk_worker_main(void *arg)
 			{
 				/* global durability barrier: each shard flushes its own qpair
 				 * (begin()->spdk_sync would flush every shard from this one
-				 * thread, racing the other shards' single-owner qpairs) */
-				immedsync_barrier(w->shard);
-				ch->status = PS_STATUS_OK;
+				 * thread, racing the other shards' single-owner qpairs).  Report
+				 * a failed/aborted barrier so the client doesn't believe the data
+				 * is durable. */
+				ch->status = immedsync_barrier(w->shard) == 0 ?
+					PS_STATUS_OK : PS_STATUS_ERROR;
 				ps_store_release(&ch->state, PS_STATE_DONE);
 			}
 			else if (owner != PS_ANY_SHARD && owner != w->shard)
@@ -352,10 +391,11 @@ spdk_worker_main(void *arg)
 			work = 1;
 		}
 
-		/* flush our own shard if another shard's IMMEDSYNC barrier requested it */
+		/* flush our own shard if another shard's IMMEDSYNC barrier requested it
+		 * (records the result + post-flush count the coordinator collects) */
 		if (__atomic_load_n(&g_flush_req[w->shard], __ATOMIC_ACQUIRE))
 		{
-			ps_spdk_flush(w->shard);
+			flush_self(w->shard);
 			__atomic_store_n(&g_flush_req[w->shard], 0, __ATOMIC_RELEASE);
 			work = 1;
 		}

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -76,13 +76,22 @@ static ReqState reqstate[PS_MAX_CHANNELS];
  * by its own worker, so a global durability barrier can't flush every shard from
  * one thread.  Instead the worker that receives IMMEDSYNC flushes its own shard
  * and sets g_flush_req[s] for every other shard; each worker flushes its own
- * curbuf when it sees its flag set.  g_super_mtx serializes the superblock write
- * so two concurrent syncs can't corrupt it.
+ * curbuf when it sees its flag set.  The whole barrier runs under g_barrier_mtx
+ * (below), so only one coordinator owns these per-shard slots at a time.
  */
 static volatile int g_flush_req[PS_MAX_SHARDS];		/* 1 = flush requested */
 static volatile int g_flush_rc[PS_MAX_SHARDS];		/* 0 ok / -1 failed flush */
 static volatile uint32_t g_flush_snap[PS_MAX_SHARDS];	/* seg count at flush */
-static pthread_mutex_t g_super_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+/*
+ * Serializes the whole IMMEDSYNC barrier so two concurrent syncs can't share the
+ * per-shard flush slots above (one resetting another's result/snapshot mid-flight
+ * and turning a failed flush into a false success).  The worker TRYLOCKs this
+ * rather than blocking: a worker that can't start its own barrier returns to its
+ * loop and keeps servicing the active barrier's flush requests, which is what
+ * prevents a deadlock between a coordinator and a would-be coordinator.
+ */
+static pthread_mutex_t g_barrier_mtx = PTHREAD_MUTEX_INITIALIZER;
 
 /* Flush this shard's own buffer, recording the result + post-flush count where
  * the barrier coordinator collects them. */
@@ -97,12 +106,14 @@ flush_self(uint32_t shard)
 }
 
 /*
- * Durability barrier for one IMMEDSYNC, run by the receiving worker for 'shard'.
- * Each shard can only flush its own qpair, so request every other shard to flush
- * itself and wait; the persisted superblock uses each shard's post-flush count
- * snapshot, never a live counter a concurrent writer advanced.  Returns 0 if all
- * shards flushed durably, -1 if any flush failed or shutdown aborted the wait
- * (so the client learns the sync did not complete).
+ * Durability barrier for one IMMEDSYNC, run by the receiving worker for 'shard'
+ * while holding g_barrier_mtx (so it owns the flush slots exclusively).  Each
+ * shard can only flush its own qpair, so request every other shard to flush
+ * itself and wait.  The superblock is persisted from each shard's post-flush
+ * count snapshot, and ONLY when every shard flushed: a failed flush leaves a
+ * count covering data that never reached the device, which recover() must not
+ * trust.  Returns 0 if all shards flushed durably, -1 if any failed or shutdown
+ * aborted the wait.
  */
 static int
 immedsync_barrier(uint32_t shard)
@@ -123,13 +134,6 @@ immedsync_barrier(uint32_t shard)
 
 		if (__atomic_load_n(&stop_requested, __ATOMIC_RELAXED))
 			return -1;			/* shutdown: abort rather than spin forever */
-		/* service a request aimed at us too, so two concurrent syncs (each
-		 * waiting on the other) cannot deadlock */
-		if (__atomic_load_n(&g_flush_req[shard], __ATOMIC_ACQUIRE))
-		{
-			flush_self(shard);
-			__atomic_store_n(&g_flush_req[shard], 0, __ATOMIC_RELEASE);
-		}
 		for (uint32_t s = 0; s < ps_nshards; s++)
 			if (s != shard && __atomic_load_n(&g_flush_req[s], __ATOMIC_ACQUIRE))
 				pending = 1;
@@ -148,10 +152,8 @@ immedsync_barrier(uint32_t shard)
 			rc = -1;
 		counts[s] = g_flush_snap[s];
 	}
-	/* persist the snapshot once, serialized against a concurrent sync */
-	pthread_mutex_lock(&g_super_mtx);
-	ps_spdk_super_write_counts(counts);
-	pthread_mutex_unlock(&g_super_mtx);
+	if (rc == 0)				/* never advance the super past a failed flush */
+		ps_spdk_super_write_counts(counts);
 	return rc;
 }
 
@@ -374,12 +376,20 @@ spdk_worker_main(void *arg)
 			{
 				/* global durability barrier: each shard flushes its own qpair
 				 * (begin()->spdk_sync would flush every shard from this one
-				 * thread, racing the other shards' single-owner qpairs).  Report
-				 * a failed/aborted barrier so the client doesn't believe the data
-				 * is durable. */
-				ch->status = immedsync_barrier(w->shard) == 0 ?
-					PS_STATUS_OK : PS_STATUS_ERROR;
-				ps_store_release(&ch->state, PS_STATE_DONE);
+				 * thread, racing the other shards' single-owner qpairs).  Trylock
+				 * to serialize barriers; if another barrier holds it, leave this
+				 * request pending and retry next iteration -- staying in the loop so
+				 * we keep servicing that barrier's flush request below (blocking
+				 * here would deadlock it).  Report a failed/aborted barrier so the
+				 * client doesn't believe the data is durable. */
+				if (pthread_mutex_trylock(&g_barrier_mtx) == 0)
+				{
+					int			brc = immedsync_barrier(w->shard);
+
+					pthread_mutex_unlock(&g_barrier_mtx);
+					ch->status = brc == 0 ? PS_STATUS_OK : PS_STATUS_ERROR;
+					ps_store_release(&ch->state, PS_STATE_DONE);
+				}
 			}
 			else if (owner != PS_ANY_SHARD && owner != w->shard)
 			{

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -71,6 +71,53 @@ typedef struct ReqState
 
 static ReqState reqstate[PS_MAX_CHANNELS];
 
+/*
+ * Cross-shard IMMEDSYNC coordination.  A shard's curbuf/qpair may only be touched
+ * by its own worker, so a global durability barrier can't flush every shard from
+ * one thread.  Instead the worker that receives IMMEDSYNC flushes its own shard
+ * and sets g_flush_req[s] for every other shard; each worker flushes its own
+ * curbuf when it sees its flag set.  g_super_mtx serializes the superblock write
+ * so two concurrent syncs can't corrupt it.
+ */
+static volatile int g_flush_req[PS_MAX_SHARDS];
+static pthread_mutex_t g_super_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+/* Durability barrier for one IMMEDSYNC, run by the receiving worker 'w'. */
+static void
+immedsync_barrier(uint32_t shard)
+{
+	ps_spdk_flush(shard);		/* this worker's own shard */
+	for (uint32_t s = 0; s < ps_nshards; s++)
+		if (s != shard)
+			__atomic_store_n(&g_flush_req[s], 1, __ATOMIC_RELEASE);
+	for (;;)
+	{
+		int			pending = 0;
+
+		/* service a request aimed at us too, so two concurrent syncs (each
+		 * waiting on the other) cannot deadlock */
+		if (__atomic_load_n(&g_flush_req[shard], __ATOMIC_ACQUIRE))
+		{
+			ps_spdk_flush(shard);
+			__atomic_store_n(&g_flush_req[shard], 0, __ATOMIC_RELEASE);
+		}
+		for (uint32_t s = 0; s < ps_nshards; s++)
+			if (s != shard && __atomic_load_n(&g_flush_req[s], __ATOMIC_ACQUIRE))
+				pending = 1;
+		if (!pending)
+			break;
+		{
+			struct timespec ts = {0, 20000};	/* 20us */
+
+			nanosleep(&ts, NULL);
+		}
+	}
+	/* persist the per-shard segment counts once, serialized */
+	pthread_mutex_lock(&g_super_mtx);
+	ps_spdk_super_sync();
+	pthread_mutex_unlock(&g_super_mtx);
+}
+
 /* one page read finished: cache the page, and when the last of a request lands
  * publish the reply */
 static void
@@ -286,13 +333,30 @@ spdk_worker_main(void *arg)
 			 * drive another shard's state/qpair from this thread.  PS_ANY_SHARD
 			 * ops (e.g. IMMEDSYNC) run anywhere. */
 			owner = ps_request_shard(ch);
-			if (owner != PS_ANY_SHARD && owner != w->shard)
+			if (ch->opcode == PS_OP_IMMEDSYNC)
+			{
+				/* global durability barrier: each shard flushes its own qpair
+				 * (begin()->spdk_sync would flush every shard from this one
+				 * thread, racing the other shards' single-owner qpairs) */
+				immedsync_barrier(w->shard);
+				ch->status = PS_STATUS_OK;
+				ps_store_release(&ch->state, PS_STATE_DONE);
+			}
+			else if (owner != PS_ANY_SHARD && owner != w->shard)
 			{
 				ch->status = PS_STATUS_ERROR;
 				ps_store_release(&ch->state, PS_STATE_DONE);
 			}
 			else
 				begin(i, ch);	/* publishes DONE (sync) or via read_done (async) */
+			work = 1;
+		}
+
+		/* flush our own shard if another shard's IMMEDSYNC barrier requested it */
+		if (__atomic_load_n(&g_flush_req[w->shard], __ATOMIC_ACQUIRE))
+		{
+			ps_spdk_flush(w->shard);
+			__atomic_store_n(&g_flush_req[w->shard], 0, __ATOMIC_RELEASE);
 			work = 1;
 		}
 

--- a/contrib/pagestore/storage_spdk.c
+++ b/contrib/pagestore/storage_spdk.c
@@ -66,14 +66,15 @@ typedef struct PsSpdkRd
 	void	   *arg;
 } PsSpdkRd;
 
-#define SPDK_SUPER_MAGIC	0x53504b53	/* "SPKS" */
+#define SPDK_SUPER_MAGIC	0x53504b54	/* "SPKT" (per-shard segment counts) */
 
 typedef struct SpdkSuper
 {
 	uint32_t	magic;
 	uint32_t	sector_size;
 	uint64_t	segment_size;
-	uint32_t	num_segments;
+	uint32_t	nshards;		/* the store's shard count (must match to reuse) */
+	uint32_t	num_segments[PS_MAX_SHARDS];	/* per-shard local segment count */
 } SpdkSuper;
 
 /*
@@ -178,11 +179,16 @@ static void
 super_write(void)
 {
 	char		path[2300];
-	/* single shard for now (step 5a); per-shard counts arrive with multi-shard
-	 * SPDK in step 5b */
-	SpdkSuper	s = {SPDK_SUPER_MAGIC, g_sector, g_segsize,
-		g_spdk[0].num_segments};
+	SpdkSuper	s;
 	FILE	   *f;
+
+	memset(&s, 0, sizeof(s));
+	s.magic = SPDK_SUPER_MAGIC;
+	s.sector_size = g_sector;
+	s.segment_size = g_segsize;
+	s.nshards = g_nshards;
+	for (uint32_t sh = 0; sh < g_nshards; sh++)
+		s.num_segments[sh] = g_spdk[sh].num_segments;
 
 	super_path(path, sizeof(path));
 	f = fopen(path, "wb");
@@ -199,14 +205,19 @@ super_read(void)
 	SpdkSuper	s;
 	FILE	   *f;
 
-	g_spdk[0].num_segments = 0;	/* default: fresh store */
+	for (uint32_t sh = 0; sh < g_nshards; sh++)
+		g_spdk[sh].num_segments = 0;	/* default: fresh store */
 	super_path(path, sizeof(path));
 	f = fopen(path, "rb");
 	if (!f)
 		return;
+	/* reuse the on-device data only if geometry AND shard count match (a different
+	 * nshards reinterprets the interleaved seg-id space, so treat it as fresh) */
 	if (fread(&s, sizeof(s), 1, f) == 1 && s.magic == SPDK_SUPER_MAGIC &&
-		s.sector_size == g_sector && s.segment_size == g_segsize)
-		g_spdk[0].num_segments = s.num_segments;
+		s.sector_size == g_sector && s.segment_size == g_segsize &&
+		s.nshards == g_nshards)
+		for (uint32_t sh = 0; sh < g_nshards; sh++)
+			g_spdk[sh].num_segments = s.num_segments[sh];
 	fclose(f);
 }
 

--- a/contrib/pagestore/storage_spdk.c
+++ b/contrib/pagestore/storage_spdk.c
@@ -67,6 +67,7 @@ typedef struct PsSpdkRd
 } PsSpdkRd;
 
 #define SPDK_SUPER_MAGIC	0x53504b54	/* "SPKT" (per-shard segment counts) */
+#define SPDK_SUPER_MAGIC_V1 0x53504b53	/* "SPKS" (legacy single segment count) */
 
 typedef struct SpdkSuper
 {
@@ -76,6 +77,15 @@ typedef struct SpdkSuper
 	uint32_t	nshards;		/* the store's shard count (must match to reuse) */
 	uint32_t	num_segments[PS_MAX_SHARDS];	/* per-shard local segment count */
 } SpdkSuper;
+
+/* legacy on-disk superblock (pre-step-5b): one global segment count, no nshards */
+typedef struct SpdkSuperV1
+{
+	uint32_t	magic;
+	uint32_t	sector_size;
+	uint64_t	segment_size;
+	uint32_t	num_segments;
+} SpdkSuperV1;
 
 /*
  * Per-shard I/O state (sharding step 5).  Each shard's worker thread owns its own
@@ -198,11 +208,17 @@ super_write(void)
 	fclose(f);
 }
 
-static void
+/*
+ * Load the persisted per-shard segment counts.  Returns 0 on success (fresh
+ * store, current format, or a migrated legacy single-shard store) and -1 on an
+ * incompatible superblock, so the caller fails the open rather than silently
+ * treating existing on-device data as fresh and overwriting it.
+ */
+static int
 super_read(void)
 {
 	char		path[2300];
-	SpdkSuper	s;
+	uint32_t	magic;
 	FILE	   *f;
 
 	for (uint32_t sh = 0; sh < g_nshards; sh++)
@@ -210,15 +226,49 @@ super_read(void)
 	super_path(path, sizeof(path));
 	f = fopen(path, "rb");
 	if (!f)
-		return;
-	/* reuse the on-device data only if geometry AND shard count match (a different
-	 * nshards reinterprets the interleaved seg-id space, so treat it as fresh) */
-	if (fread(&s, sizeof(s), 1, f) == 1 && s.magic == SPDK_SUPER_MAGIC &&
-		s.sector_size == g_sector && s.segment_size == g_segsize &&
-		s.nshards == g_nshards)
-		for (uint32_t sh = 0; sh < g_nshards; sh++)
-			g_spdk[sh].num_segments = s.num_segments[sh];
+		return 0;				/* no super -> fresh store */
+	if (fread(&magic, sizeof(magic), 1, f) != 1)
+	{
+		fclose(f);
+		return -1;				/* unreadable/corrupt */
+	}
+	rewind(f);
+
+	if (magic == SPDK_SUPER_MAGIC)
+	{
+		SpdkSuper	s;
+
+		/* reuse the on-device data only if geometry AND shard count match -- a
+		 * different nshards reinterprets the interleaved seg-id space */
+		if (fread(&s, sizeof(s), 1, f) == 1 && s.sector_size == g_sector &&
+			s.segment_size == g_segsize && s.nshards == g_nshards)
+		{
+			for (uint32_t sh = 0; sh < g_nshards; sh++)
+				g_spdk[sh].num_segments = s.num_segments[sh];
+			fclose(f);
+			return 0;
+		}
+		fclose(f);
+		return -1;				/* current format but mismatched geometry/nshards */
+	}
+	if (magic == SPDK_SUPER_MAGIC_V1)
+	{
+		SpdkSuperV1 v1;
+
+		/* legacy single-count store is only meaningful at nshards == 1 (seg ids
+		 * were 0,1,2,...); migrate it, else refuse rather than lose the data */
+		if (g_nshards == 1 && fread(&v1, sizeof(v1), 1, f) == 1 &&
+			v1.sector_size == g_sector && v1.segment_size == g_segsize)
+		{
+			g_spdk[0].num_segments = v1.num_segments;
+			fclose(f);
+			return 0;
+		}
+		fclose(f);
+		return -1;
+	}
 	fclose(f);
+	return -1;					/* unknown magic */
 }
 
 /* --- current-segment buffer management ----------------------------------- */
@@ -361,7 +411,12 @@ spdk_open(const char *path, uint64_t segment_size)
 		S->nfree = PS_SPDK_POOL;
 	}
 
-	super_read();				/* segment count: fresh dir -> 0 */
+	if (super_read() != 0)		/* segment counts: fresh dir -> 0, else load/migrate */
+	{
+		fprintf(stderr, "storage_spdk: incompatible spdk_super "
+				"(format/geometry/nshards mismatch); refusing to open\n");
+		return -1;
+	}
 
 	fprintf(stderr, "storage_spdk: %s ns1 sector=%u segsize=%llu segments=%u "
 			"nshards=%u\n", pci, g_sector, (unsigned long long) g_segsize,
@@ -564,6 +619,29 @@ ps_spdk_poll(uint32_t shard)
 	if (shard >= g_nshards)
 		return 0;
 	return spdk_nvme_qpair_process_completions(g_spdk[shard].qpair, 0);
+}
+
+/*
+ * Flush one shard's current-segment buffer to the device.  Must be called from
+ * that shard's own worker thread (it drives the shard's qpair), which is how the
+ * SPDK daemon coordinates a cross-shard IMMEDSYNC: each shard flushes itself.
+ */
+int
+ps_spdk_flush(uint32_t shard)
+{
+	if (shard >= g_nshards)
+		return 0;
+	return flush_curbuf(&g_spdk[shard]);
+}
+
+/* Persist the per-shard segment counts (the superblock).  Called once, by the
+ * worker coordinating an IMMEDSYNC, after every shard has flushed; the counts
+ * only grow and a short/empty trailing segment reads as end-of-log, so a count
+ * that a concurrent append nudged up is safe for recover(). */
+void
+ps_spdk_super_sync(void)
+{
+	super_write();
 }
 
 /* --- WAL + timeline metadata: delegated to the POSIX backend ------------- */

--- a/contrib/pagestore/storage_spdk.c
+++ b/contrib/pagestore/storage_spdk.c
@@ -185,8 +185,11 @@ super_path(char *buf, size_t buflen)
 	snprintf(buf, buflen, "%s/spdk_super", g_store);
 }
 
+/* Write the superblock from an explicit per-shard segment-count array, so the
+ * IMMEDSYNC coordinator can persist a consistent post-flush snapshot rather than
+ * the live counters that concurrent shard writers keep advancing. */
 static void
-super_write(void)
+super_write_counts(const uint32_t *counts)
 {
 	char		path[2300];
 	SpdkSuper	s;
@@ -198,7 +201,7 @@ super_write(void)
 	s.segment_size = g_segsize;
 	s.nshards = g_nshards;
 	for (uint32_t sh = 0; sh < g_nshards; sh++)
-		s.num_segments[sh] = g_spdk[sh].num_segments;
+		s.num_segments[sh] = counts[sh];
 
 	super_path(path, sizeof(path));
 	f = fopen(path, "wb");
@@ -206,6 +209,17 @@ super_write(void)
 		return;					/* best-effort */
 	fwrite(&s, sizeof(s), 1, f);
 	fclose(f);
+}
+
+/* Superblock from the live counters; safe at close (main thread, workers joined). */
+static void
+super_write(void)
+{
+	uint32_t	counts[PS_MAX_SHARDS];
+
+	for (uint32_t sh = 0; sh < g_nshards; sh++)
+		counts[sh] = g_spdk[sh].num_segments;
+	super_write_counts(counts);
 }
 
 /*
@@ -625,23 +639,29 @@ ps_spdk_poll(uint32_t shard)
  * Flush one shard's current-segment buffer to the device.  Must be called from
  * that shard's own worker thread (it drives the shard's qpair), which is how the
  * SPDK daemon coordinates a cross-shard IMMEDSYNC: each shard flushes itself.
+ * On return *out_count (if non-NULL) holds that shard's segment count AS OF the
+ * flush, so the coordinator can persist a count covering exactly the flushed data
+ * even if the shard appends more afterwards.
  */
 int
-ps_spdk_flush(uint32_t shard)
+ps_spdk_flush(uint32_t shard, uint32_t *out_count)
 {
-	if (shard >= g_nshards)
-		return 0;
-	return flush_curbuf(&g_spdk[shard]);
+	int			rc = 0;
+
+	if (shard < g_nshards)
+		rc = flush_curbuf(&g_spdk[shard]);
+	if (out_count)
+		*out_count = (shard < g_nshards) ? g_spdk[shard].num_segments : 0;
+	return rc;
 }
 
-/* Persist the per-shard segment counts (the superblock).  Called once, by the
- * worker coordinating an IMMEDSYNC, after every shard has flushed; the counts
- * only grow and a short/empty trailing segment reads as end-of-log, so a count
- * that a concurrent append nudged up is safe for recover(). */
+/* Persist the superblock from a caller-supplied per-shard count snapshot (taken
+ * at flush time by ps_spdk_flush), so the persisted counts cover exactly the
+ * flushed data and never a segment a concurrent writer added but did not flush. */
 void
-ps_spdk_super_sync(void)
+ps_spdk_super_write_counts(const uint32_t *counts)
 {
-	super_write();
+	super_write_counts(counts);
 }
 
 /* --- WAL + timeline metadata: delegated to the POSIX backend ------------- */

--- a/contrib/pagestore/storage_spdk.h
+++ b/contrib/pagestore/storage_spdk.h
@@ -36,4 +36,12 @@ extern int	ps_spdk_read_async(int seg, uint64_t off, void *dst, uint32_t len,
  * Each shard's worker polls only its own qpair (sharding step 5). */
 extern int	ps_spdk_poll(uint32_t shard);
 
+/* Flush one shard's current-segment buffer; call from that shard's worker thread
+ * (drives the shard's qpair).  Used to coordinate a cross-shard IMMEDSYNC. */
+extern int	ps_spdk_flush(uint32_t shard);
+
+/* Persist the per-shard segment counts (superblock); call once after all shards
+ * have flushed for an IMMEDSYNC. */
+extern void ps_spdk_super_sync(void);
+
 #endif							/* STORAGE_SPDK_H */

--- a/contrib/pagestore/storage_spdk.h
+++ b/contrib/pagestore/storage_spdk.h
@@ -37,11 +37,13 @@ extern int	ps_spdk_read_async(int seg, uint64_t off, void *dst, uint32_t len,
 extern int	ps_spdk_poll(uint32_t shard);
 
 /* Flush one shard's current-segment buffer; call from that shard's worker thread
- * (drives the shard's qpair).  Used to coordinate a cross-shard IMMEDSYNC. */
-extern int	ps_spdk_flush(uint32_t shard);
+ * (drives the shard's qpair).  *out_count (if non-NULL) returns the shard's
+ * segment count as of the flush, for a consistent superblock snapshot.  Used to
+ * coordinate a cross-shard IMMEDSYNC. */
+extern int	ps_spdk_flush(uint32_t shard, uint32_t *out_count);
 
-/* Persist the per-shard segment counts (superblock); call once after all shards
- * have flushed for an IMMEDSYNC. */
-extern void ps_spdk_super_sync(void);
+/* Persist the superblock from a per-shard count snapshot (from ps_spdk_flush);
+ * call once after all shards have flushed for an IMMEDSYNC. */
+extern void ps_spdk_super_write_counts(const uint32_t *counts);
 
 #endif							/* STORAGE_SPDK_H */


### PR DESCRIPTION
Completes **sharding step 5 (multi-shard SPDK)** on top of #28's per-shard I/O state. Mirrors the POSIX per-shard worker model (#24). Stacked on #28.

## What
- **One worker thread per shard**, each running the async cross-channel loop over its own `ps_shard_channel_range` pool, submitting reads to its own qpair and draining only its own qpair (`ps_spdk_poll(shard)`). Two workers never touch the same channel or qpair, so shards drive the device concurrently; the seg-id interleave (5a) guarantees a worker's ops only ever hit its own qpair (SPDK requires single-thread qpair use).
- Same **single-owner guard** as the POSIX daemon (`ps_request_shard` → its shard or `PS_ANY_SHARD`, else reject), and the same **spawn-all → publish-magic → join** lifecycle with an atomic stop flag.
- `spdk_super` now stores **per-shard segment counts** (magic bumped); a store is reused only when geometry AND `nshards` match.
- The `nshards=1` clamp is **removed**.
- `recover()` runs on the main thread before any worker spawns, so its sequential use of each shard's qpair never races a worker.

## Test
Verified on the real NVMe device (`0000:06:00.0`):
- `--nshards 4` brings up **4 worker threads** (`nshards=4 ready`) and a per-shard-routed write/read round-trip across all four shards **passes (0 mismatches across 4 shards)**.
- The per-shard `spdk_super` is written on shutdown (280 B, new format).
- Compiles clean against SPDK (`-Wall -Wextra`).

> Restart/recovery uses the unchanged core `recover()` path (the POSIX nshards=4 standalone suite covers per-shard segment recovery); deeper SPDK restart-cycle testing was limited by device-environment wedging this session. CI does not build the SPDK backend, so local compile + device run is the build check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)