### PR TITLE
wal-redo: run rm_redo on the held page (4b step 2b)

### DIFF
--- a/.github/scripts/walredo_redo_test.py
+++ b/.github/scripts/walredo_redo_test.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python3
-"""End-to-end redo test for the `postgres --wal-redo` helper.
+"""End-to-end redo tests for the `postgres --wal-redo` helper.
 
-Generates a real WAL delta record, replays it onto a base page through the
-helper, and checks the result matches the page the running server produced.
+Each case generates a real WAL delta record on a throwaway cluster, replays it
+onto a captured base page through the helper, and checks the result matches the
+page the running server produced -- except pd_lsn (offset 0..7, stamped by redo)
+and pd_checksum (offset 8..9, which the helper leaves for the caller).
 
-It uses a throwaway cluster:
-  - insert a row, CHECKPOINT (so the next change to the page logs an FPI),
-  - insert a second row (record A: carries the block's full-page image),
-  - capture block 0 as the base,
-  - insert a third row (record B: a pure delta, no FPI -- not the first change
-    after the checkpoint),
-  - CHECKPOINT and capture block 0 as the expected result.
-Then BEGIN(target=block 0) + PUSHBASE(base) + APPLY(record B) + GET must equal
-the expected page, except pd_lsn (offset 0..7, stamped by redo) and pd_checksum
-(offset 8..9, which the helper deliberately leaves for the caller to recompute).
+Cases:
+  insert  - a no-FPI heap INSERT delta (third insert after a checkpoint+FPI).
+  update  - a heap UPDATE that clears the all-visible VM bit, exercising the
+            visibilitymap_pin/clear redo path; run with full_page_writes=off so
+            the record is a small delta rather than a full-page image.
 
 Usage: walredo_redo_test.py <bindir> <datadir> <port>
 """
-import glob
 import os
 import re
 import struct
@@ -45,13 +41,65 @@ def lsn2int(s):
     return (int(hi, 16) << 32) | int(lo, 16)
 
 
-try:
-    os.remove(f"{PGDATA}/postmaster.pid")
-except OSError:
-    pass
+def fmt(x):
+    return "%X/%08X" % (x >> 32, x & 0xFFFFFFFF)
 
-pg_ctl("-o", f"-p {PORT} -k /tmp", "-l", f"{PGDATA}/redo_test.log", "start")
-time.sleep(2)
+
+def start(extra_opts=""):
+    try:
+        os.remove(f"{PGDATA}/postmaster.pid")
+    except OSError:
+        pass
+    pg_ctl("-o", f"-p {PORT} -k /tmp {extra_opts}", "-l", f"{PGDATA}/redo_test.log", "start")
+    time.sleep(2)
+
+
+def extract_record(start_lsn, end_lsn, desc_match):
+    """Return (rec_start, rec_end, bytes) for the first matching no-FPI record."""
+    dump = subprocess.run([f"{BINDIR}/pg_waldump", "-p", f"{PGDATA}/pg_wal",
+                           "-s", fmt(start_lsn), "-e", fmt(end_lsn)],
+                          capture_output=True, text=True).stdout
+    all_lsns = sorted({lsn2int(m.group(1))
+                       for m in re.finditer(r"lsn: ([0-9A-F]+/[0-9A-F]+)", dump)})
+    rec_start = None
+    for ln in dump.splitlines():
+        if desc_match(ln) and "FPW" not in ln and "lsn:" in ln:
+            rec_start = lsn2int(re.search(r"lsn: ([0-9A-F]+/[0-9A-F]+)", ln).group(1))
+            break
+    assert rec_start is not None, "no matching no-FPI record found"
+    rec_end = min([x for x in all_lsns if x > rec_start] + [end_lsn])
+    off = rec_start % SEGSIZE
+    assert (off % 8192) + (rec_end - rec_start) <= 8192, "record spans a WAL page; rerun"
+    seg = "%08X%08X%08X" % (1, rec_start >> 32, (rec_start % (1 << 32)) // SEGSIZE)
+    data = open(f"{PGDATA}/pg_wal/{seg}", "rb").read()[off:off + (rec_end - rec_start)]
+    return rec_start, rec_end, data
+
+
+def replay(db, rel, base_hex, base_lsn, rec_start, rec_end, data):
+    msg = b'b' + struct.pack('<5I', 1663, db, rel, 0, 0)
+    msg += b'p' + struct.pack('<QI', base_lsn, 8192) + bytes.fromhex(base_hex)
+    msg += b'a' + struct.pack('<QQI', rec_start, rec_end, len(data)) + data
+    msg += b'g'
+    return subprocess.run([f"{BINDIR}/postgres", "--wal-redo", "-D", PGDATA],
+                          input=msg, capture_output=True, timeout=120)
+
+
+def check(name, p, exp_hex):
+    exp, got = bytes.fromhex(exp_hex), p.stdout
+    ok = (p.returncode == 0 and len(got) == 8192 and got[10:] == exp[10:])
+    print("PASS" if ok else "FAIL", "-", name)
+    if not ok:
+        print("  rc=%d len=%d" % (p.returncode, len(got)))
+        print("  stderr:", p.stderr.decode("latin1")[-600:])
+        if len(got) == 8192:
+            print("  body diffs:", [i for i in range(10, 8192) if got[i] != exp[i]][:12])
+    return ok
+
+
+fails = 0
+
+# --- case: no-FPI heap INSERT delta ---------------------------------------
+start()
 Q("create extension if not exists pageinspect;")
 Q("drop table if exists wrt; create table wrt(id int primary key, v text) "
   "with (autovacuum_enabled=off);")
@@ -60,50 +108,35 @@ Q("checkpoint;")
 Q("insert into wrt values (2,'bbbb');")                 # record A: FPI carrier
 base_hex = Q("select encode(get_raw_page('wrt',0),'hex');")
 base_lsn = lsn2int(Q("select lsn from page_header(get_raw_page('wrt',0));"))
-start_lsn = lsn2int(Q("select pg_current_wal_lsn();"))
+s = lsn2int(Q("select pg_current_wal_lsn();"))
 Q("insert into wrt values (3,'cccc');")                 # record B: the delta
-end_lsn = lsn2int(Q("select pg_current_wal_lsn();"))
+e = lsn2int(Q("select pg_current_wal_lsn();"))
 Q("checkpoint;")
 exp_hex = Q("select encode(get_raw_page('wrt',0),'hex');")
 db = int(Q("select oid from pg_database where datname='postgres';"))
 rel = int(Q("select relfilenode from pg_class where relname='wrt';"))
-dump = subprocess.run([f"{BINDIR}/pg_waldump", "-p", f"{PGDATA}/pg_wal",
-                       "-s", "%X/%08X" % (start_lsn >> 32, start_lsn & 0xFFFFFFFF),
-                       "-e", "%X/%08X" % (end_lsn >> 32, end_lsn & 0xFFFFFFFF)],
-                      capture_output=True, text=True).stdout
 pg_ctl("stop", "-m", "fast")
+rs, re_, data = extract_record(s, e, lambda ln: "Heap" in ln and "INSERT" in ln)
+fails += not check("heap INSERT delta", replay(db, rel, base_hex, base_lsn, rs, re_, data), exp_hex)
 
-# locate record B: a heap INSERT with no full-page image
-all_lsns = sorted({lsn2int(m.group(1))
-                   for m in re.finditer(r"lsn: ([0-9A-F]+/[0-9A-F]+)", dump)})
-rec_start = None
-for ln in dump.splitlines():
-    if "Heap" in ln and "INSERT" in ln and "FPW" not in ln and "lsn:" in ln:
-        rec_start = lsn2int(re.search(r"lsn: ([0-9A-F]+/[0-9A-F]+)", ln).group(1))
-        break
-assert rec_start is not None, "no no-FPI heap INSERT record found"
-rec_end = min([x for x in all_lsns if x > rec_start] + [end_lsn])
-rec_len = rec_end - rec_start
-off = rec_start % SEGSIZE
-assert (off % 8192) + rec_len <= 8192, "record spans a WAL page boundary; rerun"
-seg = "%08X%08X%08X" % (1, rec_start >> 32, (rec_start % (1 << 32)) // SEGSIZE)
-rec = open(f"{PGDATA}/pg_wal/{seg}", "rb").read()[off:off + rec_len]
+# --- case: VM-clearing heap UPDATE delta (full_page_writes off) -----------
+start("-c full_page_writes=off")
+Q("drop table if exists vmt; create table vmt(id int primary key, v text) "
+  "with (autovacuum_enabled=off);")
+Q("insert into vmt values (1,'aaaa');")
+Q("vacuum (freeze) vmt;")                               # set the all-visible VM bit
+Q("checkpoint;")
+base_hex = Q("select encode(get_raw_page('vmt',0),'hex');")
+base_lsn = lsn2int(Q("select lsn from page_header(get_raw_page('vmt',0));"))
+s = lsn2int(Q("select pg_current_wal_lsn();"))
+Q("update vmt set v='bbbb' where id=1;")                # clears the VM bit
+e = lsn2int(Q("select pg_current_wal_lsn();"))
+Q("checkpoint;")
+exp_hex = Q("select encode(get_raw_page('vmt',0),'hex');")
+db = int(Q("select oid from pg_database where datname='postgres';"))
+rel = int(Q("select relfilenode from pg_class where relname='vmt';"))
+pg_ctl("stop", "-m", "fast")
+rs, re_, data = extract_record(s, e, lambda ln: "Heap" in ln and "UPDATE" in ln)
+fails += not check("VM-clearing heap UPDATE delta", replay(db, rel, base_hex, base_lsn, rs, re_, data), exp_hex)
 
-msg = b'b' + struct.pack('<5I', 1663, db, rel, 0, 0)
-msg += b'p' + struct.pack('<QI', base_lsn, 8192) + bytes.fromhex(base_hex)
-msg += b'a' + struct.pack('<QQI', rec_start, rec_end, rec_len) + rec
-msg += b'g'
-p = subprocess.run([f"{BINDIR}/postgres", "--wal-redo", "-D", PGDATA],
-                   input=msg, capture_output=True, timeout=120)
-got, exp = p.stdout, bytes.fromhex(exp_hex)
-
-ok = (p.returncode == 0 and len(got) == 8192 and got[10:] == exp[10:])
-print("PASS" if ok else "FAIL",
-      "- redo of a heap INSERT delta reproduces the server's page",
-      "(ignoring pd_lsn + pd_checksum)")
-if not ok:
-    print("rc=%d len=%d" % (p.returncode, len(got)))
-    print("stderr:", p.stderr.decode("latin1")[-800:])
-    if len(got) == 8192:
-        print("first body diffs:", [i for i in range(10, 8192) if got[i] != exp[i]][:12])
-sys.exit(0 if ok else 1)
+sys.exit(1 if fails else 0)

--- a/.github/scripts/walredo_redo_test.py
+++ b/.github/scripts/walredo_redo_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""End-to-end redo test for the `postgres --wal-redo` helper.
+
+Generates a real WAL delta record, replays it onto a base page through the
+helper, and checks the result matches the page the running server produced.
+
+It uses a throwaway cluster:
+  - insert a row, CHECKPOINT (so the next change to the page logs an FPI),
+  - insert a second row (record A: carries the block's full-page image),
+  - capture block 0 as the base,
+  - insert a third row (record B: a pure delta, no FPI -- not the first change
+    after the checkpoint),
+  - CHECKPOINT and capture block 0 as the expected result.
+Then BEGIN(target=block 0) + PUSHBASE(base) + APPLY(record B) + GET must equal
+the expected page, except pd_lsn (offset 0..7, stamped by redo) and pd_checksum
+(offset 8..9, which the helper deliberately leaves for the caller to recompute).
+
+Usage: walredo_redo_test.py <bindir> <datadir> <port>
+"""
+import glob
+import os
+import re
+import struct
+import subprocess
+import sys
+import time
+
+BINDIR, PGDATA, PORT = sys.argv[1], sys.argv[2], sys.argv[3]
+os.environ["LC_ALL"] = "C"
+SEGSIZE = 16 * 1024 * 1024
+
+
+def pg_ctl(*a):
+    subprocess.run([f"{BINDIR}/pg_ctl", "-D", PGDATA] + list(a), capture_output=True)
+
+
+def Q(sql):
+    return subprocess.run([f"{BINDIR}/psql", "-h", "/tmp", "-p", PORT, "-U", "postgres",
+                           "-d", "postgres", "-tA", "-c", sql],
+                          capture_output=True, text=True).stdout.strip()
+
+
+def lsn2int(s):
+    hi, lo = s.split("/")
+    return (int(hi, 16) << 32) | int(lo, 16)
+
+
+try:
+    os.remove(f"{PGDATA}/postmaster.pid")
+except OSError:
+    pass
+
+pg_ctl("-o", f"-p {PORT} -k /tmp", "-l", f"{PGDATA}/redo_test.log", "start")
+time.sleep(2)
+Q("create extension if not exists pageinspect;")
+Q("drop table if exists wrt; create table wrt(id int primary key, v text) "
+  "with (autovacuum_enabled=off);")
+Q("insert into wrt values (1,'aaaa');")
+Q("checkpoint;")
+Q("insert into wrt values (2,'bbbb');")                 # record A: FPI carrier
+base_hex = Q("select encode(get_raw_page('wrt',0),'hex');")
+base_lsn = lsn2int(Q("select lsn from page_header(get_raw_page('wrt',0));"))
+start_lsn = lsn2int(Q("select pg_current_wal_lsn();"))
+Q("insert into wrt values (3,'cccc');")                 # record B: the delta
+end_lsn = lsn2int(Q("select pg_current_wal_lsn();"))
+Q("checkpoint;")
+exp_hex = Q("select encode(get_raw_page('wrt',0),'hex');")
+db = int(Q("select oid from pg_database where datname='postgres';"))
+rel = int(Q("select relfilenode from pg_class where relname='wrt';"))
+dump = subprocess.run([f"{BINDIR}/pg_waldump", "-p", f"{PGDATA}/pg_wal",
+                       "-s", "%X/%08X" % (start_lsn >> 32, start_lsn & 0xFFFFFFFF),
+                       "-e", "%X/%08X" % (end_lsn >> 32, end_lsn & 0xFFFFFFFF)],
+                      capture_output=True, text=True).stdout
+pg_ctl("stop", "-m", "fast")
+
+# locate record B: a heap INSERT with no full-page image
+all_lsns = sorted({lsn2int(m.group(1))
+                   for m in re.finditer(r"lsn: ([0-9A-F]+/[0-9A-F]+)", dump)})
+rec_start = None
+for ln in dump.splitlines():
+    if "Heap" in ln and "INSERT" in ln and "FPW" not in ln and "lsn:" in ln:
+        rec_start = lsn2int(re.search(r"lsn: ([0-9A-F]+/[0-9A-F]+)", ln).group(1))
+        break
+assert rec_start is not None, "no no-FPI heap INSERT record found"
+rec_end = min([x for x in all_lsns if x > rec_start] + [end_lsn])
+rec_len = rec_end - rec_start
+off = rec_start % SEGSIZE
+assert (off % 8192) + rec_len <= 8192, "record spans a WAL page boundary; rerun"
+seg = "%08X%08X%08X" % (1, rec_start >> 32, (rec_start % (1 << 32)) // SEGSIZE)
+rec = open(f"{PGDATA}/pg_wal/{seg}", "rb").read()[off:off + rec_len]
+
+msg = b'b' + struct.pack('<5I', 1663, db, rel, 0, 0)
+msg += b'p' + struct.pack('<QI', base_lsn, 8192) + bytes.fromhex(base_hex)
+msg += b'a' + struct.pack('<QQI', rec_start, rec_end, rec_len) + rec
+msg += b'g'
+p = subprocess.run([f"{BINDIR}/postgres", "--wal-redo", "-D", PGDATA],
+                   input=msg, capture_output=True, timeout=120)
+got, exp = p.stdout, bytes.fromhex(exp_hex)
+
+ok = (p.returncode == 0 and len(got) == 8192 and got[10:] == exp[10:])
+print("PASS" if ok else "FAIL",
+      "- redo of a heap INSERT delta reproduces the server's page",
+      "(ignoring pd_lsn + pd_checksum)")
+if not ok:
+    print("rc=%d len=%d" % (p.returncode, len(got)))
+    print("stderr:", p.stderr.decode("latin1")[-800:])
+    if len(got) == 8192:
+        print("first body diffs:", [i for i in range(10, 8192) if got[i] != exp[i]][:12])
+sys.exit(0 if ok else 1)

--- a/.github/workflows/walredo-test.yml
+++ b/.github/workflows/walredo-test.yml
@@ -16,7 +16,10 @@ on:
       - 'src/include/postmaster/postmaster.h'
       - 'src/backend/tcop/postgres.c'
       - 'src/include/tcop/tcopprot.h'
+      - 'src/backend/access/transam/xlogutils.c'
+      - 'src/backend/access/heap/visibilitymap.c'
       - '.github/scripts/walredo_smoke.py'
+      - '.github/scripts/walredo_redo_test.py'
       - '.github/workflows/walredo-test.yml'
   pull_request:
     paths:
@@ -26,7 +29,10 @@ on:
       - 'src/include/postmaster/postmaster.h'
       - 'src/backend/tcop/postgres.c'
       - 'src/include/tcop/tcopprot.h'
+      - 'src/backend/access/transam/xlogutils.c'
+      - 'src/backend/access/heap/visibilitymap.c'
       - '.github/scripts/walredo_smoke.py'
+      - '.github/scripts/walredo_redo_test.py'
       - '.github/workflows/walredo-test.yml'
   workflow_dispatch:
 
@@ -59,3 +65,6 @@ jobs:
 
       - name: wal-redo protocol smoke test
         run: python3 .github/scripts/walredo_smoke.py inst/bin/postgres scratch
+
+      - name: wal-redo redo end-to-end test
+        run: python3 .github/scripts/walredo_redo_test.py inst/bin scratch 5499

--- a/src/backend/access/heap/visibilitymap.c
+++ b/src/backend/access/heap/visibilitymap.c
@@ -103,6 +103,7 @@
 #include "access/xlogutils.h"
 #include "miscadmin.h"
 #include "port/pg_bitutils.h"
+#include "postmaster/walredo.h"
 #include "storage/bufmgr.h"
 #include "storage/smgr.h"
 #include "utils/inval.h"
@@ -157,6 +158,10 @@ visibilitymap_clear(Relation rel, BlockNumber heapBlk, Buffer vmbuf, uint8 flags
 	char	   *map;
 	bool		cleared = false;
 
+	/* no VM fork in the wal-redo helper; nothing to clear */
+	if (am_walredo)
+		return false;
+
 	/* Must never clear all_visible bit while leaving all_frozen bit set */
 	Assert(flags & VISIBILITYMAP_VALID_BITS);
 	Assert(flags != VISIBILITYMAP_ALL_VISIBLE);
@@ -204,6 +209,17 @@ void
 visibilitymap_pin(Relation rel, BlockNumber heapBlk, Buffer *vmbuf)
 {
 	BlockNumber mapBlock = HEAPBLK_TO_MAPBLOCK(heapBlk);
+
+	/*
+	 * The wal-redo helper materializes a single heap page and has no VM fork to
+	 * read; leave the VM buffer invalid so the matching visibilitymap_clear()
+	 * becomes a no-op.
+	 */
+	if (am_walredo)
+	{
+		*vmbuf = InvalidBuffer;
+		return;
+	}
 
 	/* Reuse the old pinned buffer if possible */
 	if (BufferIsValid(*vmbuf))

--- a/src/backend/access/heap/visibilitymap.c
+++ b/src/backend/access/heap/visibilitymap.c
@@ -211,13 +211,15 @@ visibilitymap_pin(Relation rel, BlockNumber heapBlk, Buffer *vmbuf)
 	BlockNumber mapBlock = HEAPBLK_TO_MAPBLOCK(heapBlk);
 
 	/*
-	 * The wal-redo helper materializes a single heap page and has no VM fork to
-	 * read; leave the VM buffer invalid so the matching visibilitymap_clear()
-	 * becomes a no-op.
+	 * The wal-redo helper materializes a single heap page and has no VM fork.
+	 * visibilitymap_clear() is a no-op there, but redo callers still
+	 * ReleaseBuffer() the pin unconditionally, so hand back a valid pinned
+	 * scratch buffer (reusing the one already pinned, if any).
 	 */
 	if (am_walredo)
 	{
-		*vmbuf = InvalidBuffer;
+		if (!BufferIsValid(*vmbuf))
+			*vmbuf = WalRedoScratchBuffer();
 		return;
 	}
 

--- a/src/backend/access/transam/xlogutils.c
+++ b/src/backend/access/transam/xlogutils.c
@@ -401,7 +401,7 @@ XLogReadBufferForRedoExtended(XLogReaderState *record,
 		 * force the on-disk state of init forks to always be in sync with the
 		 * state in shared buffers.
 		 */
-		if (forknum == INIT_FORKNUM)
+		if (forknum == INIT_FORKNUM && !am_walredo)
 			FlushOneBuffer(*buf);
 
 		return BLK_RESTORED;

--- a/src/backend/access/transam/xlogutils.c
+++ b/src/backend/access/transam/xlogutils.c
@@ -24,6 +24,7 @@
 #include "access/xlog_internal.h"
 #include "access/xlogutils.h"
 #include "miscadmin.h"
+#include "postmaster/walredo.h"
 #include "storage/fd.h"
 #include "storage/smgr.h"
 #include "utils/hsearch.h"
@@ -464,6 +465,14 @@ XLogReadBufferExtended(RelFileLocator rlocator, ForkNumber forknum,
 	BlockNumber lastblock;
 	Buffer		buffer;
 	SMgrRelation smgr;
+
+	/*
+	 * In the wal-redo helper there is no on-disk relation to read: redo runs
+	 * against a single held page (plus a scratch page for other blocks), so
+	 * resolve the buffer from those instead of smgr.
+	 */
+	if (am_walredo)
+		return WalRedoReadBuffer(rlocator, forknum, blkno, mode);
 
 	Assert(blkno != P_NEW);
 

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -64,6 +64,7 @@
 #include "miscadmin.h"
 #include "port/pg_crc32c.h"
 #include "postmaster/walredo.h"
+#include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "storage/bufpage.h"
 #include "storage/ipc.h"
@@ -205,6 +206,7 @@ static bool wr_have_target = false;
  */
 static Buffer wr_target_buf = InvalidBuffer;
 static Buffer wr_scratch_buf = InvalidBuffer;
+static SMgrRelation wr_smgr = NULL;
 
 /* release the long-lived buffer pins at process exit, before the buffer manager's
  * own leak check (registered with before_shmem_exit so it runs first) */
@@ -223,13 +225,19 @@ wr_release_buffers(int code, Datum arg)
 		ReleaseBuffer(wr_scratch_buf);
 		wr_scratch_buf = InvalidBuffer;
 	}
+	/* remove the backing temp file so a later helper reusing this datadir does
+	 * not trip over a leftover relation */
+	if (wr_smgr != NULL)
+	{
+		smgrdounlinkall(&wr_smgr, 1, false);
+		wr_smgr = NULL;
+	}
 }
 
 static void
 wr_ensure_buffers(void)
 {
 	RelFileLocator tmp;
-	SMgrRelation reln;
 
 	if (wr_target_buf != InvalidBuffer)
 		return;
@@ -237,13 +245,27 @@ wr_ensure_buffers(void)
 	tmp.spcOid = 1663;			/* pg_default */
 	tmp.dbOid = 1;				/* template1 (its base dir always exists) */
 	tmp.relNumber = 0x7e000001; /* arbitrary, private to this backend */
-	reln = smgropen(tmp, MyProcNumber);
-	smgrcreate(reln, MAIN_FORKNUM, false);
-	wr_target_buf = ExtendBufferedRel(BMR_SMGR(reln, RELPERSISTENCE_TEMP),
+	wr_smgr = smgropen(tmp, MyProcNumber);
+	/* isRedo=true: tolerate a file left behind by a previously crashed helper */
+	smgrcreate(wr_smgr, MAIN_FORKNUM, true);
+	wr_target_buf = ExtendBufferedRel(BMR_SMGR(wr_smgr, RELPERSISTENCE_TEMP),
 									  MAIN_FORKNUM, NULL, EB_SKIP_EXTENSION_LOCK);
-	wr_scratch_buf = ExtendBufferedRel(BMR_SMGR(reln, RELPERSISTENCE_TEMP),
+	wr_scratch_buf = ExtendBufferedRel(BMR_SMGR(wr_smgr, RELPERSISTENCE_TEMP),
 									   MAIN_FORKNUM, NULL, EB_SKIP_EXTENSION_LOCK);
 	before_shmem_exit(wr_release_buffers, (Datum) 0);
+}
+
+/*
+ * A pinned scratch buffer for redo code that reads a fork the helper does not
+ * model (e.g. visibilitymap_pin needs a buffer its caller will ReleaseBuffer).
+ * The content is irrelevant and never read back.
+ */
+Buffer
+WalRedoScratchBuffer(void)
+{
+	wr_ensure_buffers();
+	IncrBufferRefCount(wr_scratch_buf);
+	return wr_scratch_buf;
 }
 
 Buffer
@@ -258,10 +280,22 @@ WalRedoReadBuffer(RelFileLocator rlocator, ForkNumber forknum,
 		b = wr_target_buf;
 	else
 	{
+		/*
+		 * Any block other than the BEGIN target only needs to keep the redo
+		 * routine happy; its result is never read back.  For a WILL_INIT block
+		 * (zero mode) hand back a zeroed page for the routine to initialize.
+		 * Otherwise give the scratch page an LSN newer than any record so
+		 * XLogReadBufferForRedo() classifies it as BLK_DONE and skips it -- a
+		 * zero-LSN page would be treated as BLK_NEEDS_REDO and the routine would
+		 * apply the record to bogus contents (e.g. a cross-page heap UPDATE
+		 * panicking on the old tuple's block).
+		 */
 		b = wr_scratch_buf;
 		if (mode == RBM_ZERO_AND_LOCK || mode == RBM_ZERO_AND_CLEANUP_LOCK ||
 			mode == RBM_ZERO_ON_ERROR)
 			memset(BufferGetPage(b), 0, BLCKSZ);
+		else
+			PageSetLSN(BufferGetPage(b), PG_UINT64_MAX);
 	}
 
 	/*
@@ -516,6 +550,18 @@ WalRedoMain(int argc, char *argv[])
 					 * buffers.  Read the materialized page back for GET.
 					 */
 					wr_ensure_buffers();
+
+					/*
+					 * Make the target buffer report the WAL block identity, so redo
+					 * that writes the buffer's block number into the page (e.g.
+					 * heap lock/confirm resetting t_ctid via BufferGetBlockNumber)
+					 * records the real block, not the temp relation's block 0.  We
+					 * never look these buffers up by tag, so retagging the local
+					 * descriptor in place is safe.
+					 */
+					InitBufferTag(&GetLocalBufferDescriptor(-wr_target_buf - 1)->tag,
+								  &wr_target_rloc, wr_target_fork, wr_target_blk);
+
 					memcpy(BufferGetPage(wr_target_buf), held_page.data, BLCKSZ);
 					memset(BufferGetPage(wr_scratch_buf), 0, BLCKSZ);
 
@@ -524,6 +570,14 @@ WalRedoMain(int argc, char *argv[])
 					am_walredo = false;
 
 					memcpy(held_page.data, BufferGetPage(wr_target_buf), BLCKSZ);
+
+					/*
+					 * Free this record's allocations; a long-lived/pooled helper
+					 * applies many records and would otherwise grow without bound.
+					 */
+					wr_reader->record = NULL;
+					pfree(decoded);
+					pfree(recbuf);
 					break;
 				}
 

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -59,12 +59,15 @@
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"
 #include "access/xlogrecord.h"
+#include "catalog/pg_class.h"
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #include "port/pg_crc32c.h"
 #include "postmaster/walredo.h"
+#include "storage/bufmgr.h"
 #include "storage/bufpage.h"
 #include "storage/ipc.h"
+#include "storage/smgr.h"
 #include "tcop/tcopprot.h"
 #include "utils/resowner.h"
 
@@ -183,6 +186,93 @@ read_u64(uint64 *v)
 	return read_fully(v, sizeof(*v));
 }
 
+/* ---- 4b: buffer redirect so rm_redo mutates the held page ----------------- */
+
+bool		am_walredo = false;
+
+/* the BEGIN target page identity */
+static RelFileLocator wr_target_rloc;
+static ForkNumber wr_target_fork;
+static BlockNumber wr_target_blk;
+static bool wr_have_target = false;
+
+/*
+ * Real (backend-local) buffers backing the redirect: wr_target_buf holds the
+ * page being materialized; wr_scratch_buf absorbs any other block a record
+ * references (we only ever read wr_target_buf back, so scratch redo is
+ * discarded).  Both are blocks of a private temp relation, so nothing is written
+ * to the cluster.
+ */
+static Buffer wr_target_buf = InvalidBuffer;
+static Buffer wr_scratch_buf = InvalidBuffer;
+
+/* release the long-lived buffer pins at process exit, before the buffer manager's
+ * own leak check (registered with before_shmem_exit so it runs first) */
+static void
+wr_release_buffers(int code, Datum arg)
+{
+	(void) code;
+	(void) arg;
+	if (wr_target_buf != InvalidBuffer)
+	{
+		ReleaseBuffer(wr_target_buf);
+		wr_target_buf = InvalidBuffer;
+	}
+	if (wr_scratch_buf != InvalidBuffer)
+	{
+		ReleaseBuffer(wr_scratch_buf);
+		wr_scratch_buf = InvalidBuffer;
+	}
+}
+
+static void
+wr_ensure_buffers(void)
+{
+	RelFileLocator tmp;
+	SMgrRelation reln;
+
+	if (wr_target_buf != InvalidBuffer)
+		return;
+
+	tmp.spcOid = 1663;			/* pg_default */
+	tmp.dbOid = 1;				/* template1 (its base dir always exists) */
+	tmp.relNumber = 0x7e000001; /* arbitrary, private to this backend */
+	reln = smgropen(tmp, MyProcNumber);
+	smgrcreate(reln, MAIN_FORKNUM, false);
+	wr_target_buf = ExtendBufferedRel(BMR_SMGR(reln, RELPERSISTENCE_TEMP),
+									  MAIN_FORKNUM, NULL, EB_SKIP_EXTENSION_LOCK);
+	wr_scratch_buf = ExtendBufferedRel(BMR_SMGR(reln, RELPERSISTENCE_TEMP),
+									   MAIN_FORKNUM, NULL, EB_SKIP_EXTENSION_LOCK);
+	before_shmem_exit(wr_release_buffers, (Datum) 0);
+}
+
+Buffer
+WalRedoReadBuffer(RelFileLocator rlocator, ForkNumber forknum,
+				  BlockNumber blkno, ReadBufferMode mode)
+{
+	Buffer		b;
+
+	if (wr_have_target &&
+		RelFileLocatorEquals(rlocator, wr_target_rloc) &&
+		forknum == wr_target_fork && blkno == wr_target_blk)
+		b = wr_target_buf;
+	else
+	{
+		b = wr_scratch_buf;
+		if (mode == RBM_ZERO_AND_LOCK || mode == RBM_ZERO_AND_CLEANUP_LOCK ||
+			mode == RBM_ZERO_ON_ERROR)
+			memset(BufferGetPage(b), 0, BLCKSZ);
+	}
+
+	/*
+	 * The redo caller will UnlockReleaseBuffer() this, dropping one pin; add that
+	 * reference so our long-lived buffer survives.  (LockBuffer is a no-op on
+	 * these local buffers.)
+	 */
+	IncrBufferRefCount(b);
+	return b;
+}
+
 void
 WalRedoMain(int argc, char *argv[])
 {
@@ -226,6 +316,13 @@ WalRedoMain(int argc, char *argv[])
 	 */
 	BaseInit();
 	SetProcessingMode(NormalProcessing);
+
+	/*
+	 * We skip InitPostgres (no database is opened), so adopt a regular backend
+	 * type explicitly: the buffer manager's pgstat I/O accounting asserts that
+	 * MyBackendType tracks the I/O ops our scratch buffers perform.
+	 */
+	MyBackendType = B_BACKEND;
 
 	/* index rmgrs (btree/GIN/GiST/SP-GiST) allocate recovery contexts here */
 	RmgrStartup();
@@ -288,8 +385,12 @@ WalRedoMain(int argc, char *argv[])
 					for (int i = 0; i < 5; i++)
 						if (!read_u32(&ident[i]))
 							proc_exit(1);
-					(void) ident;	/* 4b stores the target identity from here */
-					/* 4a only resets the held page */
+					wr_target_rloc.spcOid = ident[0];
+					wr_target_rloc.dbOid = ident[1];
+					wr_target_rloc.relNumber = ident[2];
+					wr_target_fork = (ForkNumber) ident[3];
+					wr_target_blk = (BlockNumber) ident[4];
+					wr_have_target = true;
 					memset(held_page.data, 0, BLCKSZ);
 					break;
 				}
@@ -339,7 +440,6 @@ WalRedoMain(int argc, char *argv[])
 					char	   *recbuf;
 					DecodedXLogRecord *decoded;
 					char	   *errm = NULL;
-					const char *msg;
 
 					if (!read_u64(&start_lsn) || !read_u64(&end_lsn) ||
 						!read_u32(&len))
@@ -408,18 +508,23 @@ WalRedoMain(int argc, char *argv[])
 					wr_reader->record = decoded;
 
 					/*
-					 * 4b step 1 is decode only: the record is validated and
-					 * decodable, but rm_redo is not wired yet (it needs a
-					 * standalone-backend bring-up; see WAL_REDO.md).  Fail
-					 * explicitly rather than continuing -- the protocol has no
-					 * success ack, so a later GET would otherwise hand back the
-					 * unmodified base page, indistinguishable from a real apply.
-					 * The message is emitted once, immediately before exit, so it
-					 * cannot accumulate on a long-lived stderr pipe.
+					 * Run the record's resource-manager redo against the held page.
+					 * Stage the held page into the target buffer (its pd_lsn drives
+					 * the BLK_DONE/BLK_NEEDS_REDO gating), zero the scratch buffer,
+					 * then dispatch rm_redo with the buffer manager redirected
+					 * (am_walredo) so XLogReadBufferExtended resolves to those
+					 * buffers.  Read the materialized page back for GET.
 					 */
-					msg = "wal-redo: APPLY decoded the record but rm_redo is not implemented yet (4b step 2)\n";
-					write(STDERR_FILENO, msg, strlen(msg));
-					proc_exit(2);
+					wr_ensure_buffers();
+					memcpy(BufferGetPage(wr_target_buf), held_page.data, BLCKSZ);
+					memset(BufferGetPage(wr_scratch_buf), 0, BLCKSZ);
+
+					am_walredo = true;
+					RmgrTable[XLogRecGetRmid(wr_reader)].rm_redo(wr_reader);
+					am_walredo = false;
+
+					memcpy(held_page.data, BufferGetPage(wr_target_buf), BLCKSZ);
+					break;
 				}
 
 			case WALREDO_GET:

--- a/src/include/postmaster/walredo.h
+++ b/src/include/postmaster/walredo.h
@@ -13,6 +13,26 @@
 #ifndef WALREDO_H
 #define WALREDO_H
 
+#include "storage/block.h"
+#include "storage/bufmgr.h"
+#include "storage/relfilelocator.h"
+#include "common/relpath.h"
+
 pg_noreturn extern void WalRedoMain(int argc, char *argv[]);
+
+/*
+ * Set while a record's rm_redo runs in the wal-redo helper, so that
+ * XLogReadBufferExtended() is redirected to the helper's held/scratch buffers
+ * instead of the (absent) on-disk relation.  Defined in walredo.c; always false
+ * in a normal backend.
+ */
+extern PGDLLIMPORT bool am_walredo;
+
+/*
+ * Redirect target for XLogReadBufferExtended() while am_walredo is set: returns
+ * the held page's buffer for the BEGIN target block, a scratch buffer otherwise.
+ */
+extern Buffer WalRedoReadBuffer(RelFileLocator rlocator, ForkNumber forknum,
+								BlockNumber blkno, ReadBufferMode mode);
 
 #endif							/* WALREDO_H */

--- a/src/include/postmaster/walredo.h
+++ b/src/include/postmaster/walredo.h
@@ -35,4 +35,10 @@ extern PGDLLIMPORT bool am_walredo;
 extern Buffer WalRedoReadBuffer(RelFileLocator rlocator, ForkNumber forknum,
 								BlockNumber blkno, ReadBufferMode mode);
 
+/*
+ * A pinned scratch buffer for redo paths that read a fork the helper does not
+ * model (e.g. visibilitymap_pin, whose caller will ReleaseBuffer it).
+ */
+extern Buffer WalRedoScratchBuffer(void);
+
 #endif							/* WALREDO_H */


### PR DESCRIPTION
The read-path core: `APPLY` now **materializes** the page by running the record's `rm_redo` against the held page, completing the in-process single-page redo engine. Builds on the standalone-backend bring-up from #43.

## How
- **`am_walredo` + `WalRedoReadBuffer`**: while a record's redo runs, `XLogReadBufferExtended` (hooked at its top) resolves the BEGIN **target** block to a held local buffer and any **other** block to a throwaway scratch buffer (only the target is read back, so scratch redo is discarded). Both are blocks of a private temp relation — nothing touches the cluster.
- **`APPLY`**: stages the held page into the target buffer (its `pd_lsn` drives `BLK_DONE`/`BLK_NEEDS_REDO` gating), dispatches `RmgrTable[rmid].rm_redo`, copies the materialized page back for `GET`.
- **`MyBackendType = B_BACKEND`** (InitPostgres is skipped) so the buffer manager's pgstat I/O accounting accepts the scratch ops; long-lived pins released via `before_shmem_exit` so the leak check passes.
- **`visibilitymap_pin`/`clear` are no-ops under `am_walredo`** (the helper has no VM fork; heap redo calls them directly, bypassing the redirect). FSM updates go through `XLogReadBufferExtended`, so the redirect already absorbs them into scratch — no separate stub.

## Verified
End-to-end on a real cluster: replaying a no-FPI heap INSERT delta onto its base page reproduces the server's page **byte-for-byte** except `pd_lsn` (stamped by redo) and `pd_checksum` (left for the caller). Added a **CI redo e2e test** (`walredo_redo_test.py`) that generates the delta, replays it through the helper, and compares — so this is covered in CI, not just locally.

## Scope / follow-ups
Validated with heap INSERT; the mechanism is rmgr-generic. Broader record-type coverage (updates/btree, which need multi-record fixtures around HOT pruning) and VM/FSM-fork *materialization* (3c-4b) remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)