### PR TITLE
Add a single-page WAL-redo helper mode (postgres --wal-redo) — skeleton (3c-4 / slice 4a)

### DIFF
--- a/src/backend/main/main.c
+++ b/src/backend/main/main.c
@@ -34,6 +34,7 @@
 #include "common/username.h"
 #include "miscadmin.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/walredo.h"
 #include "tcop/tcopprot.h"
 #include "utils/help_config.h"
 #include "utils/memutils.h"
@@ -52,6 +53,7 @@ static const char *const DispatchOptionNames[] =
 	[DISPATCH_FORKCHILD] = "forkchild",
 	[DISPATCH_DESCRIBE_CONFIG] = "describe-config",
 	[DISPATCH_SINGLE] = "single",
+	[DISPATCH_WALREDO] = "wal-redo",
 	/* DISPATCH_POSTMASTER has no name */
 };
 
@@ -226,6 +228,9 @@ main(int argc, char *argv[])
 		case DISPATCH_SINGLE:
 			PostgresSingleUserMain(argc, argv,
 								   strdup(get_user_name_or_exit(progname)));
+			break;
+		case DISPATCH_WALREDO:
+			WalRedoMain(argc, argv);
 			break;
 		case DISPATCH_POSTMASTER:
 			PostmasterMain(argc, argv);

--- a/src/backend/postmaster/Makefile
+++ b/src/backend/postmaster/Makefile
@@ -27,6 +27,7 @@ OBJS = \
 	postmaster.o \
 	startup.o \
 	syslogger.o \
+	walredo.o \
 	walsummarizer.o \
 	walwriter.o
 

--- a/src/backend/postmaster/meson.build
+++ b/src/backend/postmaster/meson.build
@@ -15,6 +15,7 @@ backend_sources += files(
   'postmaster.c',
   'startup.c',
   'syslogger.c',
+  'walredo.c',
   'walsummarizer.c',
   'walwriter.c',
 )

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -55,12 +55,12 @@
 #define WALREDO_GET			'g'
 
 /*
- * The single page this process holds.  4b adds the target identity
- * (RelFileLocator/fork/block) and the held page LSN; 4a only needs the page
- * bytes, since it just round-trips them (BEGIN/PUSHBASE/GET) and does not yet
- * redo.
+ * The single page this process holds.  Stored in PGAlignedBlock so it can be
+ * accessed as a Page (PageIsNew/PageSetLSN) without an unaligned access on
+ * strict-alignment platforms.  4b adds the target identity (RelFileLocator/
+ * fork/block); 4a only needs the page bytes.
  */
-static char held_page[BLCKSZ];
+static PGAlignedBlock held_page;
 
 static bool
 read_fully(void *buf, size_t len)
@@ -165,7 +165,7 @@ WalRedoMain(int argc, char *argv[])
 							_exit(1);
 					(void) ident;	/* 4b stores the target identity from here */
 					/* 4a only resets the held page */
-					memset(held_page, 0, BLCKSZ);
+					memset(held_page.data, 0, BLCKSZ);
 					break;
 				}
 
@@ -178,7 +178,7 @@ WalRedoMain(int argc, char *argv[])
 						_exit(1);
 					if (len == BLCKSZ)
 					{
-						if (!read_fully(held_page, BLCKSZ))
+						if (!read_fully(held_page.data, BLCKSZ))
 							_exit(1);
 
 						/*
@@ -188,12 +188,19 @@ WalRedoMain(int argc, char *argv[])
 						 * BLK_DONE/BLK_NEEDS_REDO gating once 4b replays deltas, see
 						 * the correct pd_lsn.  Leave an uninitialized (new) page
 						 * alone, as redo does.
+						 *
+						 * This invalidates pd_checksum, but the helper deliberately
+						 * does not recompute it: without backend initialisation it
+						 * cannot know whether data checksums are enabled.  The caller
+						 * persists/serves the page in a normal backend (with cluster
+						 * context and the block number it issued in BEGIN), and
+						 * recomputes pd_checksum there before storing or serving.
 						 */
-						if (!PageIsNew((Page) held_page))
-							PageSetLSN((Page) held_page, (XLogRecPtr) base_end_lsn);
+						if (!PageIsNew((Page) held_page.data))
+							PageSetLSN((Page) held_page.data, (XLogRecPtr) base_end_lsn);
 					}
 					else if (len == 0)
-						memset(held_page, 0, BLCKSZ);
+						memset(held_page.data, 0, BLCKSZ);
 					else
 						_exit(1);	/* malformed base length */
 					break;
@@ -225,7 +232,7 @@ WalRedoMain(int argc, char *argv[])
 				}
 
 			case WALREDO_GET:
-				write_fully(held_page, BLCKSZ);
+				write_fully(held_page.data, BLCKSZ);
 				break;
 
 			default:

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -40,8 +40,13 @@
 
 #include <errno.h>
 #include <unistd.h>
+#ifdef WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
 
 #include "postmaster/walredo.h"
+#include "storage/bufpage.h"
 
 /* protocol message tags */
 #define WALREDO_BEGIN		'b'
@@ -135,6 +140,13 @@ WalRedoMain(int argc, char *argv[])
 	(void) argc;
 	(void) argv;
 
+#ifdef WIN32
+	/* the protocol is binary; keep the CRT from translating \n/\r\n/0x1a on the
+	 * inherited stdin/stdout, which would corrupt PUSHBASE/GET page bytes */
+	_setmode(_fileno(stdin), _O_BINARY);
+	_setmode(_fileno(stdout), _O_BINARY);
+#endif
+
 	for (;;)
 	{
 		unsigned char tag;
@@ -168,12 +180,22 @@ WalRedoMain(int argc, char *argv[])
 					{
 						if (!read_fully(held_page, BLCKSZ))
 							_exit(1);
+
+						/*
+						 * RestoreBlockImage (on the driver side) copies only the
+						 * image bytes; PostgreSQL stamps a restored page's LSN
+						 * separately.  Do the same here so a base-only GET, and the
+						 * BLK_DONE/BLK_NEEDS_REDO gating once 4b replays deltas, see
+						 * the correct pd_lsn.  Leave an uninitialized (new) page
+						 * alone, as redo does.
+						 */
+						if (!PageIsNew((Page) held_page))
+							PageSetLSN((Page) held_page, (XLogRecPtr) base_end_lsn);
 					}
 					else if (len == 0)
 						memset(held_page, 0, BLCKSZ);
 					else
 						_exit(1);	/* malformed base length */
-					(void) base_end_lsn;	/* 4b seeds the held page LSN with it */
 					break;
 				}
 

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -1,0 +1,213 @@
+/*-------------------------------------------------------------------------
+ *
+ * walredo.c
+ *	  single-page WAL-redo helper process (postgres --wal-redo)
+ *
+ * Holds exactly one target page and applies WAL records to it on request, so a
+ * page store can materialize a page "as of" an LSN from a base image plus the
+ * delta records after it, without replaying all of WAL.  See
+ * contrib/pagestore/WAL_REDO.md (the 3c-4 design).
+ *
+ * Protocol (length-prefixed binary, on stdin; replies on stdout), one byte tag
+ * then a fixed payload:
+ *
+ *   'b' BEGIN     spcOid,dbOid,relNumber,forkNum,blockNum (5x uint32)
+ *                 -- set the target page identity, zero the held page
+ *   'p' PUSHBASE  base_end_lsn (uint64), len (uint32), then len page bytes
+ *                 -- seed the held page (len == BLCKSZ) or zero it (len == 0)
+ *                    and set its page LSN baseline to base_end_lsn
+ *   'a' APPLY     start_lsn (uint64), end_lsn (uint64), len (uint32), record
+ *                 -- rm_redo the record onto the held page (see below)
+ *   'g' GET       (no payload) -- reply with BLCKSZ bytes: the held page
+ *
+ * EOF on stdin is a clean shutdown.
+ *
+ * This is increment 4a: the process entry, the held-page state and the protocol
+ * framing.  The APPLY step -- running the record's resource-manager redo against
+ * the held page with the buffer manager redirected to it (and VM/FSM side
+ * effects stubbed per target fork) -- is the next increment (4b); until then
+ * APPLY reports that it is unimplemented.  All I/O is raw read()/write() over
+ * static buffers, so the mode runs without the usual backend initialisation.
+ *
+ * Portions Copyright (c) 1996-2026, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/backend/postmaster/walredo.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include <errno.h>
+#include <unistd.h>
+
+#include "postmaster/walredo.h"
+
+/* protocol message tags */
+#define WALREDO_BEGIN		'b'
+#define WALREDO_PUSHBASE	'p'
+#define WALREDO_APPLY		'a'
+#define WALREDO_GET			'g'
+
+/*
+ * The single page this process holds.  4b adds the target identity
+ * (RelFileLocator/fork/block) and the held page LSN; 4a only needs the page
+ * bytes, since it just round-trips them (BEGIN/PUSHBASE/GET) and does not yet
+ * redo.
+ */
+static char held_page[BLCKSZ];
+
+static bool
+read_fully(void *buf, size_t len)
+{
+	char	   *p = (char *) buf;
+
+	while (len > 0)
+	{
+		ssize_t		n = read(STDIN_FILENO, p, len);
+
+		if (n < 0)
+		{
+			if (errno == EINTR)
+				continue;
+			return false;
+		}
+		if (n == 0)
+			return false;		/* EOF */
+		p += n;
+		len -= (size_t) n;
+	}
+	return true;
+}
+
+static void
+write_fully(const void *buf, size_t len)
+{
+	const char *p = (const char *) buf;
+
+	while (len > 0)
+	{
+		ssize_t		n = write(STDOUT_FILENO, p, len);
+
+		if (n < 0)
+		{
+			if (errno == EINTR)
+				continue;
+			_exit(1);
+		}
+		p += n;
+		len -= (size_t) n;
+	}
+}
+
+static bool
+read_u32(uint32 *v)
+{
+	return read_fully(v, sizeof(*v));
+}
+
+static bool
+read_u64(uint64 *v)
+{
+	return read_fully(v, sizeof(*v));
+}
+
+/* discard 'len' bytes from stdin so the stream stays framed */
+static bool
+skip_bytes(uint32 len)
+{
+	char		buf[1024];
+
+	while (len > 0)
+	{
+		uint32		chunk = len < sizeof(buf) ? len : (uint32) sizeof(buf);
+
+		if (!read_fully(buf, chunk))
+			return false;
+		len -= chunk;
+	}
+	return true;
+}
+
+void
+WalRedoMain(int argc, char *argv[])
+{
+	(void) argc;
+	(void) argv;
+
+	for (;;)
+	{
+		unsigned char tag;
+
+		if (!read_fully(&tag, 1))
+			_exit(0);			/* EOF: clean shutdown */
+
+		switch (tag)
+		{
+			case WALREDO_BEGIN:
+				{
+					uint32		ident[5];	/* spc,db,rel,fork,block */
+
+					for (int i = 0; i < 5; i++)
+						if (!read_u32(&ident[i]))
+							_exit(1);
+					(void) ident;	/* 4b stores the target identity from here */
+					/* 4a only resets the held page */
+					memset(held_page, 0, BLCKSZ);
+					break;
+				}
+
+			case WALREDO_PUSHBASE:
+				{
+					uint64		base_end_lsn;
+					uint32		len;
+
+					if (!read_u64(&base_end_lsn) || !read_u32(&len))
+						_exit(1);
+					if (len == BLCKSZ)
+					{
+						if (!read_fully(held_page, BLCKSZ))
+							_exit(1);
+					}
+					else if (len == 0)
+						memset(held_page, 0, BLCKSZ);
+					else
+						_exit(1);	/* malformed base length */
+					(void) base_end_lsn;	/* 4b seeds the held page LSN with it */
+					break;
+				}
+
+			case WALREDO_APPLY:
+				{
+					uint64		start_lsn,
+								end_lsn;
+					uint32		len;
+					const char *msg = "wal-redo: APPLY not implemented yet (4b)\n";
+
+					if (!read_u64(&start_lsn) || !read_u64(&end_lsn) ||
+						!read_u32(&len))
+						_exit(1);
+					if (!skip_bytes(len))
+						_exit(1);
+					(void) start_lsn;	/* used in 4b */
+					(void) end_lsn;
+
+					/*
+					 * 4b: decode the record and run its rm_redo against held_page,
+					 * with XLogReadBufferExtended redirected to the held (target)
+					 * and scratch (other) buffers, and VM/FSM side effects stubbed
+					 * per the requested fork.  Not yet implemented.
+					 */
+					write(STDERR_FILENO, msg, strlen(msg));
+					_exit(2);
+				}
+
+			case WALREDO_GET:
+				write_fully(held_page, BLCKSZ);
+				break;
+
+			default:
+				_exit(1);		/* protocol error */
+		}
+	}
+}

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -137,6 +137,7 @@ typedef enum DispatchOption
 	DISPATCH_FORKCHILD,
 	DISPATCH_DESCRIBE_CONFIG,
 	DISPATCH_SINGLE,
+	DISPATCH_WALREDO,
 	DISPATCH_POSTMASTER,		/* must be last */
 } DispatchOption;
 

--- a/src/include/postmaster/walredo.h
+++ b/src/include/postmaster/walredo.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * walredo.h
+ *	  single-page WAL-redo helper process (postgres --wal-redo)
+ *
+ * Portions Copyright (c) 1996-2026, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/postmaster/walredo.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef WALREDO_H
+#define WALREDO_H
+
+pg_noreturn extern void WalRedoMain(int argc, char *argv[]);
+
+#endif							/* WALREDO_H */


### PR DESCRIPTION
First increment of **slice 4** — the single-page WAL-redo helper the page store uses to materialize a page as-of an LSN (base image + the delta records after it; see `contrib/pagestore/WAL_REDO.md`). A dedicated `postgres --wal-redo` process holds one page and applies WAL records to it.

## This increment (4a — dispatch + protocol skeleton)
- New `DISPATCH_WALREDO` (`"wal-redo"`) in the `main()` dispatcher → `WalRedoMain()`.
- `src/backend/postmaster/walredo.c`: held-page state + the length-prefixed **`BEGIN / PUSHBASE / APPLY / GET`** protocol on stdin/stdout (raw I/O over static buffers, so the mode needs no backend initialisation). `BEGIN/PUSHBASE/GET` round-trip a page.
- **`APPLY`** — running the record's `rm_redo` against the held page with the buffer manager redirected to it and VM/FSM side effects stubbed per fork — is the **next increment (4b)** and currently reports "not implemented".
- Registered in both meson + make builds.

## Verification
Compiles clean (`-Wall -Wextra -Werror -Wdeclaration-after-statement`) against the PG headers; full build via CI. Stacked on #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)