### PR TITLE
contrib/pagestore: cross-shard branch coordination test + docs (sharding step 6)

### DIFF
--- a/contrib/pagestore/SHARDING.md
+++ b/contrib/pagestore/SHARDING.md
@@ -222,7 +222,17 @@ timeline tree under a brief coordination point, not on the read/write hot path.
        per-shard segment counts; the `nshards == 1` clamp is gone.  Verified on the
        real NVMe device: `nshards=4` brings up 4 workers and a write/read round-trip
        across all four shards passes (0 mismatches).
-6. **Branch-create coordination** for the shared timeline tree.
+6. **Branch-create coordination** for the shared timeline tree. ✅
+     Branch-create is routed to shard 0, validated against shard 0's copy, persisted
+     durably, then `timeline_define` *synchronously* broadcasts the definition into
+     every shard's replicated timeline copy before the op publishes DONE -- the
+     contract a client relies on to write the branch on any shard immediately after
+     creating it, without a round of acks (an async delivery queue would reopen that
+     visibility gap).  The cross-thread write is race-free: a fields-then-`defined`
+     release store pairs with every reader's `tl_defined()` acquire load.  Covered
+     by a cross-shard branch test (read-through + copy-on-write + isolation over
+     relations that hash to different shards), so a branch reaching only shard 0
+     would fail at nshards > 1.
 
 Each step is independently testable; step 2 is the big mechanical change and is
 behavior-preserving, so the risky parallelism (step 4) sits on a proven refactor.

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -847,9 +847,16 @@ fork_remove(uint32_t timeline, const PsKey *key)
 /*
  * Define timeline 'id' in every shard's replicated copy.  Branch-create is rare
  * and the tree is append-only, so a broadcast keeps every shard's lock-free read
- * copy in sync; at ps_nshards == 1 it writes the single copy.  (Single-threaded
- * here; step 4c-iv delivers the update to each shard's thread via a per-shard
- * queue instead of writing peer shards' memory directly.)
+ * copy in sync; at ps_nshards == 1 it writes the single copy.
+ *
+ * The broadcast is synchronous (the CREATE_BRANCH worker writes every shard's copy
+ * before publishing DONE), which is the coordination contract clients rely on: a
+ * client that observes its branch-create complete can immediately write the branch
+ * on any shard and find the timeline defined there -- without a round of acks.  An
+ * asynchronous per-shard delivery queue would reopen exactly that visibility gap.
+ * The cross-thread write is data-race-free: each fields-then-'defined' publish is a
+ * release store (below) and every reader gates on tl_defined()'s acquire load, so
+ * parent/branch_lsn are visible once 'defined' reads 1; the slot only flips 0->1.
  */
 static void
 timeline_define(uint32_t id, int parent, uint64_t branch_lsn)

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -854,6 +854,56 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 	op_read_tl(7, REL_B, FORK0, 0, rb);
 	check(page_has_tag(rb, ps, 11), "new valid branch reads through to root");
 
+	/*
+	 * Cross-shard branch coordination (sharding step 6): a branch is created on
+	 * shard 0, but its pages route by key to every shard, so each shard must see
+	 * the timeline (timeline_define broadcasts the definition to all shards'
+	 * replicas).  Use several relations whose keys hash to different shards and
+	 * check read-through + copy-on-write + isolation on each -- so a branch that
+	 * reached only shard 0 would fail here at nshards > 1.
+	 */
+	{
+		uint32_t	rels[] = {41001, 41002, 41003, 41004,
+			41005, 41006, 41007, 41008};
+		uint32_t	nrels = sizeof(rels) / sizeof(rels[0]);
+		uint32_t	shardmask = 0;
+
+		/* seed each rel on main (@ lsn 1000, before the T8 branch point) */
+		for (uint32_t i = 0; i < nrels; i++)
+		{
+			PsKey		k = {1, 1, rels[i], FORK0};
+
+			if (g_nshards > 1)
+				shardmask |= 1u << (ps_shard_for_key(&k, g_nshards) % 32);
+			fill_page(p, ps, 1000, (unsigned char) (100 + i));
+			op_write_tl(0, rels[i], FORK0, 0, p);
+		}
+		if (g_nshards > 1)
+			check(__builtin_popcount(shardmask) > 1,
+				  "cross-shard branch test spans multiple shards");
+
+		op_create_branch(8, 0, 1500);	/* branch off main @ 1500 */
+
+		for (uint32_t i = 0; i < nrels; i++)
+		{
+			/* the branch must be visible on this rel's shard: read-through to
+			 * the parent's page seeded above */
+			op_read_tl(8, rels[i], FORK0, 0, rb);
+			check(page_has_tag(rb, ps, (unsigned char) (100 + i)),
+				  "cross-shard branch reads through to parent on its shard");
+			/* copy-on-write on the branch, on this shard */
+			fill_page(p, ps, 2000, (unsigned char) (200 + i));
+			op_write_tl(8, rels[i], FORK0, 0, p);
+			op_read_tl(8, rels[i], FORK0, 0, rb);
+			check(page_has_tag(rb, ps, (unsigned char) (200 + i)),
+				  "cross-shard branch sees its own write on its shard");
+			/* parent unaffected (isolation) on this shard */
+			op_read_tl(0, rels[i], FORK0, 0, rb);
+			check(page_has_tag(rb, ps, (unsigned char) (100 + i)),
+				  "cross-shard parent unaffected by branch write");
+		}
+	}
+
 	client_detach();
 	stop_daemon(dpid);
 	rm_rf(store);


### PR DESCRIPTION
**Sharding step 6 — branch-create coordination for the shared timeline tree.** Stacked on #29.

The coordination itself shipped with the per-shard threads (#24): `CREATE_BRANCH` routes to shard 0, is validated + persisted, then `timeline_define` **synchronously** broadcasts the definition into every shard's replicated timeline copy *before* `DONE` is published — race-free via a fields-then-`defined` release store paired with each reader's `tl_defined()` acquire load. What was missing was **coverage** and a clear statement of the contract.

## What
- **Cross-shard branch test**: seed several relations whose keys hash to different shards on `main`, branch off `main`, then on each relation's shard verify read-through to the parent, copy-on-write divergence, and parent isolation. The existing branch suite used a single relation, so at `nshards > 1` it exercised only **one** shard; a branch that reached only shard 0 now fails this test. It asserts the chosen relations actually span more than one shard at `nshards > 1`.
- **Docs**: document the synchronous-broadcast contract on `timeline_define` (and why an async per-shard delivery queue would reopen the create-then-write visibility gap), replacing the stale "deliver via a per-shard queue" note.

No change to the coordination logic itself (TSan-clean since #24) — additive test coverage + docs.

## Test
Runs in the standalone battery at nshards **1 and 4** (the new checks exercise the broadcast across shards at nshards=4). Compiles clean (`-Wall -Wextra -Werror`).

> Local capture of the daemon-spawning suite was unreliable this session (an environment issue that degraded over a long session; the binary's own output works, and the nshards=4 multi-rel routing this test builds on is already green in CI). CI runs the standalone suite in a clean environment as the definitive check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)