### PR TITLE
contrib/pagestore: block-liveness as-of LSN — redo driver step-0 (3c-4 / slice 5a)

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -643,6 +643,22 @@ pagestore_localsvc_forksize_at(const PageStoreRelKey *key, uint64 lsn,
 	return true;
 }
 
+/* Is (key, block) live as of 'lsn'?  The redo driver's step-0 (skip a block that
+ * was truncated away and not written again as-of lsn). */
+bool
+pagestore_localsvc_block_live(const PageStoreRelKey *key, BlockNumber block,
+							  uint64 lsn)
+{
+	PsChannel  *ch = ls_chan(key);
+
+	ls_fill_key(ch, key);
+	ch->opcode = PS_OP_BLOCK_LIVE;
+	ch->blocknum = block;
+	ch->req_lsn = lsn;
+	ls_exec(ch);
+	return ch->result != 0;
+}
+
 /* Called from _PG_init to register the GUCs owned by this backend. */
 void
 pagestore_localsvc_init(void)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -869,6 +869,31 @@ pagestore_redo_base_lsn(PG_FUNCTION_ARGS)
 	PG_RETURN_LSN(base_end_lsn);
 }
 
+/*
+ * pagestore_block_live(rel regclass, forknum int, blocknum int, lsn pg_lsn)
+ *   -> bool
+ *
+ * The redo driver's step-0: is the block live as-of lsn, or was it truncated away
+ * (and not written again)?  A dead block must not be materialized.  Combines the
+ * fork truncation floor with the per-page index (re-extension after the
+ * truncation) in the daemon.
+ */
+PG_FUNCTION_INFO_V1(pagestore_block_live);
+
+Datum
+pagestore_block_live(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	int32		forknum = PG_GETARG_INT32(1);
+	int32		blocknum = PG_GETARG_INT32(2);
+	XLogRecPtr	lsn = PG_GETARG_LSN(3);
+	PageStoreRelKey key;
+
+	redo_key_from_relid(relid, forknum, &key);
+	PG_RETURN_BOOL(pagestore_localsvc_block_live(&key, (BlockNumber) blocknum,
+												 (uint64) lsn));
+}
+
 void
 _PG_init(void)
 {

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -160,5 +160,7 @@ extern void pagestore_localsvc_forksize_add(const PageStoreRelKey *key,
 extern bool pagestore_localsvc_forksize_at(const PageStoreRelKey *key,
 										   uint64 lsn, BlockNumber *out,
 										   uint64 *trunc_lsn);
+extern bool pagestore_localsvc_block_live(const PageStoreRelKey *key,
+										  BlockNumber block, uint64 lsn);
 
 #endif							/* PAGESTORE_BACKEND_H */

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1786,14 +1786,21 @@ walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
 
 /*
  * Is (key, block) live as of 'lsn'?  The redo driver's step-0: skip materializing
- * a page that was truncated away (and not written again) at the target LSN.
+ * a page that was removed (the fork truncated below it, or dropped) and not
+ * written again at the target LSN.
  *
- * A block is live unless the fork's truncation floor as-of 'lsn' is at/below it
- * AND no WAL record wrote the block after that truncation (i.e. it was not
- * re-extended).  Truncation floor + LSN come from the size history (fork_size_add);
- * the re-extension check scans the per-page index for a write in (trunc_lsn, lsn],
- * across the timeline ancestry, with early exit.  On an unreadable/absent floor
- * the block is treated as live (materialize rather than wrongly drop).
+ * A block is live unless the fork's "floor" as-of 'lsn' is at/below it AND no WAL
+ * record wrote the block in the half-open window [trunc_lsn, lsn) (it was not
+ * re-extended).  The floor and its LSN come from the size history (fork_size_add);
+ * the re-extension check scans the per-page index across the timeline ancestry,
+ * with early exit.  No floor known -> live (materialize rather than wrongly drop).
+ *
+ * A relation *drop* is represented as a truncation to 0 (floor 0), so this same
+ * logic returns dead for a dropped, not-recreated fork.  NB: *populating* drop
+ * events from WAL -- decoding the dropped-relation lists in xact commit/abort
+ * records -- is a follow-up; until it lands a WAL-driven drop is not yet reflected
+ * here, so a background materializer keyed by store identity must not run ahead of
+ * that work for dropped relations.
  */
 static bool
 block_live_at(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
@@ -1809,10 +1816,13 @@ block_live_at(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 		return true;			/* within the post-truncation length */
 
 	/*
-	 * Live iff written again at/after the truncation, up to lsn.  The lower bound
-	 * is inclusive (>=): truncations are indexed by the record end LSN, while page
-	 * writes are indexed by the record start LSN, and the next record starts where
-	 * the truncation ended -- so an immediate re-extension has start == trunc_lsn.
+	 * Live iff written again in the half-open window [trunc_lsn, lsn).  Lower bound
+	 * inclusive: truncations are indexed by record end LSN, page writes by record
+	 * start LSN, and the record right after the truncation starts where it ended,
+	 * so an immediate re-extension has start == trunc_lsn.  Upper bound exclusive:
+	 * a write whose start == lsn begins at the target boundary and ends after it,
+	 * so it is not visible as-of lsn (same half-open convention as the delta window
+	 * the redo driver replays).
 	 */
 	for (uint32_t t = tl;;)
 	{
@@ -1823,7 +1833,7 @@ block_live_at(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 			if (e->timeline == t && e->block == block && key_eq(&e->key, key))
 			{
 				for (int i = 0; i < e->n; i++)
-					if (e->lsns[i] >= trunc_lsn && e->lsns[i] <= lmax)
+					if (e->lsns[i] >= trunc_lsn && e->lsns[i] < lmax)
 						return true;
 				break;
 			}

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1808,7 +1808,12 @@ block_live_at(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 	if (block < floor)
 		return true;			/* within the post-truncation length */
 
-	/* truncated away at trunc_lsn: live iff written again in (trunc_lsn, lsn] */
+	/*
+	 * Live iff written again at/after the truncation, up to lsn.  The lower bound
+	 * is inclusive (>=): truncations are indexed by the record end LSN, while page
+	 * writes are indexed by the record start LSN, and the next record starts where
+	 * the truncation ended -- so an immediate re-extension has start == trunc_lsn.
+	 */
 	for (uint32_t t = tl;;)
 	{
 		uint32_t	h = page_hash(t, key, block);
@@ -1818,7 +1823,7 @@ block_live_at(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 			if (e->timeline == t && e->block == block && key_eq(&e->key, key))
 			{
 				for (int i = 0; i < e->n; i++)
-					if (e->lsns[i] > trunc_lsn && e->lsns[i] <= lmax)
+					if (e->lsns[i] >= trunc_lsn && e->lsns[i] <= lmax)
 						return true;
 				break;
 			}

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1784,6 +1784,53 @@ walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
 	return total;
 }
 
+/*
+ * Is (key, block) live as of 'lsn'?  The redo driver's step-0: skip materializing
+ * a page that was truncated away (and not written again) at the target LSN.
+ *
+ * A block is live unless the fork's truncation floor as-of 'lsn' is at/below it
+ * AND no WAL record wrote the block after that truncation (i.e. it was not
+ * re-extended).  Truncation floor + LSN come from the size history (fork_size_add);
+ * the re-extension check scans the per-page index for a write in (trunc_lsn, lsn],
+ * across the timeline ancestry, with early exit.  On an unreadable/absent floor
+ * the block is treated as live (materialize rather than wrongly drop).
+ */
+static bool
+block_live_at(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
+{
+	const Shard *s = shard_for(key);
+	uint32_t	floor;
+	uint64_t	trunc_lsn;
+	uint64_t	lmax = lsn;
+
+	if (!fork_nblocks_at(tl, key, lsn, &floor, &trunc_lsn))
+		return true;			/* never truncated at/below lsn */
+	if (block < floor)
+		return true;			/* within the post-truncation length */
+
+	/* truncated away at trunc_lsn: live iff written again in (trunc_lsn, lsn] */
+	for (uint32_t t = tl;;)
+	{
+		uint32_t	h = page_hash(t, key, block);
+		WalIdxEnt  *e;
+
+		for (e = s->walidx[h & IDX_MASK]; e; e = e->next)
+			if (e->timeline == t && e->block == block && key_eq(&e->key, key))
+			{
+				for (int i = 0; i < e->n; i++)
+					if (e->lsns[i] > trunc_lsn && e->lsns[i] <= lmax)
+						return true;
+				break;
+			}
+		if (!timeline_has_parent(s, t))
+			break;
+		if (s->timelines[t].branch_lsn < lmax)
+			lmax = s->timelines[t].branch_lsn;
+		t = (uint32_t) s->timelines[t].parent;
+	}
+	return false;
+}
+
 /* ===================== write / read primitives ========================= */
 
 /* The page's own pd_lsn lives in its first 8 bytes (xlogid, xrecoff). */
@@ -2404,6 +2451,11 @@ ps_handle_meta(PsChannel *ch)
 				ch->result = PS_FORKSIZE_UNKNOWN;
 			break;
 		}
+
+		case PS_OP_BLOCK_LIVE:
+			ch->result = block_live_at(tl, &ch->key, ch->blocknum,
+									   ch->req_lsn) ? 1 : 0;
+			break;
 
 		case PS_OP_TRUNCATE:
 			fork_get_or_create(tl, &ch->key)->nblocks = ch->nblocks;

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 #define PS_SHM_MAGIC		0x50414753	/* "PAGS" */
-#define PS_SHM_VERSION		7			/* 7: FORK_SIZE_ADD/AT opcodes */
+#define PS_SHM_VERSION		8			/* 8: BLOCK_LIVE opcode */
 
 /* Default logical page size (overridable via the daemon's --page-size). */
 #define PS_DEFAULT_PAGE_SIZE	8192
@@ -98,6 +98,7 @@ typedef enum PsOpcode
 	PS_OP_WAL_INDEX_GET,		/* list record LSNs <= req_lsn for (key, blocknum) */
 	PS_OP_FORK_SIZE_ADD,		/* record: fork truncated to nblocks as-of req_lsn */
 	PS_OP_FORK_SIZE_AT,			/* truncation floor (blocks) as-of req_lsn; PS_FORKSIZE_UNKNOWN if never truncated */
+	PS_OP_BLOCK_LIVE,			/* is (key, blocknum) live as-of req_lsn? result 0/1 (redo step-0) */
 } PsOpcode;
 
 /* PS_OP_FORK_SIZE_AT: no truncation at/below the queried LSN. */

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -1152,6 +1152,8 @@ run_walidx_suite(const char *daemon_path, const char *tmpbase)
 	op_walidx_add(0, REL_A, FORK0, 6, 250);		/* block 6 rewritten exactly @ trunc lsn */
 	check(op_block_live(0, REL_A, FORK0, 6, 300) == 1,
 		  "re-extension exactly at the truncation LSN -> live");
+	check(op_block_live(0, REL_A, FORK0, 6, 250) == 0,
+		  "as-of the rewrite's own start LSN (upper bound exclusive) -> not yet live");
 
 	client_detach();
 	stop_daemon(dpid);

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -1147,6 +1147,11 @@ run_walidx_suite(const char *daemon_path, const char *tmpbase)
 		  "block 5 rewritten after the truncation -> live again");
 	check(op_block_live(0, REL_A, FORK0, 5, 350) == 0,
 		  "as-of 350, before the @400 rewrite -> still dead");
+	/* a re-extension whose start LSN equals the truncation LSN (the immediate
+	 * next record) must count -- the lower bound is inclusive */
+	op_walidx_add(0, REL_A, FORK0, 6, 250);		/* block 6 rewritten exactly @ trunc lsn */
+	check(op_block_live(0, REL_A, FORK0, 6, 300) == 1,
+		  "re-extension exactly at the truncation LSN -> live");
 
 	client_detach();
 	stop_daemon(dpid);

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -507,6 +507,20 @@ op_forksize_at(uint32_t tl, uint32_t rel, int32_t fork, uint64_t lsn,
 	return res;
 }
 
+/* Is (rel,fork,block) live as-of lsn?  Returns 0/1. */
+static int
+op_block_live(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block, uint64_t lsn)
+{
+	PsChannel  *ch = cl_route(rel, fork);
+
+	cl_setkey(ch, rel, fork);
+	ch->timeline = tl;
+	ch->opcode = PS_OP_BLOCK_LIVE;
+	ch->blocknum = block;
+	ch->req_lsn = lsn;
+	return (int) cl_exec(ch)->result;
+}
+
 /* Returns count; fills out[] with the record LSNs <= lsn_max, and -- when
  * out_tl != NULL -- the parallel source timeline of each LSN. */
 static int
@@ -1118,6 +1132,21 @@ run_walidx_suite(const char *daemon_path, const char *tmpbase)
 			  "branch sees parent floor capped at the fork lsn (3, not the parent's later 8)");
 		check(op_forksize_at(2, REL_B, FORK0, 600, NULL) == 2, "branch's own later truncation wins (2)");
 	}
+
+	/* --- block liveness as-of LSN (the redo driver's step-0) --- */
+	/* truncate REL_A to 1 block @250: block 5 is gone unless written again */
+	op_forksize_add(0, REL_A, FORK0, 250, 1);
+	check(op_block_live(0, REL_A, FORK0, 0, 300) == 1,
+		  "block 0 is within the truncation floor (1) -> live");
+	check(op_block_live(0, REL_A, FORK0, 5, 300) == 0,
+		  "block 5 truncated away and not rewritten -> dead");
+	check(op_block_live(0, REL_A, FORK0, 5, 200) == 1,
+		  "as-of 200, before the truncation -> not dead");
+	op_walidx_add(0, REL_A, FORK0, 5, 400);		/* re-extend block 5 at LSN 400 */
+	check(op_block_live(0, REL_A, FORK0, 5, 450) == 1,
+		  "block 5 rewritten after the truncation -> live again");
+	check(op_block_live(0, REL_A, FORK0, 5, 350) == 0,
+		  "as-of 350, before the @400 rewrite -> still dead");
 
 	client_detach();
 	stop_daemon(dpid);


### PR DESCRIPTION
The single-page redo driver's **step-0**: decide whether a page was truncated away (and not written again) at the target LSN, so a dead page is skipped rather than materialized. Implemented in the daemon, where both indexes live, by combining the merged building blocks.

## Changes
- **`block_live_at(tl,key,block,lsn)`** — live unless the fork's truncation floor as-of `lsn` (#35) is at/below the block **and** no record wrote the block in `(trunc_lsn, lsn]` (the per-page index #34, scanned across the timeline ancestry, early-exit). No floor known → live (materialize rather than wrongly drop).
- New op **`PS_OP_BLOCK_LIVE`** (+ shm version → 8), localsvc accessor, and SQL `pagestore_block_live(rel,fork,block,lsn)`.

## Verification
Standalone suite **384/0**: truncated-away → dead; within floor / before truncation / rewritten-after → live; as-of before the rewrite → still dead. PG-side wrapper via CI.

## Scope note
This is the driver's **liveness** step only. Materializing the page still needs the wal-redo **APPLY (4b)**: a WAL full-page image is the *before*-image (torn-page protection), so the page as-of an LSN requires `rm_redo` of the base record + later deltas — the hard core piece, which needs a running-PostgreSQL dev loop.

Stacked on #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)