### PR TITLE
contrib/pagestore: segment-record CRC32C + per-store generation (raw-device integrity)

### DIFF
--- a/contrib/pagestore/SPDK_NOTES.md
+++ b/contrib/pagestore/SPDK_NOTES.md
@@ -370,3 +370,23 @@ Gaps (worth closing before this path is trusted for durability):
   namespace, so the stale-magic risk above is real on a reused disk.  Options: a
   per-store generation/uuid stamped into each `SegRecHdr` (mismatch == end-of-log),
   or trimming/zeroing the device region a store owns at first open.
+
+Status (implemented):
+- `SegRecHdr` now carries a CRC32C (over position + header + page) and a per-store
+  generation persisted durably in `<store>/store_gen` (random; open fails if it
+  can't be made durable or if there is no entropy -- a predictable generation would
+  not guard a reused raw device).  `recover()` and the read paths verify both;
+  reads fail (not zero-fill) on a CRC mismatch.
+
+Remaining gap -- sync watermark:
+- Appends are not synced per record, so a record that fails to verify at the tail
+  may be an *unsynced torn tail* (expected after a crash) or *corruption of an
+  already-synced record*.  We cannot tell them apart without a durable per-shard
+  **sync watermark** (the (segment, offset) that `IMMEDSYNC`/close last made
+  durable).  Until that exists, `recover()` truncates at the first unverifiable
+  record: it never refuses to open over a normal post-crash tail, but a corruption
+  inside already-synced data truncates the later records rather than failing loudly.
+  The fix is to persist the watermark on sync and, during recovery, treat a
+  verification failure *below* it as corruption (fail open) and *at/above* it as the
+  unsynced tail (truncate).  For SPDK the superblock's per-shard segment count is
+  already a coarse (segment-granular) version of this.

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -146,13 +146,10 @@ load_store_gen(const char *store_dir)
 		close(fd);
 	}
 	if (g == 0)
-	{
-		uint64_t	h = 1469598103934665603ULL;	/* FNV-1a(path) fallback */
-
-		for (const char *p = store_dir; *p; p++)
-			h = (h ^ (unsigned char) *p) * 1099511628211ULL;
-		g = h ? h : 1;
-	}
+		return -1;				/* no entropy: refuse rather than derive a
+								 * predictable generation -- a path hash would repeat
+								 * for a store recreated at the same path on a reused
+								 * raw device, defeating the stale-bytes guard */
 
 	fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0600);
 	if (fd < 0)
@@ -183,6 +180,8 @@ load_store_gen(const char *store_dir)
 	{
 		if (fd >= 0)
 			close(fd);
+		unlink(path);			/* dir entry not durable: don't let a retry adopt
+								 * this file as "already durable" */
 		return -1;
 	}
 	close(fd);
@@ -1474,14 +1473,14 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	hdr.gen = g_store_gen;
 	hdr.crc = seg_rec_crc(s->cur_seg, s->cur_off, &hdr, page);
 
-	/* Write the page first, then the header as the commit point: recover() trusts
-	 * a record only once it sees a fully-framed header, so a torn trailing append
-	 * (page written, header not yet) reads back as no-record / end-of-log rather
-	 * than as a framed-but-corrupt record that would fail recovery. */
+	/* write header then page bytes contiguously at the append cursor.  (Ordering
+	 * page-before-header would not make a torn tail unambiguous without an fsync
+	 * barrier between the two writes, which we don't pay per append; recover()
+	 * instead treats any unverifiable record as end-of-log -- see there.) */
+	if (ps_storage->seg_write(s->cur_seg, s->cur_off, &hdr, sizeof(hdr)) != 0)
+		return -1;
 	data_off = s->cur_off + sizeof(hdr);
 	if (ps_storage->seg_write(s->cur_seg, data_off, page, page_size) != 0)
-		return -1;
-	if (ps_storage->seg_write(s->cur_seg, s->cur_off, &hdr, sizeof(hdr)) != 0)
 		return -1;
 
 	/* index points at the page bytes (data_off), so reads skip the header; carry
@@ -1662,14 +1661,18 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
  * (page_add_version + fork_grow) for every record reconstructs both indexes and
  * leaves the append cursor positioned just past the last valid record.
  *
- * A torn trailing append (header not yet written -- it is written last) reads as
- * no record and ends the scan; a fully-framed record whose page fails its CRC is
- * corruption of persisted data and aborts recovery (returns -1) rather than
- * silently dropping every later record.  Returns 0 on success, -1 on corruption
- * or allocation failure, so ps_core_open() can refuse to open over a real store.
+ * The scan stops at the first record that fails its magic/gen/len/CRC check
+ * (end-of-log).  Because appends are not synced per record, that record may be an
+ * unsynced torn tail (expected after a crash) or corruption of already-synced
+ * data; without a durable per-shard sync watermark the two are indistinguishable,
+ * so recovery truncates there rather than refusing to open over a normal tail.
+ * Returns 0 on success, -1 only on allocation failure (so ps_core_open() does not
+ * open with an empty index over a real store).
  *
  * Caveat (prototype): TRUNCATE and UNLINK are not logged as records, so their
- * effects are not reproduced on restart.
+ * effects are not reproduced on restart.  Telling synced-data corruption from an
+ * unsynced tail (to fail loudly on the former) is deferred to the sync-watermark
+ * work noted in SPDK_NOTES.
  */
 static int
 recover(void)
@@ -1698,27 +1701,29 @@ recover(void)
 			{
 				SegRecHdr	hdr;
 
-				/* No valid record framed here: a torn trailing append (the header
-				 * is written last, after the page -- see append_page), a never-
-				 * written tail, or stale device bytes from before this store.  This
-				 * is the end of the log; stop. */
+				/* Stop at the first record that does not verify -- a torn/unsynced
+				 * trailing append, a never-written tail, or stale device bytes from
+				 * before this store.  Writes are not synced per append, so without a
+				 * durable end-of-log watermark we cannot tell an unsynced torn tail
+				 * from corruption of an already-synced record; truncating here is the
+				 * safe choice (it never refuses to open over a normal post-crash
+				 * tail).  The CRC/gen check still detects the bad bytes and stops the
+				 * replay at them.  Distinguishing the two (fail on synced-data
+				 * corruption, truncate only the unsynced tail) needs a persisted
+				 * per-shard sync watermark -- see SPDK_NOTES "Verification & recovery".
+				 * A read error (vs a mismatch) is flagged before stopping. */
 				if (ps_storage->seg_read(id, off, &hdr, sizeof(hdr)) != 0 ||
 					hdr.magic != SEG_MAGIC || hdr.len != page_size ||
 					hdr.gen != g_store_gen)
 					break;
-				/* The header is fully framed as ours, so the page was written (it
-				 * precedes the header).  A read error or CRC mismatch here is thus
-				 * corruption of an already-persisted record, NOT a clean tail --
-				 * fail recovery rather than silently truncate every later record by
-				 * treating this as end-of-log. */
-				if (ps_storage->seg_read(id, off + sizeof(hdr), pg, page_size) != 0 ||
-					seg_rec_crc(id, off, &hdr, pg) != hdr.crc)
+				if (ps_storage->seg_read(id, off + sizeof(hdr), pg, page_size) != 0)
+					break;
+				if (seg_rec_crc(id, off, &hdr, pg) != hdr.crc)
 				{
-					fprintf(stderr, "pagestore: shard %u segment %d off %llu: "
-							"corrupt persisted record (crc); refusing to recover\n",
+					fprintf(stderr, "pagestore: shard %u segment %d off %llu: record "
+							"failed CRC; treating as end of log\n",
 							s->index, id, (unsigned long long) off);
-					free(pg);
-					return -1;
+					break;
 				}
 
 				page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn, id,

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -66,6 +66,115 @@ int			ps_object_tier = 0;
 const PsStorage *ps_storage = &PsStoragePosix;
 
 /*
+ * Segment-record integrity (no filesystem under the raw NVMe backend, so we carry
+ * our own checks).  CRC32C (Castagnoli) detects bit rot / torn writes; a per-store
+ * generation distinguishes our records from stale device bytes (a reused disk, or
+ * a previous store) that happen to carry a SEG_MAGIC, which a CRC alone can't.
+ */
+static uint32_t crc32c_tab[256];
+
+static void
+crc32c_init(void)
+{
+	for (uint32_t i = 0; i < 256; i++)
+	{
+		uint32_t	c = i;
+
+		for (int k = 0; k < 8; k++)
+			c = (c & 1) ? (c >> 1) ^ 0x82F63B78u : (c >> 1);
+		crc32c_tab[i] = c;
+	}
+}
+
+static uint32_t
+crc32c_upd(uint32_t crc, const void *buf, size_t len)
+{
+	const unsigned char *p = buf;
+
+	while (len--)
+		crc = crc32c_tab[(crc ^ *p++) & 0xff] ^ (crc >> 8);
+	return crc;
+}
+
+/* page-only CRC32C, stored per version and verified on the read path */
+uint32_t
+ps_crc32c(const void *buf, size_t len)
+{
+	return crc32c_upd(0xFFFFFFFFu, buf, len) ^ 0xFFFFFFFFu;
+}
+
+/* per-store generation, stamped into every segment record (0 = uninitialized) */
+static uint64_t g_store_gen;
+
+/*
+ * Load the store's generation from <store_dir>/store_gen, creating a durable
+ * random one on first open.  Stamped into each SegRecHdr so recover() can reject
+ * stale records left on a reused raw device (different/zero generation) instead of
+ * replaying them as live data.
+ */
+static void
+load_store_gen(const char *store_dir)
+{
+	char		path[2200];
+	int			fd;
+	uint64_t	g = 0;
+
+	snprintf(path, sizeof(path), "%s/store_gen", store_dir);
+	fd = open(path, O_RDONLY);
+	if (fd >= 0)
+	{
+		if (read(fd, &g, sizeof(g)) != (ssize_t) sizeof(g))
+			g = 0;
+		close(fd);
+	}
+	if (g == 0)
+	{
+		fd = open("/dev/urandom", O_RDONLY);
+		if (fd >= 0)
+		{
+			if (read(fd, &g, sizeof(g)) != (ssize_t) sizeof(g))
+				g = 0;
+			close(fd);
+		}
+		if (g == 0)
+		{
+			uint64_t	h = 1469598103934665603ULL;	/* FNV-1a(path) fallback */
+
+			for (const char *p = store_dir; *p; p++)
+				h = (h ^ (unsigned char) *p) * 1099511628211ULL;
+			g = h ? h : 1;
+		}
+		fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+		if (fd >= 0)
+		{
+			ssize_t		w = write(fd, &g, sizeof(g));
+
+			(void) w;
+			fsync(fd);
+			close(fd);
+			fd = open(store_dir, O_RDONLY);		/* make the entry durable */
+			if (fd >= 0)
+			{
+				fsync(fd);
+				close(fd);
+			}
+		}
+		else
+		{
+			/* lost a create race: adopt the peer's persisted generation */
+			fd = open(path, O_RDONLY);
+			if (fd >= 0)
+			{
+				if (read(fd, &g, sizeof(g)) != (ssize_t) sizeof(g))
+					g = g ? g : 1;
+				close(fd);
+			}
+		}
+	}
+	g_store_gen = g;
+}
+
+/*
  * Per-shard state (LSM phase 9).  One thread per shard will own its index /
  * staging / cache lock-free; the shard is chosen from the logical key only
  * (block- and timeline-independent), so a key's blocks and all its timelines live
@@ -608,7 +717,29 @@ typedef struct SegRecHdr
 	uint32_t	block;
 	uint64_t	lsn;			/* the page's pd_lsn at write time */
 	uint32_t	len;			/* page bytes following the header */
+	uint32_t	crc;			/* CRC32C over (pos, header[crc=0], page bytes) */
+	uint64_t	gen;			/* per-store generation (rejects stale device bytes) */
 } SegRecHdr;
+
+/*
+ * CRC32C covering the record's position (segment id + byte offset, to catch a
+ * misdirected write that landed elsewhere), the header with its own crc field
+ * zeroed, and the page bytes.  Computed at write, checked at recover.
+ */
+static uint32_t
+seg_rec_crc(int seg, uint64_t recoff, const SegRecHdr *h,
+			const unsigned char *page)
+{
+	SegRecHdr	tmp = *h;
+	uint32_t	crc = 0xFFFFFFFFu;
+
+	tmp.crc = 0;
+	crc = crc32c_upd(crc, &seg, sizeof(seg));
+	crc = crc32c_upd(crc, &recoff, sizeof(recoff));
+	crc = crc32c_upd(crc, &tmp, sizeof(tmp));
+	crc = crc32c_upd(crc, page, page_size);
+	return crc ^ 0xFFFFFFFFu;
+}
 
 /*
  * Segments are addressed by (id, byte offset); how they are stored is the
@@ -718,7 +849,7 @@ page_find(uint32_t timeline, const PsKey *key, uint32_t block)
  */
 static void
 page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
-				 uint64_t lsn, int seg, uint64_t off)
+				 uint64_t lsn, int seg, uint64_t off, uint32_t crc)
 {
 	uint32_t	h = page_hash(timeline, key, block);
 	Shard	   *s = shard_for(key);
@@ -741,6 +872,7 @@ page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
 	e->vers[e->nver].lsn = lsn;
 	e->vers[e->nver].seg = seg;
 	e->vers[e->nver].off = off;
+	e->vers[e->nver].crc = crc;
 	e->nver++;
 }
 
@@ -1316,12 +1448,15 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 		s->cur_off = 0;
 	}
 
+	memset(&hdr, 0, sizeof(hdr));	/* deterministic padding: the crc covers it */
 	hdr.magic = SEG_MAGIC;
 	hdr.timeline = timeline;
 	hdr.key = *key;
 	hdr.block = block;
 	hdr.lsn = page_lsn(page);	/* version key taken from the page itself */
 	hdr.len = page_size;
+	hdr.gen = g_store_gen;
+	hdr.crc = seg_rec_crc(s->cur_seg, s->cur_off, &hdr, page);
 
 	/* write header then page bytes contiguously at the append cursor */
 	if (ps_storage->seg_write(s->cur_seg, s->cur_off, &hdr, sizeof(hdr)) != 0)
@@ -1330,8 +1465,10 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	if (ps_storage->seg_write(s->cur_seg, data_off, page, page_size) != 0)
 		return -1;
 
-	/* index points at the page bytes (data_off), so reads skip the header */
-	page_add_version(timeline, key, block, hdr.lsn, s->cur_seg, data_off);
+	/* index points at the page bytes (data_off), so reads skip the header; carry
+	 * the page CRC so the read path can verify the bytes it later fetches */
+	page_add_version(timeline, key, block, hdr.lsn, s->cur_seg, data_off,
+					 ps_crc32c(page, page_size));
 	s->cur_off += reclen;
 
 	/* stage the version for the LSM memtable; flush to an image layer when full
@@ -1374,6 +1511,10 @@ read_version(const PageVer *v, unsigned char *out)
 	if (v->seg < 0)				/* layer-origin version (no segment copy) */
 		return -1;
 	if (ps_storage->seg_read(v->seg, v->off, out, page_size) != 0)
+		return -1;
+	/* verify the bytes against the version's stored CRC: catches bit rot or a
+	 * misread that happened since the index was built */
+	if (ps_crc32c(out, page_size) != v->crc)
 		return -1;
 	return 0;
 }
@@ -1499,6 +1640,10 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 static void
 recover(void)
 {
+	unsigned char *pg = malloc(page_size);	/* scratch to read+verify each page */
+
+	if (!pg)
+		return;
 	/* Each shard owns a disjoint segment-id namespace, so scan and replay each
 	 * shard's segments and position its own append cursor.  page_add_version()
 	 * self-routes by key, so a record always lands on the shard that wrote it. */
@@ -1520,11 +1665,19 @@ recover(void)
 				SegRecHdr	hdr;
 
 				if (ps_storage->seg_read(id, off, &hdr, sizeof(hdr)) != 0 ||
-					hdr.magic != SEG_MAGIC || hdr.len != page_size)
+					hdr.magic != SEG_MAGIC || hdr.len != page_size ||
+					hdr.gen != g_store_gen)
+					break;
+				/* read the page and verify the record CRC (position + header +
+				 * bytes); a record that matches SEG_MAGIC but fails the CRC or the
+				 * store generation is a torn write or stale device data, so it is
+				 * this segment's end-of-log, not live state to replay */
+				if (ps_storage->seg_read(id, off + sizeof(hdr), pg, page_size) != 0 ||
+					seg_rec_crc(id, off, &hdr, pg) != hdr.crc)
 					break;
 
 				page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn, id,
-								 off + sizeof(hdr));
+								 off + sizeof(hdr), ps_crc32c(pg, page_size));
 				fork_grow(hdr.timeline, &hdr.key, hdr.block + 1);
 				off += sizeof(hdr) + hdr.len;
 			}
@@ -1545,6 +1698,7 @@ recover(void)
 					"%d (off %llu)\n", s->index, s->cur_seg,
 					(unsigned long long) s->cur_off);
 	}
+	free(pg);
 }
 
 /* ===================== request handling (non-I/O ops) ================== */
@@ -1900,10 +2054,12 @@ validate_store_nshards(const char *store_dir)
 int
 ps_core_open(const char *store_dir)
 {
+	crc32c_init();				/* before recover() and any worker thread */
 	if (ps_storage->open(store_dir, segment_size) != 0)
 		return -1;
 	if (ps_layer_store->open(store_dir) != 0)
 		return -1;
+	load_store_gen(store_dir);	/* generation stamped into every segment record */
 	if (validate_store_nshards(store_dir) != 0)
 		return -1;
 

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -122,6 +122,7 @@ load_store_gen(const char *store_dir)
 	char		path[2200];
 	int			fd;
 	uint64_t	g = 0;
+	int			existed = 0;
 
 	snprintf(path, sizeof(path), "%s/store_gen", store_dir);
 	fd = open(path, O_RDONLY);
@@ -130,6 +131,7 @@ load_store_gen(const char *store_dir)
 		ssize_t		r = read(fd, &g, sizeof(g));
 
 		close(fd);
+		existed = 1;
 		if (r == (ssize_t) sizeof(g) && g != 0)
 		{
 			g_store_gen = g;
@@ -137,6 +139,25 @@ load_store_gen(const char *store_dir)
 		}
 		g = 0;
 	}
+
+	/*
+	 * No usable generation on disk.  Only mint one for a genuinely fresh store: if
+	 * segment data already exists, a missing or short store_gen means lost or
+	 * mismatched metadata (a restored/copied store, a deleted file), and minting a
+	 * new generation would make recover() treat every existing record as stale and
+	 * silently discard the whole log.  Fail open so the loss is visible.
+	 * (Segment id 0 is shard 0's first segment -- the first one any store writes.)
+	 */
+	if (ps_storage->seg_size(0) >= 0)
+		return -1;
+
+	/*
+	 * Fresh store: a leftover short/zero file (e.g. a crash mid-create) cannot have
+	 * stamped any record yet, so remove and recreate it rather than wedging every
+	 * future open on the EEXIST path below.
+	 */
+	if (existed)
+		unlink(path);
 
 	fd = open("/dev/urandom", O_RDONLY);
 	if (fd >= 0)

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -145,11 +145,14 @@ load_store_gen(const char *store_dir)
 	 * segment data already exists, a missing or short store_gen means lost or
 	 * mismatched metadata (a restored/copied store, a deleted file), and minting a
 	 * new generation would make recover() treat every existing record as stale and
-	 * silently discard the whole log.  Fail open so the loss is visible.
-	 * (Segment id 0 is shard 0's first segment -- the first one any store writes.)
+	 * silently discard the whole log.  Fail open so the loss is visible.  Check
+	 * every shard's first segment (seg id == shard for local index 0), since with
+	 * nshards > 1 a store may have written only to a nonzero shard, leaving seg 0
+	 * absent while later shard-local segments exist.
 	 */
-	if (ps_storage->seg_size(0) >= 0)
-		return -1;
+	for (uint32_t s = 0; s < ps_nshards; s++)
+		if (ps_storage->seg_size((int) s) >= 0)
+			return -1;
 
 	/*
 	 * Fresh store: a leftover short/zero file (e.g. a crash mid-create) cannot have
@@ -1763,6 +1766,12 @@ recover(void)
 			/* newest segment seen for this shard; its append continues after it */
 			s->cur_seg = id;
 			s->cur_off = off;
+			/* If the scan stopped with room left for another record, this segment is
+			 * the shard's end -- a tail or a mid-log corruption -- not a rolled-full
+			 * one.  Stop the shard here; continuing would index a later segment while
+			 * leaving the cursor mid-this-one, silently dropping the gap between. */
+			if (off + sizeof(SegRecHdr) + page_size <= segment_size)
+				break;
 		}
 		if (s->cur_seg >= 0)
 			fprintf(stderr, "pagestore_daemon: shard %u recovered through segment "

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1790,8 +1790,9 @@ recover(void)
 		{
 			int			id = seg_id(s->index, local);
 			uint64_t	off = 0;
+			int64_t		sz = ps_storage->seg_size(id);
 
-			if (ps_storage->seg_size(id) < 0)
+			if (sz < 0)
 				break;			/* no more segments in this shard -> done */
 
 			/* replay records until one fails to validate (end of log) */
@@ -1799,23 +1800,43 @@ recover(void)
 			{
 				SegRecHdr	hdr;
 
-				/* Stop at the first record that does not verify -- a torn/unsynced
+				/*
+				 * Stop at the first record that does not verify -- a torn/unsynced
 				 * trailing append, a never-written tail, or stale device bytes from
-				 * before this store.  Writes are not synced per append, so without a
-				 * durable end-of-log watermark we cannot tell an unsynced torn tail
-				 * from corruption of an already-synced record; truncating here is the
-				 * safe choice (it never refuses to open over a normal post-crash
-				 * tail).  The CRC/gen check still detects the bad bytes and stops the
-				 * replay at them.  Distinguishing the two (fail on synced-data
-				 * corruption, truncate only the unsynced tail) needs a persisted
-				 * per-shard sync watermark -- see SPDK_NOTES "Verification & recovery".
-				 * A read error (vs a mismatch) is flagged before stopping. */
-				if (ps_storage->seg_read(id, off, &hdr, sizeof(hdr)) != 0 ||
-					hdr.magic != SEG_MAGIC || hdr.len != page_size ||
+				 * before this store.  Truncating here is safe (it never refuses to
+				 * open over a normal post-crash tail), and zero_shard_forward() below
+				 * physically discards the rest.
+				 *
+				 * But distinguish an expected short tail from a real backend read
+				 * error: a full record needs sizeof(hdr)+page_size bytes present, so
+				 * bytes past the segment's written size are the tail (break), while a
+				 * seg_read failure WITHIN that size is an actual I/O error -- fail the
+				 * open rather than truncate, which could otherwise zero live data on a
+				 * transient read fault.  (On SPDK seg_size() reports a present segment
+				 * as full, so its tail is detected by the magic/gen/CRC check on the
+				 * stale bytes, and only a real do_io failure reaches the -1 paths.)
+				 */
+				if (off + sizeof(hdr) + page_size > (uint64_t) sz)
+					break;
+				if (ps_storage->seg_read(id, off, &hdr, sizeof(hdr)) != 0)
+				{
+					fprintf(stderr, "pagestore: shard %u segment %d off %llu: header "
+							"read failed; refusing to recover\n",
+							s->index, id, (unsigned long long) off);
+					free(pg);
+					return -1;
+				}
+				if (hdr.magic != SEG_MAGIC || hdr.len != page_size ||
 					hdr.gen != g_store_gen)
 					break;
 				if (ps_storage->seg_read(id, off + sizeof(hdr), pg, page_size) != 0)
-					break;
+				{
+					fprintf(stderr, "pagestore: shard %u segment %d off %llu: page "
+							"read failed; refusing to recover\n",
+							s->index, id, (unsigned long long) off);
+					free(pg);
+					return -1;
+				}
 				if (seg_rec_crc(id, off, &hdr, pg) != hdr.crc)
 				{
 					fprintf(stderr, "pagestore: shard %u segment %d off %llu: record "
@@ -2192,6 +2213,19 @@ ps_core_maintenance(void)
 	return 0;
 }
 
+/* fsync a store directory so a freshly created metadata file's entry is durable */
+static void
+fsync_store_dir(const char *store_dir)
+{
+	int			fd = open(store_dir, O_RDONLY);
+
+	if (fd >= 0)
+	{
+		fsync(fd);
+		close(fd);
+	}
+}
+
 /*
  * The store records the shard count it was created with.  Per-shard segment and
  * manifest namespaces -- and how recover() partitions segments -- are derived
@@ -2252,6 +2286,7 @@ validate_store_nshards(const char *store_dir)
 		return -1;
 	}
 	close(fd);
+	fsync_store_dir(store_dir);	/* make the new file's directory entry durable */
 	return 0;
 }
 
@@ -2307,6 +2342,7 @@ validate_store_segment_size(const char *store_dir)
 		return -1;
 	}
 	close(fd);
+	fsync_store_dir(store_dir);	/* make the new file's directory entry durable */
 	return 0;
 }
 

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1820,39 +1820,54 @@ recover(void)
 		 * unwritten tail.  A clean tail (cursor at the true end, nothing after) is
 		 * left untouched so normal recovery does no extra I/O.
 		 */
-		if (s->cur_seg >= 0)
 		{
-			int			next = seg_id(s->index, seg_local(s->cur_seg) + 1);
-			int			stale = (ps_storage->seg_size(next) >= 0);
-			SegRecHdr	probe;
+			/* Start clearing at the append cursor, or -- when recovery rebuilt
+			 * nothing because the shard's very first segment's first record was
+			 * already invalid -- at that first segment, so its stale later records
+			 * can't resurrect either. */
+			int			zseg = (s->cur_seg >= 0) ? s->cur_seg : seg_id(s->index, 0);
+			uint64_t	zoff = (s->cur_seg >= 0) ? s->cur_off : 0;
 
-			if (!stale &&
-				ps_storage->seg_read(s->cur_seg, s->cur_off, &probe,
-									 sizeof(probe)) == 0)
-				for (size_t k = 0; k < sizeof(probe); k++)
-					if (((unsigned char *) &probe)[k])
-					{
-						stale = 1;
-						break;
-					}
-			if (stale)
+			if (ps_storage->seg_size(zseg) >= 0)
 			{
-				int			z;
+				int			next = seg_id(s->index, seg_local(zseg) + 1);
+				int			stale = (ps_storage->seg_size(next) >= 0);
+				SegRecHdr	probe;
 
-				memset(pg, 0, page_size);
-				z = zero_shard_forward(s->index, s->cur_seg, s->cur_off, pg);
-				if (z < 0)
+				if (!stale &&
+					ps_storage->seg_read(zseg, zoff, &probe, sizeof(probe)) == 0)
+					for (size_t k = 0; k < sizeof(probe); k++)
+						if (((unsigned char *) &probe)[k])
+						{
+							stale = 1;
+							break;
+						}
+				if (stale)
 				{
-					free(pg);
-					return -1;
+					int			z;
+
+					memset(pg, 0, page_size);
+					z = zero_shard_forward(s->index, zseg, zoff, pg);
+					if (z < 0)
+					{
+						free(pg);
+						return -1;
+					}
+					if (z)
+						need_sync = 1;
 				}
-				if (z)
-					need_sync = 1;
 			}
 		}
 	}
-	if (need_sync)
-		ps_storage->sync();		/* make the tail truncation durable */
+	if (need_sync && ps_storage->sync() != 0)
+	{
+		/* the truncation is only in memory; opening now would let a later crash
+		 * replay the stale records we meant to drop -- fail the open instead */
+		fprintf(stderr, "pagestore: could not durably zero a truncated tail; "
+				"refusing to recover\n");
+		free(pg);
+		return -1;
+	}
 	free(pg);
 	return 0;
 }
@@ -2215,14 +2230,19 @@ ps_core_open(const char *store_dir)
 		return -1;
 	if (ps_layer_store->open(store_dir) != 0)
 		return -1;
+	/* Validate --nshards against the stored value BEFORE minting a generation: the
+	 * freshness check below probes the live shards' first segments, so a wrong
+	 * nshards could misjudge an existing store as fresh and durably write a new
+	 * store_gen before this rejected the mismatch -- leaving the real records'
+	 * generations stale on the next correct-nshards open. */
+	if (validate_store_nshards(store_dir) != 0)
+		return -1;
 	if (load_store_gen(store_dir) != 0)	/* generation stamped into each record */
 	{
 		fprintf(stderr, "pagestore_core: could not durably establish store "
 				"generation in %s\n", store_dir);
 		return -1;
 	}
-	if (validate_store_nshards(store_dir) != 0)
-		return -1;
 
 	/* the LSM write side (memtable/flush/compaction) runs only when layers are
 	 * the read path; the SPDK daemon stays on the segment path for now.  Reject

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1699,37 +1699,76 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
  * work noted in SPDK_NOTES.
  */
 /*
- * Physically clear everything from (seg, off) forward in a shard's segments, so a
- * truncated tail cannot be resurrected: the old records past a truncation point
- * keep valid CRCs at their own offsets, so after the daemon overwrites only some of
- * them and crashes again, the next recover would otherwise replay the untouched
- * ones.  Zeroing their headers makes them unreadable.  zbuf is page_size zeros.
- * Returns 1 if it wrote anything (caller must sync), 0 if nothing, -1 on error.
+ * Physically clear the written bytes from (seg, off) forward in a shard's
+ * segments, so a truncated tail cannot be resurrected: the old records past a
+ * truncation point keep valid CRCs at their own offsets, so after the daemon
+ * overwrites only some of them and crashes again, the next recover would otherwise
+ * replay the untouched ones.
+ *
+ * Idempotent and self-bounding: it reads each chunk (only up to the segment's
+ * written size) and rewrites zeros ONLY where it finds non-zero bytes.  So a clean
+ * tail (cursor already at the segment's end) scans nothing, an already-zeroed tail
+ * costs reads but no writes/sync, and -- crucially -- a recovery interrupted partway
+ * through zeroing is finished by the next one (it scans the whole tail rather than
+ * trusting a single probe).  Returns 1 if it wrote anything (caller must sync), 0
+ * if nothing, -1 on error.
  */
 static int
-zero_shard_forward(uint32_t shard, int seg, uint64_t off, unsigned char *zbuf)
+zero_shard_forward(uint32_t shard, int seg, uint64_t off)
 {
 	uint32_t	local = seg_local(seg);
+	unsigned char *zbuf = calloc(1, page_size);
+	unsigned char *rb = malloc(page_size);
 	int			wrote = 0;
+	int			err = 0;
 
+	if (!zbuf || !rb)
+	{
+		free(zbuf);
+		free(rb);
+		return -1;
+	}
 	for (;; local++, off = 0)
 	{
 		int			id = seg_id(shard, local);
+		int64_t		sz = ps_storage->seg_size(id);
 
-		if (ps_storage->seg_size(id) < 0)
+		if (sz < 0)
 			break;				/* no more segments in this shard */
-		for (uint64_t p = off; p < segment_size;)
+		for (uint64_t p = off; p < (uint64_t) sz && !err;)
 		{
-			uint32_t	n = (segment_size - p > page_size)
-				? page_size : (uint32_t) (segment_size - p);
+			uint32_t	n = ((uint64_t) sz - p > page_size)
+				? page_size : (uint32_t) ((uint64_t) sz - p);
+			int			nz = 0;
 
-			if (ps_storage->seg_write(id, p, zbuf, n) != 0)
-				return -1;
+			if (ps_storage->seg_read(id, p, rb, n) != 0)
+			{
+				err = 1;
+				break;
+			}
+			for (uint32_t k = 0; k < n; k++)
+				if (rb[k])
+				{
+					nz = 1;
+					break;
+				}
+			if (nz)
+			{
+				if (ps_storage->seg_write(id, p, zbuf, n) != 0)
+				{
+					err = 1;
+					break;
+				}
+				wrote = 1;
+			}
 			p += n;
-			wrote = 1;
 		}
+		if (err)
+			break;
 	}
-	return wrote;
+	free(zbuf);
+	free(rb);
+	return err ? -1 : wrote;
 }
 
 static int
@@ -1843,51 +1882,22 @@ recover(void)
 		else
 		{
 			/*
-			 * Physically clear the tail past the append cursor when it actually
-			 * holds non-zero bytes -- a torn/corrupt/stale record at the cursor, or
-			 * at the start of the next segment -- so those records can't resurrect
-			 * after a partial overwrite + crash.  Probing content (not mere segment
-			 * existence) means a tail a previous recovery already zeroed is not
-			 * re-zeroed on every restart.
+			 * Physically clear any written bytes past the append cursor so a
+			 * torn/corrupt/stale tail can't resurrect after a partial overwrite +
+			 * crash.  zero_shard_forward() is idempotent and self-bounding: a clean
+			 * tail (cursor at the segment's written end) scans nothing, an already-
+			 * zeroed tail writes nothing, and a previously-interrupted zeroing is
+			 * finished here -- so it is safe to run unconditionally.
 			 */
-			int			stale = 0;
-			SegRecHdr	probe;
+			int			z = zero_shard_forward(s->index, s->cur_seg, s->cur_off);
 
-			if (ps_storage->seg_read(s->cur_seg, s->cur_off, &probe,
-									 sizeof(probe)) == 0)
-				for (size_t k = 0; k < sizeof(probe); k++)
-					if (((unsigned char *) &probe)[k])
-					{
-						stale = 1;
-						break;
-					}
-			if (!stale)
+			if (z < 0)
 			{
-				int			next = seg_id(s->index, seg_local(s->cur_seg) + 1);
-
-				if (ps_storage->seg_size(next) >= 0 &&
-					ps_storage->seg_read(next, 0, &probe, sizeof(probe)) == 0)
-					for (size_t k = 0; k < sizeof(probe); k++)
-						if (((unsigned char *) &probe)[k])
-						{
-							stale = 1;
-							break;
-						}
+				free(pg);
+				return -1;
 			}
-			if (stale)
-			{
-				int			z;
-
-				memset(pg, 0, page_size);
-				z = zero_shard_forward(s->index, s->cur_seg, s->cur_off, pg);
-				if (z < 0)
-				{
-					free(pg);
-					return -1;
-				}
-				if (z)
-					need_sync = 1;
-			}
+			if (z)
+				need_sync = 1;
 		}
 	}
 	if (need_sync && ps_storage->sync() != 0)
@@ -2246,6 +2256,61 @@ validate_store_nshards(const char *store_dir)
 }
 
 /*
+ * Persist and validate the store's segment_size.  recover() interprets segment
+ * boundaries (where a segment is "full" and rolls) from segment_size, so reopening
+ * a POSIX store with a different --segment-size would mis-locate the log tail and
+ * could truncate/zero live later segments.  (SPDK records segment_size in its
+ * superblock; this gives POSIX -- and any backend -- the same protection.)
+ * Returns 0 on match / first-time record, -1 on mismatch or I/O error.
+ */
+static int
+validate_store_segment_size(const char *store_dir)
+{
+	char		path[4096];
+	char		buf[64];
+	int			fd;
+	ssize_t		n;
+
+	if (snprintf(path, sizeof(path), "%s/segment_size", store_dir) >=
+		(int) sizeof(path))
+		return -1;
+
+	fd = open(path, O_RDONLY);
+	if (fd >= 0)
+	{
+		uint64_t	stored;
+
+		n = read(fd, buf, sizeof(buf) - 1);
+		close(fd);
+		if (n <= 0)
+			return -1;
+		buf[n] = '\0';
+		stored = strtoull(buf, NULL, 10);
+		if (stored != segment_size)
+		{
+			fprintf(stderr, "pagestore_core: store was created with segment_size "
+					"%llu; reopen with --segment-size %llu\n",
+					(unsigned long long) stored, (unsigned long long) stored);
+			return -1;
+		}
+		return 0;
+	}
+
+	/* first open of this store: record segment_size durably */
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (fd < 0)
+		return -1;
+	n = snprintf(buf, sizeof(buf), "%llu\n", (unsigned long long) segment_size);
+	if (write(fd, buf, (size_t) n) != n || fsync(fd) != 0)
+	{
+		close(fd);
+		return -1;
+	}
+	close(fd);
+	return 0;
+}
+
+/*
  * Open the store and rebuild all in-memory state from it: define the root
  * timeline, load persisted branches, rebuild the page/fork indexes from the
  * image layers (falling back to a segment scan only for a store that has no
@@ -2267,6 +2332,8 @@ ps_core_open(const char *store_dir)
 	 * store_gen before this rejected the mismatch -- leaving the real records'
 	 * generations stale on the next correct-nshards open. */
 	if (validate_store_nshards(store_dir) != 0)
+		return -1;
+	if (validate_store_segment_size(store_dir) != 0)
 		return -1;
 	if (load_store_gen(store_dir) != 0)	/* generation stamped into each record */
 	{

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -27,6 +27,7 @@
  *
  *-------------------------------------------------------------------------
  */
+#include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -110,9 +111,12 @@ static uint64_t g_store_gen;
  * Load the store's generation from <store_dir>/store_gen, creating a durable
  * random one on first open.  Stamped into each SegRecHdr so recover() can reject
  * stale records left on a reused raw device (different/zero generation) instead of
- * replaying them as live data.
+ * replaying them as live data.  Returns 0 on success, -1 if a fresh generation
+ * cannot be made durable -- the caller must then fail the open, since records
+ * stamped with a generation that a crash could lose would be rejected (i.e. lost)
+ * by the next recover().
  */
-static void
+static int
 load_store_gen(const char *store_dir)
 {
 	char		path[2200];
@@ -123,55 +127,67 @@ load_store_gen(const char *store_dir)
 	fd = open(path, O_RDONLY);
 	if (fd >= 0)
 	{
+		ssize_t		r = read(fd, &g, sizeof(g));
+
+		close(fd);
+		if (r == (ssize_t) sizeof(g) && g != 0)
+		{
+			g_store_gen = g;
+			return 0;			/* already durable from a prior open */
+		}
+		g = 0;
+	}
+
+	fd = open("/dev/urandom", O_RDONLY);
+	if (fd >= 0)
+	{
 		if (read(fd, &g, sizeof(g)) != (ssize_t) sizeof(g))
 			g = 0;
 		close(fd);
 	}
 	if (g == 0)
 	{
-		fd = open("/dev/urandom", O_RDONLY);
-		if (fd >= 0)
-		{
-			if (read(fd, &g, sizeof(g)) != (ssize_t) sizeof(g))
-				g = 0;
-			close(fd);
-		}
-		if (g == 0)
-		{
-			uint64_t	h = 1469598103934665603ULL;	/* FNV-1a(path) fallback */
+		uint64_t	h = 1469598103934665603ULL;	/* FNV-1a(path) fallback */
 
-			for (const char *p = store_dir; *p; p++)
-				h = (h ^ (unsigned char) *p) * 1099511628211ULL;
-			g = h ? h : 1;
-		}
-		fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0600);
-		if (fd >= 0)
-		{
-			ssize_t		w = write(fd, &g, sizeof(g));
-
-			(void) w;
-			fsync(fd);
-			close(fd);
-			fd = open(store_dir, O_RDONLY);		/* make the entry durable */
-			if (fd >= 0)
-			{
-				fsync(fd);
-				close(fd);
-			}
-		}
-		else
-		{
-			/* lost a create race: adopt the peer's persisted generation */
-			fd = open(path, O_RDONLY);
-			if (fd >= 0)
-			{
-				if (read(fd, &g, sizeof(g)) != (ssize_t) sizeof(g))
-					g = g ? g : 1;
-				close(fd);
-			}
-		}
+		for (const char *p = store_dir; *p; p++)
+			h = (h ^ (unsigned char) *p) * 1099511628211ULL;
+		g = h ? h : 1;
 	}
+
+	fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+	if (fd < 0)
+	{
+		/* lost a create race: adopt the peer's now-durable generation */
+		if (errno == EEXIST && (fd = open(path, O_RDONLY)) >= 0)
+		{
+			ssize_t		r = read(fd, &g, sizeof(g));
+
+			close(fd);
+			if (r == (ssize_t) sizeof(g) && g != 0)
+			{
+				g_store_gen = g;
+				return 0;
+			}
+		}
+		return -1;
+	}
+	if (write(fd, &g, sizeof(g)) != (ssize_t) sizeof(g) || fsync(fd) != 0)
+	{
+		close(fd);
+		unlink(path);
+		return -1;				/* not durable: caller fails the open */
+	}
+	close(fd);
+	fd = open(store_dir, O_RDONLY);		/* make the directory entry durable */
+	if (fd < 0 || fsync(fd) != 0)
+	{
+		if (fd >= 0)
+			close(fd);
+		return -1;
+	}
+	close(fd);
 	g_store_gen = g;
+	return 0;
 }
 
 /*
@@ -1458,11 +1474,14 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	hdr.gen = g_store_gen;
 	hdr.crc = seg_rec_crc(s->cur_seg, s->cur_off, &hdr, page);
 
-	/* write header then page bytes contiguously at the append cursor */
-	if (ps_storage->seg_write(s->cur_seg, s->cur_off, &hdr, sizeof(hdr)) != 0)
-		return -1;
+	/* Write the page first, then the header as the commit point: recover() trusts
+	 * a record only once it sees a fully-framed header, so a torn trailing append
+	 * (page written, header not yet) reads back as no-record / end-of-log rather
+	 * than as a framed-but-corrupt record that would fail recovery. */
 	data_off = s->cur_off + sizeof(hdr);
 	if (ps_storage->seg_write(s->cur_seg, data_off, page, page_size) != 0)
+		return -1;
+	if (ps_storage->seg_write(s->cur_seg, s->cur_off, &hdr, sizeof(hdr)) != 0)
 		return -1;
 
 	/* index points at the page bytes (data_off), so reads skip the header; carry
@@ -1504,18 +1523,23 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	return 0;
 }
 
-/* Read a specific version's page bytes into out (page_size bytes). */
+/*
+ * Read a specific version's page bytes into out (page_size bytes).  Returns 0 on
+ * success, -1 if the version has no segment copy (layer-origin), and -2 on an
+ * integrity error -- a device read failure or a CRC mismatch (bit rot / misread)
+ * -- which the caller must surface rather than treat as an unwritten page.
+ */
 int
 read_version(const PageVer *v, unsigned char *out)
 {
 	if (v->seg < 0)				/* layer-origin version (no segment copy) */
 		return -1;
 	if (ps_storage->seg_read(v->seg, v->off, out, page_size) != 0)
-		return -1;
+		return -2;
 	/* verify the bytes against the version's stored CRC: catches bit rot or a
 	 * misread that happened since the index was built */
 	if (ps_crc32c(out, page_size) != v->crc)
-		return -1;
+		return -2;
 	return 0;
 }
 
@@ -1610,8 +1634,13 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 			}
 			else
 			{
+				int			rv;
+
 				s->rr_seg++;
-				served = (read_version(pv, out) == 0);	/* segment fallback */
+				rv = read_version(pv, out);		/* segment fallback */
+				if (rv == -2)
+					return -1;	/* corrupt stored page: surface, don't zero-fill */
+				served = (rv == 0);
 			}
 			if (served && !ambig)
 				ps_pgcache_insert(&s->pgcache, tl, key, block, pv->lsn, out);
@@ -1633,17 +1662,22 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
  * (page_add_version + fork_grow) for every record reconstructs both indexes and
  * leaves the append cursor positioned just past the last valid record.
  *
+ * A torn trailing append (header not yet written -- it is written last) reads as
+ * no record and ends the scan; a fully-framed record whose page fails its CRC is
+ * corruption of persisted data and aborts recovery (returns -1) rather than
+ * silently dropping every later record.  Returns 0 on success, -1 on corruption
+ * or allocation failure, so ps_core_open() can refuse to open over a real store.
+ *
  * Caveat (prototype): TRUNCATE and UNLINK are not logged as records, so their
- * effects are not reproduced on restart.  Also a partial/torn trailing record
- * is simply treated as end-of-log (the magic/len check below stops the scan).
+ * effects are not reproduced on restart.
  */
-static void
+static int
 recover(void)
 {
 	unsigned char *pg = malloc(page_size);	/* scratch to read+verify each page */
 
 	if (!pg)
-		return;
+		return -1;				/* don't open with an empty index over a real store */
 	/* Each shard owns a disjoint segment-id namespace, so scan and replay each
 	 * shard's segments and position its own append cursor.  page_add_version()
 	 * self-routes by key, so a record always lands on the shard that wrote it. */
@@ -1664,17 +1698,28 @@ recover(void)
 			{
 				SegRecHdr	hdr;
 
+				/* No valid record framed here: a torn trailing append (the header
+				 * is written last, after the page -- see append_page), a never-
+				 * written tail, or stale device bytes from before this store.  This
+				 * is the end of the log; stop. */
 				if (ps_storage->seg_read(id, off, &hdr, sizeof(hdr)) != 0 ||
 					hdr.magic != SEG_MAGIC || hdr.len != page_size ||
 					hdr.gen != g_store_gen)
 					break;
-				/* read the page and verify the record CRC (position + header +
-				 * bytes); a record that matches SEG_MAGIC but fails the CRC or the
-				 * store generation is a torn write or stale device data, so it is
-				 * this segment's end-of-log, not live state to replay */
+				/* The header is fully framed as ours, so the page was written (it
+				 * precedes the header).  A read error or CRC mismatch here is thus
+				 * corruption of an already-persisted record, NOT a clean tail --
+				 * fail recovery rather than silently truncate every later record by
+				 * treating this as end-of-log. */
 				if (ps_storage->seg_read(id, off + sizeof(hdr), pg, page_size) != 0 ||
 					seg_rec_crc(id, off, &hdr, pg) != hdr.crc)
-					break;
+				{
+					fprintf(stderr, "pagestore: shard %u segment %d off %llu: "
+							"corrupt persisted record (crc); refusing to recover\n",
+							s->index, id, (unsigned long long) off);
+					free(pg);
+					return -1;
+				}
 
 				page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn, id,
 								 off + sizeof(hdr), ps_crc32c(pg, page_size));
@@ -1699,6 +1744,7 @@ recover(void)
 					(unsigned long long) s->cur_off);
 	}
 	free(pg);
+	return 0;
 }
 
 /* ===================== request handling (non-I/O ops) ================== */
@@ -2059,7 +2105,12 @@ ps_core_open(const char *store_dir)
 		return -1;
 	if (ps_layer_store->open(store_dir) != 0)
 		return -1;
-	load_store_gen(store_dir);	/* generation stamped into every segment record */
+	if (load_store_gen(store_dir) != 0)	/* generation stamped into each record */
+	{
+		fprintf(stderr, "pagestore_core: could not durably establish store "
+				"generation in %s\n", store_dir);
+		return -1;
+	}
 	if (validate_store_nshards(store_dir) != 0)
 		return -1;
 
@@ -2160,7 +2211,8 @@ ps_core_open(const char *store_dir)
 	 * already-flushed segment prefix via a persisted flush watermark is a
 	 * deferred optimization.)
 	 */
-	recover();
+	if (recover() != 0)			/* corruption or OOM: don't open over a real store */
+		return -1;
 
 	/* rebuild each timeline's shipped-WAL end LSN from its log (WAL is shard-0,
 	 * single-threaded here; all shards' timeline copies are identical) */

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1698,10 +1698,45 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
  * unsynced tail (to fail loudly on the former) is deferred to the sync-watermark
  * work noted in SPDK_NOTES.
  */
+/*
+ * Physically clear everything from (seg, off) forward in a shard's segments, so a
+ * truncated tail cannot be resurrected: the old records past a truncation point
+ * keep valid CRCs at their own offsets, so after the daemon overwrites only some of
+ * them and crashes again, the next recover would otherwise replay the untouched
+ * ones.  Zeroing their headers makes them unreadable.  zbuf is page_size zeros.
+ * Returns 1 if it wrote anything (caller must sync), 0 if nothing, -1 on error.
+ */
+static int
+zero_shard_forward(uint32_t shard, int seg, uint64_t off, unsigned char *zbuf)
+{
+	uint32_t	local = seg_local(seg);
+	int			wrote = 0;
+
+	for (;; local++, off = 0)
+	{
+		int			id = seg_id(shard, local);
+
+		if (ps_storage->seg_size(id) < 0)
+			break;				/* no more segments in this shard */
+		for (uint64_t p = off; p < segment_size;)
+		{
+			uint32_t	n = (segment_size - p > page_size)
+				? page_size : (uint32_t) (segment_size - p);
+
+			if (ps_storage->seg_write(id, p, zbuf, n) != 0)
+				return -1;
+			p += n;
+			wrote = 1;
+		}
+	}
+	return wrote;
+}
+
 static int
 recover(void)
 {
 	unsigned char *pg = malloc(page_size);	/* scratch to read+verify each page */
+	int			need_sync = 0;	/* a tail was zeroed and must be made durable */
 
 	if (!pg)
 		return -1;				/* don't open with an empty index over a real store */
@@ -1777,7 +1812,47 @@ recover(void)
 			fprintf(stderr, "pagestore_daemon: shard %u recovered through segment "
 					"%d (off %llu)\n", s->index, s->cur_seg,
 					(unsigned long long) s->cur_off);
+
+		/*
+		 * Physically clear the tail past the append cursor when it could hold
+		 * resurrectable records: either segments exist beyond the cursor, or the
+		 * stop point holds non-zero (torn/corrupt/stale) bytes rather than a clean
+		 * unwritten tail.  A clean tail (cursor at the true end, nothing after) is
+		 * left untouched so normal recovery does no extra I/O.
+		 */
+		if (s->cur_seg >= 0)
+		{
+			int			next = seg_id(s->index, seg_local(s->cur_seg) + 1);
+			int			stale = (ps_storage->seg_size(next) >= 0);
+			SegRecHdr	probe;
+
+			if (!stale &&
+				ps_storage->seg_read(s->cur_seg, s->cur_off, &probe,
+									 sizeof(probe)) == 0)
+				for (size_t k = 0; k < sizeof(probe); k++)
+					if (((unsigned char *) &probe)[k])
+					{
+						stale = 1;
+						break;
+					}
+			if (stale)
+			{
+				int			z;
+
+				memset(pg, 0, page_size);
+				z = zero_shard_forward(s->index, s->cur_seg, s->cur_off, pg);
+				if (z < 0)
+				{
+					free(pg);
+					return -1;
+				}
+				if (z)
+					need_sync = 1;
+			}
+		}
 	}
+	if (need_sync)
+		ps_storage->sync();		/* make the tail truncation durable */
 	free(pg);
 	return 0;
 }

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1813,49 +1813,80 @@ recover(void)
 					"%d (off %llu)\n", s->index, s->cur_seg,
 					(unsigned long long) s->cur_off);
 
-		/*
-		 * Physically clear the tail past the append cursor when it could hold
-		 * resurrectable records: either segments exist beyond the cursor, or the
-		 * stop point holds non-zero (torn/corrupt/stale) bytes rather than a clean
-		 * unwritten tail.  A clean tail (cursor at the true end, nothing after) is
-		 * left untouched so normal recovery does no extra I/O.
-		 */
+		if (s->cur_seg < 0)
 		{
-			/* Start clearing at the append cursor, or -- when recovery rebuilt
-			 * nothing because the shard's very first segment's first record was
-			 * already invalid -- at that first segment, so its stale later records
-			 * can't resurrect either. */
-			int			zseg = (s->cur_seg >= 0) ? s->cur_seg : seg_id(s->index, 0);
-			uint64_t	zoff = (s->cur_seg >= 0) ? s->cur_off : 0;
+			/*
+			 * Recovered nothing from this shard.  If its first segment nonetheless
+			 * holds non-zero data, we could not replay it -- a wrong --page-size, a
+			 * corrupt or foreign store_gen, or corruption of the very first record.
+			 * That is indistinguishable from stale raw-device bytes, and zeroing it
+			 * would erase a valid store merely opened with the wrong config, so fail
+			 * open instead.  A fresh store has no first segment (or an all-zero one
+			 * from a prior truncation) and opens normally.
+			 */
+			int			first = seg_id(s->index, 0);
+			SegRecHdr	probe;
 
-			if (ps_storage->seg_size(zseg) >= 0)
+			if (ps_storage->seg_size(first) >= 0 &&
+				ps_storage->seg_read(first, 0, &probe, sizeof(probe)) == 0)
+				for (size_t k = 0; k < sizeof(probe); k++)
+					if (((unsigned char *) &probe)[k])
+					{
+						fprintf(stderr, "pagestore: shard %u: existing segment data "
+								"could not be recovered (wrong --page-size, or a "
+								"corrupt/foreign store generation); refusing to "
+								"recover\n", s->index);
+						free(pg);
+						return -1;
+					}
+		}
+		else
+		{
+			/*
+			 * Physically clear the tail past the append cursor when it actually
+			 * holds non-zero bytes -- a torn/corrupt/stale record at the cursor, or
+			 * at the start of the next segment -- so those records can't resurrect
+			 * after a partial overwrite + crash.  Probing content (not mere segment
+			 * existence) means a tail a previous recovery already zeroed is not
+			 * re-zeroed on every restart.
+			 */
+			int			stale = 0;
+			SegRecHdr	probe;
+
+			if (ps_storage->seg_read(s->cur_seg, s->cur_off, &probe,
+									 sizeof(probe)) == 0)
+				for (size_t k = 0; k < sizeof(probe); k++)
+					if (((unsigned char *) &probe)[k])
+					{
+						stale = 1;
+						break;
+					}
+			if (!stale)
 			{
-				int			next = seg_id(s->index, seg_local(zseg) + 1);
-				int			stale = (ps_storage->seg_size(next) >= 0);
-				SegRecHdr	probe;
+				int			next = seg_id(s->index, seg_local(s->cur_seg) + 1);
 
-				if (!stale &&
-					ps_storage->seg_read(zseg, zoff, &probe, sizeof(probe)) == 0)
+				if (ps_storage->seg_size(next) >= 0 &&
+					ps_storage->seg_read(next, 0, &probe, sizeof(probe)) == 0)
 					for (size_t k = 0; k < sizeof(probe); k++)
 						if (((unsigned char *) &probe)[k])
 						{
 							stale = 1;
 							break;
 						}
-				if (stale)
-				{
-					int			z;
+			}
+			if (stale)
+			{
+				int			z;
 
-					memset(pg, 0, page_size);
-					z = zero_shard_forward(s->index, zseg, zoff, pg);
-					if (z < 0)
-					{
-						free(pg);
-						return -1;
-					}
-					if (z)
-						need_sync = 1;
+				memset(pg, 0, page_size);
+				z = zero_shard_forward(s->index, s->cur_seg, s->cur_off, pg);
+				if (z < 0)
+				{
+					free(pg);
+					return -1;
 				}
+				if (z)
+					need_sync = 1;
 			}
 		}
 	}
@@ -2272,6 +2303,16 @@ ps_core_open(const char *store_dir)
 	{
 		fprintf(stderr, "pagestore_core: --cache-pages must be >= 0 (got %d)\n",
 				cache_pages);
+		return -1;
+	}
+	/* a segment record (header + one page) must fit in a segment; otherwise a
+	 * grossly-wrong --page-size would make recover()'s first record overflow the
+	 * segment and be mis-handled */
+	if (sizeof(SegRecHdr) + page_size > segment_size)
+	{
+		fprintf(stderr, "pagestore_core: page_size %u + record header exceeds "
+				"segment_size %llu\n", page_size,
+				(unsigned long long) segment_size);
 		return -1;
 	}
 

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -106,7 +106,8 @@ extern uint32_t ps_crc32c(const void *buf, size_t len);
 /*
  * Resolve a read into out (page_size bytes), serving from memtable / image
  * layers with a segment fallback.  Returns 1 if found (out filled), 0 if the
- * page is unwritten.
+ * page is unwritten, and -1 on an integrity error (a corrupt or failed segment
+ * read) -- which the caller must surface as an error, not serve as zeros.
  */
 extern int	read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 						 uint64_t read_lsn, unsigned char *out);

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -31,6 +31,7 @@ typedef struct PageVer
 	uint64_t	lsn;			/* the page's pd_lsn when it was written */
 	int			seg;			/* segment id holding the bytes */
 	uint64_t	off;			/* byte offset of the page within that segment */
+	uint32_t	crc;			/* CRC32C of the page bytes (verified on read) */
 } PageVer;
 
 /* Configuration shared with the frontend; set by the frontend before open. */
@@ -98,6 +99,9 @@ extern PageVer *read_through_cacheable(uint32_t timeline, const PsKey *key,
 									   uint32_t block, uint64_t read_lsn,
 									   uint32_t *src_tl, int *ambiguous);
 extern int	read_version(const PageVer *v, unsigned char *out);
+
+/* CRC32C of a buffer (page-integrity checks shared with the SPDK read path). */
+extern uint32_t ps_crc32c(const void *buf, size_t len);
 
 /*
  * Resolve a read into out (page_size bytes), serving from memtable / image

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -154,16 +154,30 @@ handle_request(PsChannel *ch)
 			for (uint32_t i = 0; i < ch->nblocks; i++)
 			{
 				unsigned char *dst = ch->data + (size_t) i * page_size;
+				int			r = read_resolve(tl, &ch->key, ch->blocknum + i,
+											 UINT64_MAX, dst);
 
-				if (!read_resolve(tl, &ch->key, ch->blocknum + i, UINT64_MAX, dst))
+				if (r < 0)		/* corrupt stored page: fail, don't serve zeros */
+				{
+					ch->status = PS_STATUS_ERROR;
+					break;
+				}
+				if (r == 0)
 					memset(dst, 0, page_size);	/* unwritten -> zeros */
 			}
 			break;
 
 		case PS_OP_READ_AT:
 			/* as-of read on this timeline, honoring branch ancestry */
-			if (!read_resolve(tl, &ch->key, ch->blocknum, ch->req_lsn, ch->data))
-				memset(ch->data, 0, page_size);
+			{
+				int			r = read_resolve(tl, &ch->key, ch->blocknum,
+											 ch->req_lsn, ch->data);
+
+				if (r < 0)
+					ch->status = PS_STATUS_ERROR;
+				else if (r == 0)
+					memset(ch->data, 0, page_size);
+			}
 			break;
 
 		default:

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -166,10 +166,14 @@ read_done(void *arg, int ok)
 	BlkCtx	   *bc = arg;
 	ReqState   *rs = bc->rs;
 
+	/* A failed engine read (submission/device error, or a read too large for the
+	 * async buffer) must not be published as OK with stale/zero data. */
+	if (!ok)
+		rs->ch->status = PS_STATUS_ERROR;
 	/* verify the delivered page against the version's CRC: device bit rot or a
 	 * misread must not be served as valid or cached.  Zero-fill and fail the
 	 * request rather than hand the client corrupt bytes. */
-	if (ok && ps_crc32c(bc->dst, page_size) != bc->crc)
+	else if (ps_crc32c(bc->dst, page_size) != bc->crc)
 	{
 		memset(bc->dst, 0, page_size);
 		rs->ch->status = PS_STATUS_ERROR;

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -56,6 +56,7 @@ typedef struct BlkCtx
 	PsKey		key;
 	uint32_t	block;
 	uint64_t	lsn;
+	uint32_t	crc;			/* expected page CRC32C (from the version index) */
 	int			cacheable;		/* 0 if the version's lsn is ambiguous */
 	unsigned char *dst;
 } BlkCtx;
@@ -165,6 +166,15 @@ read_done(void *arg, int ok)
 	BlkCtx	   *bc = arg;
 	ReqState   *rs = bc->rs;
 
+	/* verify the delivered page against the version's CRC: device bit rot or a
+	 * misread must not be served as valid or cached.  Zero-fill and fail the
+	 * request rather than hand the client corrupt bytes. */
+	if (ok && ps_crc32c(bc->dst, page_size) != bc->crc)
+	{
+		memset(bc->dst, 0, page_size);
+		rs->ch->status = PS_STATUS_ERROR;
+		ok = 0;
+	}
 	if (ok && bc->cacheable)	/* the engine delivered the page into bc->dst */
 		ps_pgcache_insert(ps_core_pgcache_for(&bc->key), bc->tl, &bc->key,
 						  bc->block, bc->lsn, bc->dst);
@@ -269,6 +279,7 @@ begin(uint32_t i, PsChannel *ch)
 					bc->key = ch->key;
 					bc->block = blk;
 					bc->lsn = v->lsn;
+					bc->crc = v->crc;
 					bc->cacheable = !ambig;
 					bc->dst = dst;
 					rs->pending++;
@@ -319,6 +330,7 @@ begin(uint32_t i, PsChannel *ch)
 				bc->key = ch->key;
 				bc->block = ch->blocknum;
 				bc->lsn = v->lsn;
+				bc->crc = v->crc;
 				bc->cacheable = !ambig;
 				bc->dst = ch->data;
 				ps_spdk_read_async(v->seg, v->off, ch->data, page_size,


### PR DESCRIPTION
On the raw-NVMe backend there's no filesystem to provide sparse-zero reads, atomic metadata, or fsck, so segment records carry their own integrity — following what modern filesystems do (**CRC32C** + self-identifying + **generation**, à la btrfs/ext4 `metadata_csum`, ZFS txg, T10-PI reference tag). Answers the "is CRC enough / what do modern FSes use" discussion: CRC alone isn't — it's paired with position + generation. Stacked on #30.

## What
- **`SegRecHdr` gains `crc` + `gen`.** `crc` = CRC32C over the record's **position** (seg id + offset → catches a misdirected write), the header (crc zeroed, deterministic padding), and the page bytes. `gen` = a per-store generation (random, persisted durably in `<store>/store_gen`) stamped into every record.
- **`recover()`** reads each page and rejects a record whose magic matches but whose `gen` ≠ the store's or whose `crc` fails — treating it as end-of-log instead of replaying a torn write or **stale prior-tenant bytes a raw device leaves behind** (an FS would read those as zeros).
- **Read-path verification**: a per-version page CRC in the index is checked by `read_version()` (POSIX segment fallback) and the SPDK read completion (`read_done`) — zero-fill + fail the request on mismatch rather than serve bit rot.
- `ps_crc32c()` shared with the SPDK daemon; table + generation initialized in `ps_core_open()` before recover and any worker.

## Test
- CRC32C validated against the standard vector: `crc32c("123456789") == 0xE3069283`.
- Compiles clean (POSIX + SPDK, `-Wall -Wextra -Werror`); image-layer unit test **74/0**; nshards=1 unchanged.

> A new store bumps the segment format (gen/crc fields), so an old segment store reads as fresh — fine for this unmerged line. Note: local daemon-suite capture + SPDK device-bind were environmentally unavailable this session, so CI (clean env) is the regression check for the full standalone suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)