### PR TITLE
Add wal-redo APPLY record decode (4b step 1)

### DIFF
--- a/.github/scripts/walredo_smoke.py
+++ b/.github/scripts/walredo_smoke.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Smoke test for the `postgres --wal-redo` helper.
+
+Drives the binary protocol over stdin/stdout without needing a cluster:
+  - BEGIN + PUSHBASE(page) + GET round-trips the page with pd_lsn stamped (4a);
+  - APPLY rejects malformed records (too short / length mismatch / bad CRC),
+    exercising the validation that guards the decode path.
+
+Usage: walredo_smoke.py <path-to-postgres-binary>
+Exit status is nonzero if any check fails.
+"""
+import struct
+import subprocess
+import sys
+
+PG = sys.argv[1]
+BLCKSZ = 8192
+SizeOfXLogRecord = 24            # 64-bit layout
+RM_XLOG_ID = 0                   # a valid resource-manager id
+
+fails = 0
+
+
+def check(name, ok):
+    global fails
+    print(("PASS" if ok else "FAIL"), "-", name)
+    if not ok:
+        fails += 1
+
+
+def run(payload):
+    return subprocess.run([PG, "--wal-redo"], input=payload,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          timeout=60)
+
+
+def begin():
+    return b'b' + struct.pack('<5I', 1663, 5, 16384, 0, 0)
+
+
+# 1) BEGIN + PUSHBASE(page) + GET: the page comes back with pd_lsn stamped.
+page = bytearray(BLCKSZ)
+struct.pack_into('<H', page, 14, 8000)        # pd_upper != 0 -> not a new page
+marker = b'HELLO-WALREDO'
+page[100:100 + len(marker)] = marker
+base_lsn = 0x12345678ABCD
+out = run(begin() + b'p' + struct.pack('<QI', base_lsn, BLCKSZ) + bytes(page) + b'g').stdout
+check("GET returns BLCKSZ bytes", len(out) == BLCKSZ)
+check("GET preserves page body", out[100:100 + len(marker)] == marker)
+xlogid, xrecoff = struct.unpack('<II', out[0:8]) if len(out) >= 8 else (0, 0)
+check("GET stamps pd_lsn = base_end_lsn", ((xlogid << 32) | xrecoff) == base_lsn)
+
+# 2) APPLY with a record shorter than the header is rejected.
+check("APPLY too-short record rejected (exit 1)",
+      run(begin() + b'a' + struct.pack('<QQI', 0, 0, 8) + b'\0' * 8).returncode == 1)
+
+# 3) APPLY whose header xl_tot_len disagrees with the framed length is rejected.
+rec = bytearray(SizeOfXLogRecord + 8)
+struct.pack_into('<I', rec, 0, 999)           # xl_tot_len != len
+check("APPLY xl_tot_len mismatch rejected (exit 1)",
+      run(begin() + b'a' + struct.pack('<QQI', 0, 0, len(rec)) + bytes(rec)).returncode == 1)
+
+# 4) APPLY with matching length and valid rmid but a bad CRC is rejected.
+rec = bytearray(SizeOfXLogRecord + 8)
+struct.pack_into('<I', rec, 0, len(rec))      # xl_tot_len == len
+rec[17] = RM_XLOG_ID                          # xl_rmid valid; xl_crc (off 20) left 0 -> mismatch
+check("APPLY bad CRC rejected (exit 1)",
+      run(begin() + b'a' + struct.pack('<QQI', 0, 0, len(rec)) + bytes(rec)).returncode == 1)
+
+print("---", "all passed" if not fails else f"{fails} FAILED")
+sys.exit(1 if fails else 0)

--- a/.github/workflows/walredo-test.yml
+++ b/.github/workflows/walredo-test.yml
@@ -1,0 +1,49 @@
+# CI for the backend wal-redo helper (postgres --wal-redo).
+#
+# Unlike the pagestore daemon CI, this DOES build PostgreSQL -- the helper is
+# backend code (src/backend/postmaster/walredo.c) linked into the postgres
+# binary, so it cannot be exercised by the freestanding daemon job.  It builds
+# only the `postgres` target (not the whole tree / contrib) and runs a protocol
+# smoke test, closing the gap where backend changes had no CI coverage.
+name: walredo
+
+on:
+  push:
+    paths:
+      - 'src/backend/postmaster/walredo.c'
+      - 'src/include/postmaster/walredo.h'
+      - 'src/backend/main/main.c'
+      - 'src/include/postmaster/postmaster.h'
+      - '.github/scripts/walredo_smoke.py'
+      - '.github/workflows/walredo-test.yml'
+  pull_request:
+    paths:
+      - 'src/backend/postmaster/walredo.c'
+      - 'src/include/postmaster/walredo.h'
+      - 'src/backend/main/main.c'
+      - 'src/include/postmaster/postmaster.h'
+      - '.github/scripts/walredo_smoke.py'
+      - '.github/workflows/walredo-test.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-smoke:
+    name: build postgres + wal-redo smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            meson ninja-build bison flex pkg-config \
+            libreadline-dev zlib1g-dev libicu-dev
+
+      - name: Configure and build the postgres binary
+        run: |
+          meson setup build -Dcassert=true
+          ninja -C build src/backend/postgres
+
+      - name: wal-redo protocol smoke test
+        run: python3 .github/scripts/walredo_smoke.py build/src/backend/postgres

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -45,10 +45,12 @@
 #include <io.h>
 #endif
 
+#include "access/rmgr.h"
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"
 #include "access/xlogrecord.h"
+#include "port/pg_crc32c.h"
 #include "postmaster/walredo.h"
 #include "storage/bufpage.h"
 
@@ -221,13 +223,34 @@ WalRedoMain(int argc, char *argv[])
 
 					/*
 					 * This path feeds the bytes straight to DecodeXLogRecord,
-					 * bypassing XLogReadRecord's length/CRC checks, so validate
-					 * the header length against the framed length first: a header
-					 * whose xl_tot_len exceeds the bytes we read would let the
-					 * decoder run off the end of recbuf.
+					 * which (unlike XLogReadRecord) does not validate the record,
+					 * so replicate the checks XLogReadRecord would make before
+					 * trusting the record:
+					 *
+					 *  - the header length must equal the framed length, or the
+					 *    decoder could run off the end of recbuf;
+					 *  - the resource manager id must be valid;
+					 *  - the CRC must match, so a damaged chunk that still frames
+					 *    correctly is rejected rather than (once rm_redo is wired)
+					 *    applied as if it were good WAL.
 					 */
-					if (((XLogRecord *) recbuf)->xl_tot_len != len)
-						_exit(1);
+					{
+						XLogRecord *rec = (XLogRecord *) recbuf;
+						pg_crc32c	crc;
+
+						if (rec->xl_tot_len != len)
+							_exit(1);
+						if (!RmgrIdIsValid(rec->xl_rmid))
+							_exit(1);
+
+						INIT_CRC32C(crc);
+						COMP_CRC32C(crc, recbuf + SizeOfXLogRecord,
+									len - SizeOfXLogRecord);
+						COMP_CRC32C(crc, rec, offsetof(XLogRecord, xl_crc));
+						FIN_CRC32C(crc);
+						if (!EQ_CRC32C(crc, rec->xl_crc))
+							_exit(1);
+					}
 
 					if (wr_reader == NULL)
 					{
@@ -245,6 +268,15 @@ WalRedoMain(int argc, char *argv[])
 					if (!DecodeXLogRecord(wr_reader, decoded, (XLogRecord *) recbuf,
 										  (XLogRecPtr) end_lsn, &errm))
 						_exit(1);
+
+					/*
+					 * Populate the reader so the XLogRecGet* accessors and (once
+					 * wired) rm_redo see a consistent record, including the start
+					 * and end LSNs used for page-LSN decisions.
+					 */
+					wr_reader->ReadRecPtr = (XLogRecPtr) start_lsn;
+					wr_reader->EndRecPtr = (XLogRecPtr) end_lsn;
+					wr_reader->record = decoded;
 
 					/*
 					 * 4b step 1 is decode only: the record is validated and

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -45,8 +45,15 @@
 #include <io.h>
 #endif
 
+#include "access/xlog.h"
+#include "access/xlog_internal.h"
+#include "access/xlogreader.h"
+#include "access/xlogrecord.h"
 #include "postmaster/walredo.h"
 #include "storage/bufpage.h"
+
+/* XLogReader reused across APPLY messages (lazily allocated) */
+static XLogReaderState *wr_reader = NULL;
 
 /* protocol message tags */
 #define WALREDO_BEGIN		'b'
@@ -117,23 +124,6 @@ read_u64(uint64 *v)
 	return read_fully(v, sizeof(*v));
 }
 
-/* discard 'len' bytes from stdin so the stream stays framed */
-static bool
-skip_bytes(uint32 len)
-{
-	char		buf[1024];
-
-	while (len > 0)
-	{
-		uint32		chunk = len < sizeof(buf) ? len : (uint32) sizeof(buf);
-
-		if (!read_fully(buf, chunk))
-			return false;
-		len -= chunk;
-	}
-	return true;
-}
-
 void
 WalRedoMain(int argc, char *argv[])
 {
@@ -146,6 +136,10 @@ WalRedoMain(int argc, char *argv[])
 	_setmode(_fileno(stdin), _O_BINARY);
 	_setmode(_fileno(stdout), _O_BINARY);
 #endif
+
+	/* APPLY decodes records with an XLogReader, which needs a valid segment size */
+	if (wal_segment_size == 0)
+		wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 
 	for (;;)
 	{
@@ -211,24 +205,56 @@ WalRedoMain(int argc, char *argv[])
 					uint64		start_lsn,
 								end_lsn;
 					uint32		len;
-					const char *msg = "wal-redo: APPLY not implemented yet (4b)\n";
+					char	   *recbuf;
+					DecodedXLogRecord *decoded;
+					char	   *errm = NULL;
+					char		dbg[80];
+					int			n;
 
 					if (!read_u64(&start_lsn) || !read_u64(&end_lsn) ||
 						!read_u32(&len))
 						_exit(1);
-					if (!skip_bytes(len))
+					if (len < SizeOfXLogRecord)
 						_exit(1);
-					(void) start_lsn;	/* used in 4b */
-					(void) end_lsn;
+					recbuf = palloc(len);
+					if (!read_fully(recbuf, len))
+						_exit(1);
+
+					if (wr_reader == NULL)
+					{
+						wr_reader = XLogReaderAllocate(wal_segment_size, NULL,
+													   XL_ROUTINE(.page_read = NULL,
+																  .segment_open = NULL,
+																  .segment_close = NULL),
+													   NULL);
+						if (wr_reader == NULL)
+							_exit(1);
+					}
+
+					decoded = palloc(DecodeXLogRecordRequiredSpace(
+										 ((XLogRecord *) recbuf)->xl_tot_len));
+					if (!DecodeXLogRecord(wr_reader, decoded, (XLogRecord *) recbuf,
+										  (XLogRecPtr) end_lsn, &errm))
+						_exit(1);
+					wr_reader->ReadRecPtr = (XLogRecPtr) start_lsn;
+					wr_reader->EndRecPtr = (XLogRecPtr) end_lsn;
+					wr_reader->record = decoded;
 
 					/*
-					 * 4b: decode the record and run its rm_redo against held_page,
-					 * with XLogReadBufferExtended redirected to the held (target)
-					 * and scratch (other) buffers, and VM/FSM side effects stubbed
-					 * per the requested fork.  Not yet implemented.
+					 * 4b step 1 (decode): the record is now decodable via the
+					 * XLogRecGet* accessors.  Running its rm_redo against the held
+					 * page (with the buffer manager redirected) is the next step;
+					 * for now report what was decoded.
 					 */
-					write(STDERR_FILENO, msg, strlen(msg));
-					_exit(2);
+					n = snprintf(dbg, sizeof(dbg),
+								 "wal-redo: decoded rmid=%u info=0x%02X maxblk=%d\n",
+								 (unsigned) XLogRecGetRmid(wr_reader),
+								 (unsigned) XLogRecGetInfo(wr_reader),
+								 XLogRecMaxBlockId(wr_reader));
+					write(STDERR_FILENO, dbg, n);
+					pfree(decoded);
+					pfree(recbuf);
+					break;
 				}
 
 			case WALREDO_GET:

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -208,8 +208,7 @@ WalRedoMain(int argc, char *argv[])
 					char	   *recbuf;
 					DecodedXLogRecord *decoded;
 					char	   *errm = NULL;
-					char		dbg[80];
-					int			n;
+					const char *msg;
 
 					if (!read_u64(&start_lsn) || !read_u64(&end_lsn) ||
 						!read_u32(&len))
@@ -218,6 +217,16 @@ WalRedoMain(int argc, char *argv[])
 						_exit(1);
 					recbuf = palloc(len);
 					if (!read_fully(recbuf, len))
+						_exit(1);
+
+					/*
+					 * This path feeds the bytes straight to DecodeXLogRecord,
+					 * bypassing XLogReadRecord's length/CRC checks, so validate
+					 * the header length against the framed length first: a header
+					 * whose xl_tot_len exceeds the bytes we read would let the
+					 * decoder run off the end of recbuf.
+					 */
+					if (((XLogRecord *) recbuf)->xl_tot_len != len)
 						_exit(1);
 
 					if (wr_reader == NULL)
@@ -236,25 +245,20 @@ WalRedoMain(int argc, char *argv[])
 					if (!DecodeXLogRecord(wr_reader, decoded, (XLogRecord *) recbuf,
 										  (XLogRecPtr) end_lsn, &errm))
 						_exit(1);
-					wr_reader->ReadRecPtr = (XLogRecPtr) start_lsn;
-					wr_reader->EndRecPtr = (XLogRecPtr) end_lsn;
-					wr_reader->record = decoded;
 
 					/*
-					 * 4b step 1 (decode): the record is now decodable via the
-					 * XLogRecGet* accessors.  Running its rm_redo against the held
-					 * page (with the buffer manager redirected) is the next step;
-					 * for now report what was decoded.
+					 * 4b step 1 is decode only: the record is validated and
+					 * decodable, but rm_redo is not wired yet (it needs a
+					 * standalone-backend bring-up; see WAL_REDO.md).  Fail
+					 * explicitly rather than continuing -- the protocol has no
+					 * success ack, so a later GET would otherwise hand back the
+					 * unmodified base page, indistinguishable from a real apply.
+					 * The message is emitted once, immediately before exit, so it
+					 * cannot accumulate on a long-lived stderr pipe.
 					 */
-					n = snprintf(dbg, sizeof(dbg),
-								 "wal-redo: decoded rmid=%u info=0x%02X maxblk=%d\n",
-								 (unsigned) XLogRecGetRmid(wr_reader),
-								 (unsigned) XLogRecGetInfo(wr_reader),
-								 XLogRecMaxBlockId(wr_reader));
-					write(STDERR_FILENO, dbg, n);
-					pfree(decoded);
-					pfree(recbuf);
-					break;
+					msg = "wal-redo: APPLY decoded the record but rm_redo is not implemented yet (4b step 2)\n";
+					write(STDERR_FILENO, msg, strlen(msg));
+					_exit(2);
 				}
 
 			case WALREDO_GET:


### PR DESCRIPTION
First code increment of **4b** (the `postgres --wal-redo` `APPLY` body), developed and tested on a real build+run loop.

## What this does
`APPLY` now reads the supplied record bytes and **decodes** them with an `XLogReader` (`DecodeXLogRecord` + `state->record`, with `ReadRecPtr`/`EndRecPtr` set from the message), so the `XLogRecGet*` accessors work inside the helper. `wal_segment_size` is defaulted so the reader can be allocated.

## Verified
Against a **real `HOT_UPDATE` record** extracted from a live cluster's WAL, driven through the actual `postgres --wal-redo` binary: the record decodes correctly (`rmid=10` Heap, one block ref), and `BEGIN`/`PUSHBASE`/`GET` still round-trip.

## Scope (WIP step)
This is decode only — `APPLY` does **not** yet mutate the held page. The next step runs the record's `rm_redo` against the held page with the buffer manager redirected (`am_walredo` + `WalRedoReadBuffer` hooked into `XLogReadBufferExtended`, `RmgrStartup()`, fork-aware VM/FSM stubs), after which `GET` returns the materialized page. Committed as a checkpoint of the verified decode foundation.

Pure backend (`walredo.c`); no contrib dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)