### PR TITLE
contrib/pagestore: WAL index returns (timeline,lsn) + overflow flag (redo 3c-4 prereq)

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -582,27 +582,25 @@ pagestore_localsvc_walidx_get(const PageStoreRelKey *key, BlockNumber block,
 {
 	PsChannel  *ch = ls_chan(key);
 	uint32	   *tls;
-	int			n;
-	bool		ov;
+	int			total,
+				n;
 
 	ls_fill_key(ch, key);
 	ch->opcode = PS_OP_WAL_INDEX_GET;
 	ch->blocknum = block;
 	ch->req_lsn = lsn_max;
 	ls_exec(ch);
-	n = (int) ch->result;
-	ov = (ch->result_flags & PS_WALIDX_OVERFLOW) != 0;
+	total = (int) ch->result;	/* true match count (may exceed the payload) */
 	tls = (uint32 *) (ch->data + (size_t) PS_WALIDX_CAP * sizeof(uint64));
+	/* the payload holds only the first min(total, PS_WALIDX_CAP) pairs */
+	n = total < PS_WALIDX_CAP ? total : PS_WALIDX_CAP;
 	if (n > maxn)
-	{
 		n = maxn;
-		ov = true;				/* caller's buffer can't hold the whole chain */
-	}
 	memcpy(out, ch->data, (size_t) n * sizeof(uint64));
 	if (out_tl)
 		memcpy(out_tl, tls, (size_t) n * sizeof(uint32));
 	if (overflow)
-		*overflow = ov;
+		*overflow = (n < total);	/* caller did not receive the whole chain */
 	return n;
 }
 

--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -571,14 +571,19 @@ pagestore_localsvc_walidx_count(const PageStoreRelKey *key, BlockNumber block)
 	return (int) ch->result;
 }
 
-/* Fetch up to maxn record LSNs (<= lsn_max) for (key, block) into out;
- * returns how many.  Ascending order. */
+/* Fetch up to maxn record LSNs (<= lsn_max) for (key, block) into out, and -- if
+ * out_tl != NULL -- the source timeline of each LSN into out_tl; returns how
+ * many.  Sets *overflow if the full chain did not fit (in the channel or in
+ * maxn), so the caller paginates or fails rather than using a truncated list. */
 int
 pagestore_localsvc_walidx_get(const PageStoreRelKey *key, BlockNumber block,
-							  uint64 lsn_max, uint64 *out, int maxn)
+							  uint64 lsn_max, uint64 *out, uint32 *out_tl,
+							  int maxn, bool *overflow)
 {
 	PsChannel  *ch = ls_chan(key);
+	uint32	   *tls;
 	int			n;
+	bool		ov;
 
 	ls_fill_key(ch, key);
 	ch->opcode = PS_OP_WAL_INDEX_GET;
@@ -586,9 +591,18 @@ pagestore_localsvc_walidx_get(const PageStoreRelKey *key, BlockNumber block,
 	ch->req_lsn = lsn_max;
 	ls_exec(ch);
 	n = (int) ch->result;
+	ov = (ch->result_flags & PS_WALIDX_OVERFLOW) != 0;
+	tls = (uint32 *) (ch->data + (size_t) PS_WALIDX_CAP * sizeof(uint64));
 	if (n > maxn)
+	{
 		n = maxn;
+		ov = true;				/* caller's buffer can't hold the whole chain */
+	}
 	memcpy(out, ch->data, (size_t) n * sizeof(uint64));
+	if (out_tl)
+		memcpy(out_tl, tls, (size_t) n * sizeof(uint32));
+	if (overflow)
+		*overflow = ov;
 	return n;
 }
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -694,10 +694,18 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 										  (uint64) lsn, lsns, NULL,
 										  PS_REDO_MAX_RECS, &overflow);
 		if (overflow)
+		{
+			/* The chain is longer than we fetched, so the newest full-page image
+			 * may be in the unseen suffix; a base built from the truncated prefix
+			 * could be stale.  Fail (no page) until pagination exists, rather than
+			 * report success with a possibly-wrong image. */
 			ereport(WARNING,
 					(errmsg("pagestore WAL-index chain for block %d exceeds %d records; "
-							"base-image scan may miss the newest full-page image",
+							"cannot reconstruct base image without pagination",
 							blocknum, PS_REDO_MAX_RECS)));
+			pfree(lsns);
+			PG_RETURN_NULL();
+		}
 	}
 	if (n == 0)
 		PG_RETURN_NULL();

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -687,8 +687,18 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 	relation_close(rel, AccessShareLock);
 
 	lsns = palloc(sizeof(uint64) * PS_REDO_MAX_RECS);
-	n = pagestore_localsvc_walidx_get(&key, (BlockNumber) blocknum, (uint64) lsn,
-									  lsns, PS_REDO_MAX_RECS);
+	{
+		bool		overflow = false;
+
+		n = pagestore_localsvc_walidx_get(&key, (BlockNumber) blocknum,
+										  (uint64) lsn, lsns, NULL,
+										  PS_REDO_MAX_RECS, &overflow);
+		if (overflow)
+			ereport(WARNING,
+					(errmsg("pagestore WAL-index chain for block %d exceeds %d records; "
+							"base-image scan may miss the newest full-page image",
+							blocknum, PS_REDO_MAX_RECS)));
+	}
 	if (n == 0)
 		PG_RETURN_NULL();
 

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -153,6 +153,7 @@ extern int	pagestore_localsvc_walidx_count(const PageStoreRelKey *key,
 											BlockNumber block);
 extern int	pagestore_localsvc_walidx_get(const PageStoreRelKey *key,
 										  BlockNumber block, uint64 lsn_max,
-										  uint64 *out, int maxn);
+										  uint64 *out, uint32 *out_tl, int maxn,
+										  bool *overflow);
 
 #endif							/* PAGESTORE_BACKEND_H */

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1603,13 +1603,18 @@ walidx_add(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 }
 
 /* Copy the record LSNs for (tl,key,block) that are <= lsn_max into out (cap
- * max_out); return how many.  Walks the timeline ancestry. */
+ * max_out), and -- when out_tl != NULL -- the source timeline of each LSN into
+ * out_tl (the ancestry level it came from, which the caller needs to fetch each
+ * record from the right per-timeline WAL).  Returns how many were written; sets
+ * *overflow if there were more matches than fit, so the caller can paginate or
+ * fail rather than silently use a truncated chain.  Walks the timeline ancestry. */
 static int
 walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
-		   uint64_t *out, int max_out)
+		   uint64_t *out, uint32_t *out_tl, int max_out, bool *overflow)
 {
 	Shard	   *s = shard_for(key);	/* same shard across the ancestry walk */
 	int			got = 0;
+	bool		ov = false;
 
 	for (;;)
 	{
@@ -1619,9 +1624,19 @@ walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
 		for (e = s->walidx[h & IDX_MASK]; e; e = e->next)
 			if (e->timeline == tl && e->block == block && key_eq(&e->key, key))
 			{
-				for (int i = 0; i < e->n && got < max_out; i++)
+				for (int i = 0; i < e->n; i++)
 					if (e->lsns[i] <= lsn_max)
-						out[got++] = e->lsns[i];
+					{
+						if (got < max_out)
+						{
+							out[got] = e->lsns[i];
+							if (out_tl)
+								out_tl[got] = tl;	/* source timeline of this LSN */
+							got++;
+						}
+						else
+							ov = true;	/* more matches than fit */
+					}
 				break;
 			}
 		if (!timeline_has_parent(s, tl))
@@ -1630,6 +1645,8 @@ walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
 			lsn_max = s->timelines[tl].branch_lsn;
 		tl = (uint32_t) s->timelines[tl].parent;
 	}
+	if (overflow)
+		*overflow = ov;
 	return got;
 }
 
@@ -2285,10 +2302,18 @@ ps_handle_meta(PsChannel *ch)
 			break;
 
 		case PS_OP_WAL_INDEX_GET:
+		{
+			uint64_t   *lsns = (uint64_t *) ch->data;
+			uint32_t   *tls = (uint32_t *) (ch->data +
+											(size_t) PS_WALIDX_CAP * sizeof(uint64_t));
+			bool		ov = false;
+
 			ch->result = (uint32_t) walidx_get(tl, &ch->key, ch->blocknum,
-											   ch->req_lsn, (uint64_t *) ch->data,
-											   (int) (PS_IO_UNIT / sizeof(uint64_t)));
+											   ch->req_lsn, lsns, tls,
+											   PS_WALIDX_CAP, &ov);
+			ch->result_flags = ov ? PS_WALIDX_OVERFLOW : 0;
 			break;
+		}
 
 		case PS_OP_IMMEDSYNC:
 			/* capture-before-sync + commit, serialized against concurrent syncs */

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1605,16 +1605,17 @@ walidx_add(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 /* Copy the record LSNs for (tl,key,block) that are <= lsn_max into out (cap
  * max_out), and -- when out_tl != NULL -- the source timeline of each LSN into
  * out_tl (the ancestry level it came from, which the caller needs to fetch each
- * record from the right per-timeline WAL).  Returns how many were written; sets
- * *overflow if there were more matches than fit, so the caller can paginate or
- * fail rather than silently use a truncated chain.  Walks the timeline ancestry. */
+ * record from the right per-timeline WAL).  Writes at most max_out pairs but
+ * returns the TRUE total number of matches, so a caller that only needs the count
+ * (PS_OP_WAL_INDEX_GET with no buffer pressure) gets it uncapped and a caller that
+ * reads the pairs can tell the chain was truncated (total > written).  Walks the
+ * timeline ancestry. */
 static int
 walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
-		   uint64_t *out, uint32_t *out_tl, int max_out, bool *overflow)
+		   uint64_t *out, uint32_t *out_tl, int max_out)
 {
 	Shard	   *s = shard_for(key);	/* same shard across the ancestry walk */
-	int			got = 0;
-	bool		ov = false;
+	int			total = 0;
 
 	for (;;)
 	{
@@ -1627,15 +1628,13 @@ walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
 				for (int i = 0; i < e->n; i++)
 					if (e->lsns[i] <= lsn_max)
 					{
-						if (got < max_out)
+						if (total < max_out)
 						{
-							out[got] = e->lsns[i];
+							out[total] = e->lsns[i];
 							if (out_tl)
-								out_tl[got] = tl;	/* source timeline of this LSN */
-							got++;
+								out_tl[total] = tl;	/* source timeline of this LSN */
 						}
-						else
-							ov = true;	/* more matches than fit */
+						total++;	/* counts all matches, even past max_out */
 					}
 				break;
 			}
@@ -1645,9 +1644,7 @@ walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
 			lsn_max = s->timelines[tl].branch_lsn;
 		tl = (uint32_t) s->timelines[tl].parent;
 	}
-	if (overflow)
-		*overflow = ov;
-	return got;
+	return total;
 }
 
 /* ===================== write / read primitives ========================= */
@@ -2306,12 +2303,13 @@ ps_handle_meta(PsChannel *ch)
 			uint64_t   *lsns = (uint64_t *) ch->data;
 			uint32_t   *tls = (uint32_t *) (ch->data +
 											(size_t) PS_WALIDX_CAP * sizeof(uint64_t));
-			bool		ov = false;
+			int			total = walidx_get(tl, &ch->key, ch->blocknum,
+										   ch->req_lsn, lsns, tls, PS_WALIDX_CAP);
 
-			ch->result = (uint32_t) walidx_get(tl, &ch->key, ch->blocknum,
-											   ch->req_lsn, lsns, tls,
-											   PS_WALIDX_CAP, &ov);
-			ch->result_flags = ov ? PS_WALIDX_OVERFLOW : 0;
+			/* result is the true match count (so the count path is uncapped);
+			 * the payload holds only the first min(total, PS_WALIDX_CAP) pairs */
+			ch->result = (uint32_t) total;
+			ch->result_flags = (total > PS_WALIDX_CAP) ? PS_WALIDX_OVERFLOW : 0;
 			break;
 		}
 

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -42,6 +42,15 @@
  */
 #define PS_IO_UNIT			(256 * 1024)
 
+/* result_flags bits.  WAL_INDEX_GET: the (timeline,lsn) chain had more records
+ * than fit in one response -- the returned set is a prefix, not the whole chain;
+ * the caller must paginate or treat it as an error rather than a complete list. */
+#define PS_WALIDX_OVERFLOW	0x1u
+
+/* WAL_INDEX_GET payload: lsns[] (uint64) at data[0], then the parallel source
+ * timelines tls[] (uint32) at data[cap*8]; cap = how many pairs fit. */
+#define PS_WALIDX_CAP		((int) (PS_IO_UNIT / (sizeof(uint64_t) + sizeof(uint32_t))))
+
 /* Geometry */
 #define PS_MAX_CHANNELS		128
 
@@ -118,13 +127,14 @@ typedef struct PsChannel
 	uint32_t	timeline;		/* timeline this op targets (0 = main) */
 	uint32_t	parent_timeline;	/* CREATE_BRANCH: parent timeline */
 	uint32_t	datalen;		/* WAL_APPEND: number of WAL bytes in data[] */
-	uint32_t	pad1;
+	uint32_t	pad1;			/* keep req_lsn 8-byte aligned */
 	uint64_t	req_lsn;		/* READ_AT/WAL_APPEND: LSN; WAL_SIZE: out end LSN */
 	PsKey		key;
 
 	/* result */
 	uint32_t	status;
 	uint32_t	result;			/* NBLOCKS -> count; EXISTS -> 0/1 */
+	uint32_t	result_flags;	/* WAL_INDEX_GET -> PS_WALIDX_* (was pad1) */
 
 	/* payload: up to PS_IO_UNIT bytes (io_unit / page_size pages) */
 	unsigned char data[PS_IO_UNIT];

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 #define PS_SHM_MAGIC		0x50414753	/* "PAGS" */
-#define PS_SHM_VERSION		5			/* 5: pad0 -> nshards (shard-pool routing) */
+#define PS_SHM_VERSION		6			/* 6: WAL_INDEX_GET (timeline,lsn) + result_flags */
 
 /* Default logical page size (overridable via the daemon's --page-size). */
 #define PS_DEFAULT_PAGE_SIZE	8192
@@ -135,6 +135,7 @@ typedef struct PsChannel
 	uint32_t	status;
 	uint32_t	result;			/* NBLOCKS -> count; EXISTS -> 0/1 */
 	uint32_t	result_flags;	/* WAL_INDEX_GET -> PS_WALIDX_* (was pad1) */
+	uint32_t	result_pad;		/* keep data[] 8-byte aligned for (uint64*)data */
 
 	/* payload: up to PS_IO_UNIT bytes (io_unit / page_size pages) */
 	unsigned char data[PS_IO_UNIT];

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -473,10 +473,11 @@ op_walidx_add(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block, uint64_t 
 	cl_exec(ch);
 }
 
-/* Returns count; fills out[] with the record LSNs <= lsn_max. */
+/* Returns count; fills out[] with the record LSNs <= lsn_max, and -- when
+ * out_tl != NULL -- the parallel source timeline of each LSN. */
 static int
 op_walidx_get(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
-			  uint64_t lsn_max, uint64_t *out)
+			  uint64_t lsn_max, uint64_t *out, uint32_t *out_tl)
 {
 	PsChannel  *ch = cl_route(rel, fork);
 	int			n;
@@ -488,6 +489,9 @@ op_walidx_get(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
 	ch->req_lsn = lsn_max;
 	n = (int) cl_exec(ch)->result;
 	memcpy(out, ch->data, (size_t) n * sizeof(uint64_t));
+	if (out_tl)
+		memcpy(out_tl, ch->data + (size_t) PS_WALIDX_CAP * sizeof(uint64_t),
+			   (size_t) n * sizeof(uint32_t));
 	return n;
 }
 
@@ -1011,22 +1015,38 @@ run_walidx_suite(const char *daemon_path, const char *tmpbase)
 	op_walidx_add(0, REL_A, FORK0, 0, 300);
 	op_walidx_add(0, REL_A, FORK0, 1, 150);
 
-	n = op_walidx_get(0, REL_A, FORK0, 0, 250, out);
+	n = op_walidx_get(0, REL_A, FORK0, 0, 250, out, NULL);
 	check(n == 2 && out[0] == 100 && out[1] == 200,
 		  "index returns records <= lsn (block 0 as-of 250 -> [100,200])");
-	n = op_walidx_get(0, REL_A, FORK0, 0, 1000000, out);
+	n = op_walidx_get(0, REL_A, FORK0, 0, 1000000, out, NULL);
 	check(n == 3 && out[2] == 300, "index returns all records up to a high lsn");
-	check(op_walidx_get(0, REL_A, FORK0, 0, 50, out) == 0, "no records below the first lsn");
-	n = op_walidx_get(0, REL_A, FORK0, 1, 200, out);
+	check(op_walidx_get(0, REL_A, FORK0, 0, 50, out, NULL) == 0, "no records below the first lsn");
+	n = op_walidx_get(0, REL_A, FORK0, 1, 200, out, NULL);
 	check(n == 1 && out[0] == 150, "per-block separation (block 1 -> [150])");
-	check(op_walidx_get(0, REL_A, FORK0, 9, 1000000, out) == 0, "unindexed block -> empty");
+	check(op_walidx_get(0, REL_A, FORK0, 9, 1000000, out, NULL) == 0, "unindexed block -> empty");
 
-	/* a branch sees its own records plus the parent's, capped at the fork LSN */
+	/* a branch sees its own records plus the parent's, capped at the fork LSN,
+	 * and each returned LSN is tagged with the timeline it came from */
 	op_create_branch(1, 0, 250);
 	op_walidx_add(1, REL_A, FORK0, 0, 400);
-	n = op_walidx_get(1, REL_A, FORK0, 0, 1000000, out);
-	/* branch's 400, plus parent's <= branch_lsn 250 (100,200; not 300) */
-	check(n == 3, "branch index reads through to parent capped at the branch lsn");
+	{
+		uint32_t	tls[64];
+		int			from_child = 0,
+					from_parent = 0;
+
+		n = op_walidx_get(1, REL_A, FORK0, 0, 1000000, out, tls);
+		/* branch's 400, plus parent's <= branch_lsn 250 (100,200; not 300) */
+		check(n == 3, "branch index reads through to parent capped at the branch lsn");
+		for (int i = 0; i < n; i++)
+		{
+			if (out[i] == 400)
+				from_child += (tls[i] == 1);
+			else
+				from_parent += (tls[i] == 0);
+		}
+		check(from_child == 1 && from_parent == 2,
+			  "branch index tags each LSN with its source timeline (400->tl1, 100/200->tl0)");
+	}
 
 	client_detach();
 	stop_daemon(dpid);

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -480,19 +480,21 @@ op_walidx_get(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
 			  uint64_t lsn_max, uint64_t *out, uint32_t *out_tl)
 {
 	PsChannel  *ch = cl_route(rel, fork);
-	int			n;
+	int			total,
+				ndata;
 
 	cl_setkey(ch, rel, fork);
 	ch->timeline = tl;
 	ch->opcode = PS_OP_WAL_INDEX_GET;
 	ch->blocknum = block;
 	ch->req_lsn = lsn_max;
-	n = (int) cl_exec(ch)->result;
-	memcpy(out, ch->data, (size_t) n * sizeof(uint64_t));
+	total = (int) cl_exec(ch)->result;	/* true match count */
+	ndata = total < PS_WALIDX_CAP ? total : PS_WALIDX_CAP;	/* pairs in payload */
+	memcpy(out, ch->data, (size_t) ndata * sizeof(uint64_t));
 	if (out_tl)
 		memcpy(out_tl, ch->data + (size_t) PS_WALIDX_CAP * sizeof(uint64_t),
-			   (size_t) n * sizeof(uint32_t));
-	return n;
+			   (size_t) ndata * sizeof(uint32_t));
+	return total;
 }
 
 /* ===================== page helpers ==================================== */


### PR DESCRIPTION
First **implementation** slice toward 3c-4 single-page WAL redo (the design landed in #33). Makes the per-page WAL index query carry what the redo driver needs and stop truncating silently — directly addressing two design-review findings ("carry source timeline", "no silent truncation").

## Changes
- **`walidx_get()`** fills a parallel **source-timeline** array (the ancestry level each LSN came from — the driver fetches each record from the right per-timeline WAL) and reports **overflow** via an out-param: it keeps counting matches past `max_out` and sets `*overflow` when the chain didn't fit, instead of silently capping.
- **`WAL_INDEX_GET`** marshals `lsns[]` then the parallel `tls[]` in the channel (`cap = PS_WALIDX_CAP`) and sets `result_flags & PS_WALIDX_OVERFLOW`; the request padding word becomes `result_flags`.
- **`pagestore_localsvc_walidx_get()`** exposes `out_tl` + `*overflow` (also set when the caller's `maxn` < full chain).
- **`pagestore_redo_page` (3c-3)** now warns on overflow rather than silently scanning a truncated chain (a later driver slice will paginate).
- **Standalone test** tags the branch case: `400 -> tl1`, inherited `100/200 -> tl0`.

## Verification
Core compiles `-Werror`; standalone daemon suite **358/0** (incl. the new timeline-tagging assertions). PG-side files (`pagestore.c`, `backend_localsvc.c`) verified by CI.

Stacked on `feat/pagestore-walredo-plan` (#33, the design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)