### PR TITLE
wal-redo: bring up a standalone backend (4b step 2a)

### DIFF
--- a/.github/scripts/walredo_smoke.py
+++ b/.github/scripts/walredo_smoke.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Smoke test for the `postgres --wal-redo` helper.
 
-Drives the binary protocol over stdin/stdout without needing a cluster:
+Drives the binary protocol over stdin/stdout:
   - BEGIN + PUSHBASE(page) + GET round-trips the page with pd_lsn stamped (4a);
   - APPLY rejects malformed records (too short / length mismatch / bad CRC),
     exercising the validation that guards the decode path.
 
-Usage: walredo_smoke.py <path-to-postgres-binary>
+The helper brings up a standalone backend, so it needs a (throwaway) data
+directory; pass an initdb'd scratch cluster.
+
+Usage: walredo_smoke.py <path-to-postgres-binary> <datadir>
 Exit status is nonzero if any check fails.
 """
 import struct
@@ -14,6 +17,7 @@ import subprocess
 import sys
 
 PG = sys.argv[1]
+PGDATA = sys.argv[2]
 BLCKSZ = 8192
 SizeOfXLogRecord = 24            # 64-bit layout
 RM_XLOG_ID = 0                   # a valid resource-manager id
@@ -29,9 +33,9 @@ def check(name, ok):
 
 
 def run(payload):
-    return subprocess.run([PG, "--wal-redo"], input=payload,
+    return subprocess.run([PG, "--wal-redo", "-D", PGDATA], input=payload,
                           stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                          timeout=60)
+                          timeout=120)
 
 
 def begin():

--- a/.github/workflows/walredo-test.yml
+++ b/.github/workflows/walredo-test.yml
@@ -14,6 +14,8 @@ on:
       - 'src/include/postmaster/walredo.h'
       - 'src/backend/main/main.c'
       - 'src/include/postmaster/postmaster.h'
+      - 'src/backend/tcop/postgres.c'
+      - 'src/include/tcop/tcopprot.h'
       - '.github/scripts/walredo_smoke.py'
       - '.github/workflows/walredo-test.yml'
   pull_request:
@@ -22,6 +24,8 @@ on:
       - 'src/include/postmaster/walredo.h'
       - 'src/backend/main/main.c'
       - 'src/include/postmaster/postmaster.h'
+      - 'src/backend/tcop/postgres.c'
+      - 'src/include/tcop/tcopprot.h'
       - '.github/scripts/walredo_smoke.py'
       - '.github/workflows/walredo-test.yml'
   workflow_dispatch:
@@ -40,8 +44,13 @@ jobs:
             meson ninja-build bison flex pkg-config \
             libreadline-dev zlib1g-dev libicu-dev
 
-      - name: Configure, build and install
+      - name: Configure, build and install (core only)
         run: |
+          # contrib/pagestore's PG module (pagestore.c) only builds against the
+          # branchdb_18 core (f_smgr/smgr_register export) and is unrelated to the
+          # wal-redo helper; skip it here so a full install doesn't break on it.
+          # The pagestore daemon has its own CI (the "pagestore" workflow).
+          sed -i "/subdir('pagestore')/d" contrib/meson.build
           meson setup build -Dcassert=true -Dprefix="$PWD/inst"
           ninja -C build install
 

--- a/.github/workflows/walredo-test.yml
+++ b/.github/workflows/walredo-test.yml
@@ -40,10 +40,13 @@ jobs:
             meson ninja-build bison flex pkg-config \
             libreadline-dev zlib1g-dev libicu-dev
 
-      - name: Configure and build the postgres binary
+      - name: Configure, build and install
         run: |
-          meson setup build -Dcassert=true
-          ninja -C build src/backend/postgres
+          meson setup build -Dcassert=true -Dprefix="$PWD/inst"
+          ninja -C build install
+
+      - name: initdb a throwaway scratch cluster
+        run: inst/bin/initdb -D scratch --no-locale -U postgres
 
       - name: wal-redo protocol smoke test
-        run: python3 .github/scripts/walredo_smoke.py build/src/backend/postgres
+        run: python3 .github/scripts/walredo_smoke.py inst/bin/postgres scratch

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -106,7 +106,17 @@ read_fully(void *buf, size_t len)
 
 	while (len > 0)
 	{
-		ssize_t		n = read(STDIN_FILENO, p, len);
+		ssize_t		n;
+
+		/*
+		 * Honor a termination signal that arrived between reads: at that point no
+		 * EINTR is pending to interrupt the upcoming blocking read, so check the
+		 * flag here as well as in the EINTR branch below.
+		 */
+		if (walredo_shutdown_requested)
+			proc_exit(1);
+
+		n = read(STDIN_FILENO, p, len);
 
 		if (n < 0)
 		{
@@ -163,8 +173,6 @@ read_u64(uint64 *v)
 void
 WalRedoMain(int argc, char *argv[])
 {
-	const char *dbname = NULL;
-
 #ifdef WIN32
 	/* the protocol is binary; keep the CRT from translating \n/\r\n/0x1a on the
 	 * inherited stdin/stdout, which would corrupt PUSHBASE/GET page bytes */
@@ -191,8 +199,13 @@ WalRedoMain(int argc, char *argv[])
 	 * (whose lock file is held by the postmaster): the helper only ever mutates
 	 * pages handed to it over the protocol, so a generic scratch cluster of the
 	 * same BLCKSZ is sufficient for redo.
+	 *
+	 * Pass a NULL dbname: this mode opens no database, and a non-NULL pointer
+	 * would let process_postgres_switches() consume a stray positional argument as
+	 * a database name (e.g. "--wal-redo scratch" silently falling back to PGDATA
+	 * instead of the intended -D directory).
 	 */
-	InitStandaloneBackend(argc, argv, NULL, &dbname, false);
+	InitStandaloneBackend(argc, argv, NULL, NULL, false);
 
 	/*
 	 * BaseInit() sets up smgr and the buffer manager (InitBufferManagerAccess),

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -145,12 +145,25 @@ write_fully(const void *buf, size_t len)
 
 	while (len > 0)
 	{
-		ssize_t		n = write(STDOUT_FILENO, p, len);
+		ssize_t		n;
+
+		/* honor a termination signal that arrived between writes (e.g. while the
+		 * controller has stopped draining stdout), as read_fully() does */
+		if (walredo_shutdown_requested)
+			proc_exit(1);
+
+		n = write(STDOUT_FILENO, p, len);
 
 		if (n < 0)
 		{
 			if (errno == EINTR)
+			{
+				/* a termination signal interrupted the write; act on it rather
+				 * than retrying into a full pipe forever */
+				if (walredo_shutdown_requested)
+					proc_exit(1);
 				continue;
+			}
 			proc_exit(1);
 		}
 		p += n;
@@ -205,7 +218,7 @@ WalRedoMain(int argc, char *argv[])
 	 * a database name (e.g. "--wal-redo scratch" silently falling back to PGDATA
 	 * instead of the intended -D directory).
 	 */
-	InitStandaloneBackend(argc, argv, NULL, NULL, false);
+	InitStandaloneBackend(argc, argv, NULL, NULL, false, true);
 
 	/*
 	 * BaseInit() sets up smgr and the buffer manager (InitBufferManagerAccess),

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -22,12 +22,20 @@
  *
  * EOF on stdin is a clean shutdown.
  *
- * This is increment 4a: the process entry, the held-page state and the protocol
- * framing.  The APPLY step -- running the record's resource-manager redo against
- * the held page with the buffer manager redirected to it (and VM/FSM side
- * effects stubbed per target fork) -- is the next increment (4b); until then
- * APPLY reports that it is unimplemented.  All I/O is raw read()/write() over
- * static buffers, so the mode runs without the usual backend initialisation.
+ * Startup brings up a standalone backend (shared memory + a PGPROC + the buffer
+ * manager) by reusing the single-user init path (InitStandaloneBackend), so it
+ * needs a data directory: `postgres --wal-redo -D <datadir>`.  This must be a
+ * private, throwaway cluster, not the live one -- the helper only ever mutates
+ * pages handed to it over the protocol, so any cluster of the same BLCKSZ works,
+ * and using the live datadir would collide with the postmaster's lock file.  The
+ * full backend context is required because running a record's rm_redo goes
+ * through the normal buffer manager.
+ *
+ * APPLY currently decodes and validates the record (header length, rmid, CRC) but
+ * does not yet mutate the held page: running the record's resource-manager redo
+ * against it with the buffer manager redirected to the held/scratch buffers (and
+ * VM/FSM side effects stubbed per target fork) is the next increment.  Protocol
+ * I/O is raw read()/write() over static buffers.
  *
  * Portions Copyright (c) 1996-2026, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
@@ -50,9 +58,13 @@
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"
 #include "access/xlogrecord.h"
+#include "miscadmin.h"
 #include "port/pg_crc32c.h"
 #include "postmaster/walredo.h"
 #include "storage/bufpage.h"
+#include "storage/ipc.h"
+#include "tcop/tcopprot.h"
+#include "utils/resowner.h"
 
 /* XLogReader reused across APPLY messages (lazily allocated) */
 static XLogReaderState *wr_reader = NULL;
@@ -107,7 +119,7 @@ write_fully(const void *buf, size_t len)
 		{
 			if (errno == EINTR)
 				continue;
-			_exit(1);
+			proc_exit(1);
 		}
 		p += n;
 		len -= (size_t) n;
@@ -129,8 +141,7 @@ read_u64(uint64 *v)
 void
 WalRedoMain(int argc, char *argv[])
 {
-	(void) argc;
-	(void) argv;
+	const char *dbname = NULL;
 
 #ifdef WIN32
 	/* the protocol is binary; keep the CRT from translating \n/\r\n/0x1a on the
@@ -139,7 +150,42 @@ WalRedoMain(int argc, char *argv[])
 	_setmode(_fileno(stdout), _O_BINARY);
 #endif
 
-	/* APPLY decodes records with an XLogReader, which needs a valid segment size */
+	/*
+	 * Drop the leading "--wal-redo" dispatch token so the shared standalone
+	 * bring-up sees a normal argv (process_postgres_switches only special-cases
+	 * "--single").  argv[0] is preserved as the program name.
+	 */
+	if (argc > 1)
+	{
+		argv[1] = argv[0];
+		argv++;
+		argc--;
+	}
+
+	/*
+	 * Bring up a standalone backend: switches (incl. -D), config, control file,
+	 * shared memory and a PGPROC -- everything the buffer manager needs.  This
+	 * runs against a private, throwaway data directory, never the live cluster's
+	 * (whose lock file is held by the postmaster): the helper only ever mutates
+	 * pages handed to it over the protocol, so a generic scratch cluster of the
+	 * same BLCKSZ is sufficient for redo.
+	 */
+	InitStandaloneBackend(argc, argv, NULL, &dbname, false);
+
+	/*
+	 * BaseInit() sets up smgr and the buffer manager (InitBufferManagerAccess),
+	 * which need the shared memory + MyProc that InitStandaloneBackend created.
+	 */
+	BaseInit();
+	SetProcessingMode(NormalProcessing);
+
+	/* index rmgrs (btree/GIN/GiST/SP-GiST) allocate recovery contexts here */
+	RmgrStartup();
+
+	/* buffer pins are tracked against a resource owner */
+	CurrentResourceOwner = ResourceOwnerCreate(NULL, "wal-redo");
+
+	/* the control file supplies the cluster's real WAL segment size */
 	if (wal_segment_size == 0)
 		wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 
@@ -148,7 +194,12 @@ WalRedoMain(int argc, char *argv[])
 		unsigned char tag;
 
 		if (!read_fully(&tag, 1))
-			_exit(0);			/* EOF: clean shutdown */
+		{
+			/* EOF: clean shutdown -- match RmgrStartup() so the index rmgrs'
+			 * recovery contexts are torn down */
+			RmgrCleanup();
+			proc_exit(0);
+		}
 
 		switch (tag)
 		{
@@ -158,7 +209,7 @@ WalRedoMain(int argc, char *argv[])
 
 					for (int i = 0; i < 5; i++)
 						if (!read_u32(&ident[i]))
-							_exit(1);
+							proc_exit(1);
 					(void) ident;	/* 4b stores the target identity from here */
 					/* 4a only resets the held page */
 					memset(held_page.data, 0, BLCKSZ);
@@ -171,11 +222,11 @@ WalRedoMain(int argc, char *argv[])
 					uint32		len;
 
 					if (!read_u64(&base_end_lsn) || !read_u32(&len))
-						_exit(1);
+						proc_exit(1);
 					if (len == BLCKSZ)
 					{
 						if (!read_fully(held_page.data, BLCKSZ))
-							_exit(1);
+							proc_exit(1);
 
 						/*
 						 * RestoreBlockImage (on the driver side) copies only the
@@ -198,7 +249,7 @@ WalRedoMain(int argc, char *argv[])
 					else if (len == 0)
 						memset(held_page.data, 0, BLCKSZ);
 					else
-						_exit(1);	/* malformed base length */
+						proc_exit(1);	/* malformed base length */
 					break;
 				}
 
@@ -214,12 +265,12 @@ WalRedoMain(int argc, char *argv[])
 
 					if (!read_u64(&start_lsn) || !read_u64(&end_lsn) ||
 						!read_u32(&len))
-						_exit(1);
+						proc_exit(1);
 					if (len < SizeOfXLogRecord)
-						_exit(1);
+						proc_exit(1);
 					recbuf = palloc(len);
 					if (!read_fully(recbuf, len))
-						_exit(1);
+						proc_exit(1);
 
 					/*
 					 * This path feeds the bytes straight to DecodeXLogRecord,
@@ -239,9 +290,9 @@ WalRedoMain(int argc, char *argv[])
 						pg_crc32c	crc;
 
 						if (rec->xl_tot_len != len)
-							_exit(1);
+							proc_exit(1);
 						if (!RmgrIdIsValid(rec->xl_rmid))
-							_exit(1);
+							proc_exit(1);
 
 						INIT_CRC32C(crc);
 						COMP_CRC32C(crc, recbuf + SizeOfXLogRecord,
@@ -249,7 +300,7 @@ WalRedoMain(int argc, char *argv[])
 						COMP_CRC32C(crc, rec, offsetof(XLogRecord, xl_crc));
 						FIN_CRC32C(crc);
 						if (!EQ_CRC32C(crc, rec->xl_crc))
-							_exit(1);
+							proc_exit(1);
 					}
 
 					if (wr_reader == NULL)
@@ -260,14 +311,14 @@ WalRedoMain(int argc, char *argv[])
 																  .segment_close = NULL),
 													   NULL);
 						if (wr_reader == NULL)
-							_exit(1);
+							proc_exit(1);
 					}
 
 					decoded = palloc(DecodeXLogRecordRequiredSpace(
 										 ((XLogRecord *) recbuf)->xl_tot_len));
 					if (!DecodeXLogRecord(wr_reader, decoded, (XLogRecord *) recbuf,
 										  (XLogRecPtr) end_lsn, &errm))
-						_exit(1);
+						proc_exit(1);
 
 					/*
 					 * Populate the reader so the XLogRecGet* accessors and (once
@@ -290,7 +341,7 @@ WalRedoMain(int argc, char *argv[])
 					 */
 					msg = "wal-redo: APPLY decoded the record but rm_redo is not implemented yet (4b step 2)\n";
 					write(STDERR_FILENO, msg, strlen(msg));
-					_exit(2);
+					proc_exit(2);
 				}
 
 			case WALREDO_GET:
@@ -298,7 +349,7 @@ WalRedoMain(int argc, char *argv[])
 				break;
 
 			default:
-				_exit(1);		/* protocol error */
+				proc_exit(1);		/* protocol error */
 		}
 	}
 }

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -47,6 +47,7 @@
 #include "postgres.h"
 
 #include <errno.h>
+#include <signal.h>
 #include <unistd.h>
 #ifdef WIN32
 #include <fcntl.h>
@@ -58,6 +59,7 @@
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"
 #include "access/xlogrecord.h"
+#include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #include "port/pg_crc32c.h"
 #include "postmaster/walredo.h"
@@ -83,6 +85,20 @@ static XLogReaderState *wr_reader = NULL;
  */
 static PGAlignedBlock held_page;
 
+/*
+ * Set by the termination-signal handler.  The handler does nothing but set this
+ * flag (async-signal-safe); the protocol read loop notices it when the blocking
+ * read returns EINTR and shuts the helper down cleanly via proc_exit().
+ */
+static volatile sig_atomic_t walredo_shutdown_requested = 0;
+
+static void
+walredo_term_handler(int signo)
+{
+	(void) signo;
+	walredo_shutdown_requested = 1;
+}
+
 static bool
 read_fully(void *buf, size_t len)
 {
@@ -95,7 +111,13 @@ read_fully(void *buf, size_t len)
 		if (n < 0)
 		{
 			if (errno == EINTR)
+			{
+				/* a termination signal delivered while we block here interrupts
+				 * the read; honor it instead of silently retrying */
+				if (walredo_shutdown_requested)
+					proc_exit(1);
 				continue;
+			}
 			return false;
 		}
 		if (n == 0)
@@ -184,6 +206,36 @@ WalRedoMain(int argc, char *argv[])
 
 	/* buffer pins are tracked against a resource owner */
 	CurrentResourceOwner = ResourceOwnerCreate(NULL, "wal-redo");
+
+	/*
+	 * InitStandaloneProcess() leaves the signal mask blocked (BlockSig).  Install
+	 * handlers and unblock so a long-lived/pooled helper can be stopped with
+	 * SIGINT/SIGTERM rather than getting stuck until stdin closes; die() sets a
+	 * pending interrupt that read_fully() acts on via CHECK_FOR_INTERRUPTS() when
+	 * the blocking read returns EINTR, giving a clean proc_exit().
+	 */
+	{
+		struct sigaction act;
+		int			diesigs[] = {SIGINT, SIGTERM, SIGQUIT};
+
+		/*
+		 * Install the termination handler deliberately *without* SA_RESTART (so
+		 * not via pqsignal): the helper blocks in read(), and we need that read to
+		 * return EINTR on a termination signal so the loop can shut down.  With
+		 * SA_RESTART the read would silently resume and the process would stay
+		 * stuck until stdin closed.  The handler only sets a flag, so it is
+		 * async-signal-safe; proc_exit() runs later from read_fully().
+		 */
+		memset(&act, 0, sizeof(act));
+		act.sa_handler = walredo_term_handler;
+		sigemptyset(&act.sa_mask);
+		act.sa_flags = 0;
+		for (int i = 0; i < (int) lengthof(diesigs); i++)
+			sigaction(diesigs[i], &act, NULL);
+	}
+	pqsignal(SIGHUP, PG_SIG_IGN);
+	pqsignal(SIGPIPE, PG_SIG_IGN);
+	sigprocmask(SIG_SETMASK, &UnBlockSig, NULL);
 
 	/* the control file supplies the cluster's real WAL segment size */
 	if (wal_segment_size == 0)

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4127,14 +4127,25 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
  * process queries. Single user mode specific setup should go here, rather
  * than PostgresMain() or InitPostgres() when reasonably possible.
  */
+/*
+ * Bring up a standalone (no-postmaster) backend's process and shared-memory
+ * environment, in the exact order these prerequisites require: parse switches,
+ * read config + control file, size and create shared memory, and attach a
+ * PGPROC.  This is the load-bearing prefix shared by PostgresSingleUserMain()
+ * and the wal-redo helper (WalRedoMain()); keeping the sequence in one place
+ * avoids the easy-to-get-wrong reordering of these steps.
+ *
+ * On return, shared memory exists and MyProc is set, so the caller may run
+ * BaseInit() (which calls InitBufferManagerAccess()).  The parsed database name
+ * is returned in *dbname; when need_dbname is set and none was given it defaults
+ * to username (FATAL if that is also NULL), matching historical single-user
+ * behaviour.  Callers that open no database (e.g. wal-redo) pass need_dbname =
+ * false.
+ */
 void
-PostgresSingleUserMain(int argc, char *argv[],
-					   const char *username)
+InitStandaloneBackend(int argc, char *argv[], const char *username,
+					  const char **dbname, bool need_dbname)
 {
-	const char *dbname = NULL;
-
-	Assert(!IsUnderPostmaster);
-
 	/* Initialize startup process environment. */
 	InitStandaloneProcess(argv[0]);
 
@@ -4146,13 +4157,13 @@ PostgresSingleUserMain(int argc, char *argv[],
 	/*
 	 * Parse command-line options.
 	 */
-	process_postgres_switches(argc, argv, PGC_POSTMASTER, &dbname);
+	process_postgres_switches(argc, argv, PGC_POSTMASTER, dbname);
 
 	/* Must have gotten a database name, or have a default (the username) */
-	if (dbname == NULL)
+	if (need_dbname && *dbname == NULL)
 	{
-		dbname = username;
-		if (dbname == NULL)
+		*dbname = username;
+		if (*dbname == NULL)
 			ereport(FATAL,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("%s: no database nor user name specified",
@@ -4250,6 +4261,18 @@ PostgresSingleUserMain(int argc, char *argv[],
 	 * before we can use LWLocks.
 	 */
 	InitProcess();
+}
+
+void
+PostgresSingleUserMain(int argc, char *argv[],
+					   const char *username)
+{
+	const char *dbname = NULL;
+
+	Assert(!IsUnderPostmaster);
+
+	/* Shared standalone-backend bring-up: switches, config, shmem, PGPROC. */
+	InitStandaloneBackend(argc, argv, username, &dbname, true);
 
 	/*
 	 * Now that sufficient infrastructure has been initialized, PostgresMain()

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4144,7 +4144,7 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
  */
 void
 InitStandaloneBackend(int argc, char *argv[], const char *username,
-					  const char **dbname, bool need_dbname)
+					  const char **dbname, bool need_dbname, bool require_datadir)
 {
 	/* Initialize startup process environment. */
 	InitStandaloneProcess(argv[0]);
@@ -4169,6 +4169,16 @@ InitStandaloneBackend(int argc, char *argv[], const char *username,
 					 errmsg("%s: no database nor user name specified",
 							progname)));
 	}
+
+	/*
+	 * Callers that must not silently fall back to PGDATA (e.g. the wal-redo
+	 * helper, which has to run against an explicit private scratch directory and
+	 * never the live cluster) require an explicit -D.
+	 */
+	if (require_datadir && userDoption == NULL)
+		ereport(FATAL,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("%s: -D / --pgdata must be specified", progname)));
 
 	/* Acquire configuration parameters */
 	if (!SelectConfigFiles(userDoption, progname))
@@ -4271,8 +4281,9 @@ PostgresSingleUserMain(int argc, char *argv[],
 
 	Assert(!IsUnderPostmaster);
 
-	/* Shared standalone-backend bring-up: switches, config, shmem, PGPROC. */
-	InitStandaloneBackend(argc, argv, username, &dbname, true);
+	/* Shared standalone-backend bring-up: switches, config, shmem, PGPROC.
+	 * Single-user mode keeps the historical PGDATA fallback (require_datadir=false). */
+	InitStandaloneBackend(argc, argv, username, &dbname, true, false);
 
 	/*
 	 * Now that sufficient infrastructure has been initialized, PostgresMain()

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -80,6 +80,8 @@ extern void ProcessClientWriteInterrupt(bool blocked);
 
 extern void process_postgres_switches(int argc, char *argv[],
 									  GucContext ctx, const char **dbname);
+extern void InitStandaloneBackend(int argc, char *argv[], const char *username,
+								  const char **dbname, bool need_dbname);
 pg_noreturn extern void PostgresSingleUserMain(int argc, char *argv[],
 											   const char *username);
 pg_noreturn extern void PostgresMain(const char *dbname,

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -81,7 +81,8 @@ extern void ProcessClientWriteInterrupt(bool blocked);
 extern void process_postgres_switches(int argc, char *argv[],
 									  GucContext ctx, const char **dbname);
 extern void InitStandaloneBackend(int argc, char *argv[], const char *username,
-								  const char **dbname, bool need_dbname);
+								  const char **dbname, bool need_dbname,
+								  bool require_datadir);
 pg_noreturn extern void PostgresSingleUserMain(int argc, char *argv[],
 											   const char *username);
 pg_noreturn extern void PostgresMain(const char *dbname,


### PR DESCRIPTION
Second 4b increment: the helper init the redesign (#42) called for, developed + tested on a real build/run loop.

## Why
Running a record's `rm_redo` goes through the normal buffer manager, and `InitBufferManagerAccess()` asserts `MyProc != NULL` + needs shared memory — so the helper can't use a minimal/fake init. It must be a real **standalone backend**.

## What
- **Factor** the single-user init prefix (switches → config → control file → shmem sizing/creation → PGPROC) out of `PostgresSingleUserMain` into a shared `InitStandaloneBackend()`, so the load-bearing ordering lives in one place (codex's #42 guidance: reuse, don't re-order). `PostgresSingleUserMain` now calls it; `need_dbname=false` skips DB-name defaulting for callers that open no database.
- `WalRedoMain` strips the `--wal-redo` token, calls `InitStandaloneBackend` (so `-D` is parsed via `process_postgres_switches`), then `BaseInit()` + `RmgrStartup()` + a resource owner, and `RmgrCleanup()` on clean shutdown. Runs against a **private throwaway datadir**, never the live cluster's (avoids the postmaster lock); the helper only mutates protocol-supplied pages, so any BLCKSZ-matching scratch cluster works.
- Exit via `proc_exit()` (not `_exit()`) now that the process owns shmem + semaphores.
- Helper now requires `postgres --wal-redo -D <datadir>`; the CI smoke job builds+installs, `initdb`s a scratch cluster, and drives the protocol against it.

## Verified
wal-redo starts and round-trips BEGIN/PUSHBASE/GET against a real datadir; single-user mode still works; smoke test 6/6. `APPLY` still only decodes/validates (exit 2) — running `rm_redo` on the held page (the buffer redirect) is the next step (2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)