### PR TITLE
Reconcile wal-redo helper onto the pagestore base + CI for the PG module (phase 0)

### DIFF
--- a/.github/scripts/walredo_redo_test.py
+++ b/.github/scripts/walredo_redo_test.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""End-to-end redo tests for the `postgres --wal-redo` helper.
+
+Each case generates a real WAL delta record on a throwaway cluster, replays it
+onto a captured base page through the helper, and checks the result matches the
+page the running server produced -- except pd_lsn (offset 0..7, stamped by redo)
+and pd_checksum (offset 8..9, which the helper leaves for the caller).
+
+Cases:
+  insert  - a no-FPI heap INSERT delta (third insert after a checkpoint+FPI).
+  update  - a heap UPDATE that clears the all-visible VM bit, exercising the
+            visibilitymap_pin/clear redo path; run with full_page_writes=off so
+            the record is a small delta rather than a full-page image.
+
+Usage: walredo_redo_test.py <bindir> <datadir> <port>
+"""
+import os
+import re
+import struct
+import subprocess
+import sys
+import time
+
+BINDIR, PGDATA, PORT = sys.argv[1], sys.argv[2], sys.argv[3]
+os.environ["LC_ALL"] = "C"
+SEGSIZE = 16 * 1024 * 1024
+
+
+def pg_ctl(*a):
+    subprocess.run([f"{BINDIR}/pg_ctl", "-D", PGDATA] + list(a), capture_output=True)
+
+
+def Q(sql):
+    return subprocess.run([f"{BINDIR}/psql", "-h", "/tmp", "-p", PORT, "-U", "postgres",
+                           "-d", "postgres", "-tA", "-c", sql],
+                          capture_output=True, text=True).stdout.strip()
+
+
+def lsn2int(s):
+    hi, lo = s.split("/")
+    return (int(hi, 16) << 32) | int(lo, 16)
+
+
+def fmt(x):
+    return "%X/%08X" % (x >> 32, x & 0xFFFFFFFF)
+
+
+def start(extra_opts=""):
+    try:
+        os.remove(f"{PGDATA}/postmaster.pid")
+    except OSError:
+        pass
+    pg_ctl("-o", f"-p {PORT} -k /tmp {extra_opts}", "-l", f"{PGDATA}/redo_test.log", "start")
+    time.sleep(2)
+
+
+def extract_record(start_lsn, end_lsn, desc_match):
+    """Return (rec_start, rec_end, bytes) for the first matching no-FPI record."""
+    dump = subprocess.run([f"{BINDIR}/pg_waldump", "-p", f"{PGDATA}/pg_wal",
+                           "-s", fmt(start_lsn), "-e", fmt(end_lsn)],
+                          capture_output=True, text=True).stdout
+    all_lsns = sorted({lsn2int(m.group(1))
+                       for m in re.finditer(r"lsn: ([0-9A-F]+/[0-9A-F]+)", dump)})
+    rec_start = None
+    for ln in dump.splitlines():
+        if desc_match(ln) and "FPW" not in ln and "lsn:" in ln:
+            rec_start = lsn2int(re.search(r"lsn: ([0-9A-F]+/[0-9A-F]+)", ln).group(1))
+            break
+    assert rec_start is not None, "no matching no-FPI record found"
+    rec_end = min([x for x in all_lsns if x > rec_start] + [end_lsn])
+    off = rec_start % SEGSIZE
+    assert (off % 8192) + (rec_end - rec_start) <= 8192, "record spans a WAL page; rerun"
+    seg = "%08X%08X%08X" % (1, rec_start >> 32, (rec_start % (1 << 32)) // SEGSIZE)
+    data = open(f"{PGDATA}/pg_wal/{seg}", "rb").read()[off:off + (rec_end - rec_start)]
+    return rec_start, rec_end, data
+
+
+def replay(db, rel, base_hex, base_lsn, rec_start, rec_end, data):
+    msg = b'b' + struct.pack('<5I', 1663, db, rel, 0, 0)
+    msg += b'p' + struct.pack('<QI', base_lsn, 8192) + bytes.fromhex(base_hex)
+    msg += b'a' + struct.pack('<QQI', rec_start, rec_end, len(data)) + data
+    msg += b'g'
+    return subprocess.run([f"{BINDIR}/postgres", "--wal-redo", "-D", PGDATA],
+                          input=msg, capture_output=True, timeout=120)
+
+
+def check(name, p, exp_hex):
+    exp, got = bytes.fromhex(exp_hex), p.stdout
+    ok = (p.returncode == 0 and len(got) == 8192 and got[10:] == exp[10:])
+    print("PASS" if ok else "FAIL", "-", name)
+    if not ok:
+        print("  rc=%d len=%d" % (p.returncode, len(got)))
+        print("  stderr:", p.stderr.decode("latin1")[-600:])
+        if len(got) == 8192:
+            print("  body diffs:", [i for i in range(10, 8192) if got[i] != exp[i]][:12])
+    return ok
+
+
+fails = 0
+
+# --- case: no-FPI heap INSERT delta ---------------------------------------
+start()
+Q("create extension if not exists pageinspect;")
+Q("drop table if exists wrt; create table wrt(id int primary key, v text) "
+  "with (autovacuum_enabled=off);")
+Q("insert into wrt values (1,'aaaa');")
+Q("checkpoint;")
+Q("insert into wrt values (2,'bbbb');")                 # record A: FPI carrier
+base_hex = Q("select encode(get_raw_page('wrt',0),'hex');")
+base_lsn = lsn2int(Q("select lsn from page_header(get_raw_page('wrt',0));"))
+s = lsn2int(Q("select pg_current_wal_lsn();"))
+Q("insert into wrt values (3,'cccc');")                 # record B: the delta
+e = lsn2int(Q("select pg_current_wal_lsn();"))
+Q("checkpoint;")
+exp_hex = Q("select encode(get_raw_page('wrt',0),'hex');")
+db = int(Q("select oid from pg_database where datname='postgres';"))
+rel = int(Q("select relfilenode from pg_class where relname='wrt';"))
+pg_ctl("stop", "-m", "fast")
+rs, re_, data = extract_record(s, e, lambda ln: "Heap" in ln and "INSERT" in ln)
+fails += not check("heap INSERT delta", replay(db, rel, base_hex, base_lsn, rs, re_, data), exp_hex)
+
+# --- case: VM-clearing heap UPDATE delta (full_page_writes off) -----------
+start("-c full_page_writes=off")
+Q("drop table if exists vmt; create table vmt(id int primary key, v text) "
+  "with (autovacuum_enabled=off);")
+Q("insert into vmt values (1,'aaaa');")
+Q("vacuum (freeze) vmt;")                               # set the all-visible VM bit
+Q("checkpoint;")
+base_hex = Q("select encode(get_raw_page('vmt',0),'hex');")
+base_lsn = lsn2int(Q("select lsn from page_header(get_raw_page('vmt',0));"))
+s = lsn2int(Q("select pg_current_wal_lsn();"))
+Q("update vmt set v='bbbb' where id=1;")                # clears the VM bit
+e = lsn2int(Q("select pg_current_wal_lsn();"))
+Q("checkpoint;")
+exp_hex = Q("select encode(get_raw_page('vmt',0),'hex');")
+db = int(Q("select oid from pg_database where datname='postgres';"))
+rel = int(Q("select relfilenode from pg_class where relname='vmt';"))
+pg_ctl("stop", "-m", "fast")
+rs, re_, data = extract_record(s, e, lambda ln: "Heap" in ln and "UPDATE" in ln)
+fails += not check("VM-clearing heap UPDATE delta", replay(db, rel, base_hex, base_lsn, rs, re_, data), exp_hex)
+
+sys.exit(1 if fails else 0)

--- a/.github/scripts/walredo_smoke.py
+++ b/.github/scripts/walredo_smoke.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Smoke test for the `postgres --wal-redo` helper.
+
+Drives the binary protocol over stdin/stdout:
+  - BEGIN + PUSHBASE(page) + GET round-trips the page with pd_lsn stamped (4a);
+  - APPLY rejects malformed records (too short / length mismatch / bad CRC),
+    exercising the validation that guards the decode path.
+
+The helper brings up a standalone backend, so it needs a (throwaway) data
+directory; pass an initdb'd scratch cluster.
+
+Usage: walredo_smoke.py <path-to-postgres-binary> <datadir>
+Exit status is nonzero if any check fails.
+"""
+import struct
+import subprocess
+import sys
+
+PG = sys.argv[1]
+PGDATA = sys.argv[2]
+BLCKSZ = 8192
+SizeOfXLogRecord = 24            # 64-bit layout
+RM_XLOG_ID = 0                   # a valid resource-manager id
+
+fails = 0
+
+
+def check(name, ok):
+    global fails
+    print(("PASS" if ok else "FAIL"), "-", name)
+    if not ok:
+        fails += 1
+
+
+def run(payload):
+    return subprocess.run([PG, "--wal-redo", "-D", PGDATA], input=payload,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          timeout=120)
+
+
+def begin():
+    return b'b' + struct.pack('<5I', 1663, 5, 16384, 0, 0)
+
+
+# 1) BEGIN + PUSHBASE(page) + GET: the page comes back with pd_lsn stamped.
+page = bytearray(BLCKSZ)
+struct.pack_into('<H', page, 14, 8000)        # pd_upper != 0 -> not a new page
+marker = b'HELLO-WALREDO'
+page[100:100 + len(marker)] = marker
+base_lsn = 0x12345678ABCD
+out = run(begin() + b'p' + struct.pack('<QI', base_lsn, BLCKSZ) + bytes(page) + b'g').stdout
+check("GET returns BLCKSZ bytes", len(out) == BLCKSZ)
+check("GET preserves page body", out[100:100 + len(marker)] == marker)
+xlogid, xrecoff = struct.unpack('<II', out[0:8]) if len(out) >= 8 else (0, 0)
+check("GET stamps pd_lsn = base_end_lsn", ((xlogid << 32) | xrecoff) == base_lsn)
+
+# 2) APPLY with a record shorter than the header is rejected.
+check("APPLY too-short record rejected (exit 1)",
+      run(begin() + b'a' + struct.pack('<QQI', 0, 0, 8) + b'\0' * 8).returncode == 1)
+
+# 3) APPLY whose header xl_tot_len disagrees with the framed length is rejected.
+rec = bytearray(SizeOfXLogRecord + 8)
+struct.pack_into('<I', rec, 0, 999)           # xl_tot_len != len
+check("APPLY xl_tot_len mismatch rejected (exit 1)",
+      run(begin() + b'a' + struct.pack('<QQI', 0, 0, len(rec)) + bytes(rec)).returncode == 1)
+
+# 4) APPLY with matching length and valid rmid but a bad CRC is rejected.
+rec = bytearray(SizeOfXLogRecord + 8)
+struct.pack_into('<I', rec, 0, len(rec))      # xl_tot_len == len
+rec[17] = RM_XLOG_ID                          # xl_rmid valid; xl_crc (off 20) left 0 -> mismatch
+check("APPLY bad CRC rejected (exit 1)",
+      run(begin() + b'a' + struct.pack('<QQI', 0, 0, len(rec)) + bytes(rec)).returncode == 1)
+
+print("---", "all passed" if not fails else f"{fails} FAILED")
+sys.exit(1 if fails else 0)

--- a/.github/workflows/walredo-test.yml
+++ b/.github/workflows/walredo-test.yml
@@ -1,0 +1,87 @@
+# CI for the PostgreSQL-side pagestore integration: the wal-redo helper AND the
+# smgr-shim PG module (contrib/pagestore/pagestore.so).
+#
+# Unlike the freestanding pagestore daemon CI (the "pagestore" workflow), this
+# DOES build PostgreSQL. It exists to catch two things the daemon job can't:
+#   - the wal-redo helper (src/backend/postmaster/walredo.c), backend code linked
+#     into the postgres binary; and
+#   - the PG module (pagestore.c), the f_smgr/smgr_register smgr shim, which only
+#     compiles against the core export and was previously never built in CI.
+# It does a full build+install (so pagestore.so is built), asserts the module is
+# present, then runs the wal-redo protocol + redo end-to-end tests.
+name: walredo
+
+on:
+  push:
+    paths:
+      - 'src/backend/postmaster/walredo.c'
+      - 'src/include/postmaster/walredo.h'
+      - 'src/backend/main/main.c'
+      - 'src/include/postmaster/postmaster.h'
+      - 'src/backend/tcop/postgres.c'
+      - 'src/include/tcop/tcopprot.h'
+      - 'src/backend/access/transam/xlogutils.c'
+      - 'src/backend/access/heap/visibilitymap.c'
+      - 'src/include/storage/smgr.h'
+      - 'contrib/pagestore/pagestore.c'
+      - 'contrib/pagestore/backend_localsvc.c'
+      - 'contrib/pagestore/pagestore_backend.h'
+      - 'contrib/pagestore/pagestore_ipc.h'
+      - 'contrib/pagestore/meson.build'
+      - '.github/scripts/walredo_smoke.py'
+      - '.github/scripts/walredo_redo_test.py'
+      - '.github/workflows/walredo-test.yml'
+  pull_request:
+    paths:
+      - 'src/backend/postmaster/walredo.c'
+      - 'src/include/postmaster/walredo.h'
+      - 'src/backend/main/main.c'
+      - 'src/include/postmaster/postmaster.h'
+      - 'src/backend/tcop/postgres.c'
+      - 'src/include/tcop/tcopprot.h'
+      - 'src/backend/access/transam/xlogutils.c'
+      - 'src/backend/access/heap/visibilitymap.c'
+      - 'src/include/storage/smgr.h'
+      - 'contrib/pagestore/pagestore.c'
+      - 'contrib/pagestore/backend_localsvc.c'
+      - 'contrib/pagestore/pagestore_backend.h'
+      - 'contrib/pagestore/pagestore_ipc.h'
+      - 'contrib/pagestore/meson.build'
+      - '.github/scripts/walredo_smoke.py'
+      - '.github/scripts/walredo_redo_test.py'
+      - '.github/workflows/walredo-test.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-smoke:
+    name: build postgres + PG module + wal-redo tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            meson ninja-build bison flex pkg-config \
+            libreadline-dev zlib1g-dev libicu-dev
+
+      - name: Configure, build and install (incl. the pagestore PG module)
+        run: |
+          meson setup build -Dcassert=true -Dprefix="$PWD/inst"
+          ninja -C build install
+
+      - name: Assert the pagestore smgr-shim module built
+        run: |
+          find inst -name pagestore.so | grep -q . \
+            && echo "pagestore.so present" \
+            || { echo "ERROR: pagestore.so was not built/installed"; exit 1; }
+
+      - name: initdb a throwaway scratch cluster
+        run: inst/bin/initdb -D scratch --no-locale -U postgres
+
+      - name: wal-redo protocol smoke test
+        run: python3 .github/scripts/walredo_smoke.py inst/bin/postgres scratch
+
+      - name: wal-redo redo end-to-end test
+        run: python3 .github/scripts/walredo_redo_test.py inst/bin scratch 5499

--- a/src/backend/access/heap/visibilitymap.c
+++ b/src/backend/access/heap/visibilitymap.c
@@ -92,6 +92,7 @@
 #include "access/xlogutils.h"
 #include "miscadmin.h"
 #include "port/pg_bitutils.h"
+#include "postmaster/walredo.h"
 #include "storage/bufmgr.h"
 #include "storage/smgr.h"
 #include "utils/inval.h"
@@ -146,6 +147,10 @@ visibilitymap_clear(Relation rel, BlockNumber heapBlk, Buffer vmbuf, uint8 flags
 	char	   *map;
 	bool		cleared = false;
 
+	/* no VM fork in the wal-redo helper; nothing to clear */
+	if (am_walredo)
+		return false;
+
 	/* Must never clear all_visible bit while leaving all_frozen bit set */
 	Assert(flags & VISIBILITYMAP_VALID_BITS);
 	Assert(flags != VISIBILITYMAP_ALL_VISIBLE);
@@ -193,6 +198,19 @@ void
 visibilitymap_pin(Relation rel, BlockNumber heapBlk, Buffer *vmbuf)
 {
 	BlockNumber mapBlock = HEAPBLK_TO_MAPBLOCK(heapBlk);
+
+	/*
+	 * The wal-redo helper materializes a single heap page and has no VM fork.
+	 * visibilitymap_clear() is a no-op there, but redo callers still
+	 * ReleaseBuffer() the pin unconditionally, so hand back a valid pinned
+	 * scratch buffer (reusing the one already pinned, if any).
+	 */
+	if (am_walredo)
+	{
+		if (!BufferIsValid(*vmbuf))
+			*vmbuf = WalRedoScratchBuffer();
+		return;
+	}
 
 	/* Reuse the old pinned buffer if possible */
 	if (BufferIsValid(*vmbuf))

--- a/src/backend/access/transam/xlogutils.c
+++ b/src/backend/access/transam/xlogutils.c
@@ -24,6 +24,7 @@
 #include "access/xlog_internal.h"
 #include "access/xlogutils.h"
 #include "miscadmin.h"
+#include "postmaster/walredo.h"
 #include "storage/fd.h"
 #include "storage/smgr.h"
 #include "utils/hsearch.h"
@@ -400,7 +401,7 @@ XLogReadBufferForRedoExtended(XLogReaderState *record,
 		 * force the on-disk state of init forks to always be in sync with the
 		 * state in shared buffers.
 		 */
-		if (forknum == INIT_FORKNUM)
+		if (forknum == INIT_FORKNUM && !am_walredo)
 			FlushOneBuffer(*buf);
 
 		return BLK_RESTORED;
@@ -464,6 +465,14 @@ XLogReadBufferExtended(RelFileLocator rlocator, ForkNumber forknum,
 	BlockNumber lastblock;
 	Buffer		buffer;
 	SMgrRelation smgr;
+
+	/*
+	 * In the wal-redo helper there is no on-disk relation to read: redo runs
+	 * against a single held page (plus a scratch page for other blocks), so
+	 * resolve the buffer from those instead of smgr.
+	 */
+	if (am_walredo)
+		return WalRedoReadBuffer(rlocator, forknum, blkno, mode);
 
 	Assert(blkno != P_NEW);
 

--- a/src/backend/main/main.c
+++ b/src/backend/main/main.c
@@ -34,6 +34,7 @@
 #include "common/username.h"
 #include "miscadmin.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/walredo.h"
 #include "tcop/tcopprot.h"
 #include "utils/help_config.h"
 #include "utils/memutils.h"
@@ -52,6 +53,7 @@ static const char *const DispatchOptionNames[] =
 	[DISPATCH_FORKCHILD] = "forkchild",
 	[DISPATCH_DESCRIBE_CONFIG] = "describe-config",
 	[DISPATCH_SINGLE] = "single",
+	[DISPATCH_WALREDO] = "wal-redo",
 	/* DISPATCH_POSTMASTER has no name */
 };
 
@@ -222,6 +224,9 @@ main(int argc, char *argv[])
 		case DISPATCH_SINGLE:
 			PostgresSingleUserMain(argc, argv,
 								   strdup(get_user_name_or_exit(progname)));
+			break;
+		case DISPATCH_WALREDO:
+			WalRedoMain(argc, argv);
 			break;
 		case DISPATCH_POSTMASTER:
 			PostmasterMain(argc, argv);

--- a/src/backend/postmaster/Makefile
+++ b/src/backend/postmaster/Makefile
@@ -26,6 +26,7 @@ OBJS = \
 	postmaster.o \
 	startup.o \
 	syslogger.o \
+	walredo.o \
 	walsummarizer.o \
 	walwriter.o
 

--- a/src/backend/postmaster/meson.build
+++ b/src/backend/postmaster/meson.build
@@ -14,6 +14,7 @@ backend_sources += files(
   'postmaster.c',
   'startup.c',
   'syslogger.c',
+  'walredo.c',
   'walsummarizer.c',
   'walwriter.c',
 )

--- a/src/backend/postmaster/walredo.c
+++ b/src/backend/postmaster/walredo.c
@@ -1,0 +1,592 @@
+/*-------------------------------------------------------------------------
+ *
+ * walredo.c
+ *	  single-page WAL-redo helper process (postgres --wal-redo)
+ *
+ * Holds exactly one target page and applies WAL records to it on request, so a
+ * page store can materialize a page "as of" an LSN from a base image plus the
+ * delta records after it, without replaying all of WAL.  See
+ * contrib/pagestore/WAL_REDO.md (the 3c-4 design).
+ *
+ * Protocol (length-prefixed binary, on stdin; replies on stdout), one byte tag
+ * then a fixed payload:
+ *
+ *   'b' BEGIN     spcOid,dbOid,relNumber,forkNum,blockNum (5x uint32)
+ *                 -- set the target page identity, zero the held page
+ *   'p' PUSHBASE  base_end_lsn (uint64), len (uint32), then len page bytes
+ *                 -- seed the held page (len == BLCKSZ) or zero it (len == 0)
+ *                    and set its page LSN baseline to base_end_lsn
+ *   'a' APPLY     start_lsn (uint64), end_lsn (uint64), len (uint32), record
+ *                 -- rm_redo the record onto the held page (see below)
+ *   'g' GET       (no payload) -- reply with BLCKSZ bytes: the held page
+ *
+ * EOF on stdin is a clean shutdown.
+ *
+ * Startup brings up a standalone backend (shared memory + a PGPROC + the buffer
+ * manager) by reusing the single-user init path (InitStandaloneBackend), so it
+ * needs a data directory: `postgres --wal-redo -D <datadir>`.  This must be a
+ * private, throwaway cluster, not the live one -- the helper only ever mutates
+ * pages handed to it over the protocol, so any cluster of the same BLCKSZ works,
+ * and using the live datadir would collide with the postmaster's lock file.  The
+ * full backend context is required because running a record's rm_redo goes
+ * through the normal buffer manager.
+ *
+ * APPLY currently decodes and validates the record (header length, rmid, CRC) but
+ * does not yet mutate the held page: running the record's resource-manager redo
+ * against it with the buffer manager redirected to the held/scratch buffers (and
+ * VM/FSM side effects stubbed per target fork) is the next increment.  Protocol
+ * I/O is raw read()/write() over static buffers.
+ *
+ * Portions Copyright (c) 1996-2026, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/backend/postmaster/walredo.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <unistd.h>
+#ifdef WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
+#include "access/rmgr.h"
+#include "access/xlog.h"
+#include "access/xlog_internal.h"
+#include "access/xlogreader.h"
+#include "access/xlogrecord.h"
+#include "catalog/pg_class.h"
+#include "libpq/pqsignal.h"
+#include "miscadmin.h"
+#include "port/pg_crc32c.h"
+#include "postmaster/walredo.h"
+#include "storage/buf_internals.h"
+#include "storage/bufmgr.h"
+#include "storage/bufpage.h"
+#include "storage/ipc.h"
+#include "storage/smgr.h"
+#include "tcop/tcopprot.h"
+#include "utils/resowner.h"
+
+/* XLogReader reused across APPLY messages (lazily allocated) */
+static XLogReaderState *wr_reader = NULL;
+
+/* protocol message tags */
+#define WALREDO_BEGIN		'b'
+#define WALREDO_PUSHBASE	'p'
+#define WALREDO_APPLY		'a'
+#define WALREDO_GET			'g'
+
+/*
+ * The single page this process holds.  Stored in PGAlignedBlock so it can be
+ * accessed as a Page (PageIsNew/PageSetLSN) without an unaligned access on
+ * strict-alignment platforms.  4b adds the target identity (RelFileLocator/
+ * fork/block); 4a only needs the page bytes.
+ */
+static PGAlignedBlock held_page;
+
+/*
+ * Set by the termination-signal handler.  The handler does nothing but set this
+ * flag (async-signal-safe); the protocol read loop notices it when the blocking
+ * read returns EINTR and shuts the helper down cleanly via proc_exit().
+ */
+static volatile sig_atomic_t walredo_shutdown_requested = 0;
+
+static void
+walredo_term_handler(int signo)
+{
+	(void) signo;
+	walredo_shutdown_requested = 1;
+}
+
+static bool
+read_fully(void *buf, size_t len)
+{
+	char	   *p = (char *) buf;
+
+	while (len > 0)
+	{
+		ssize_t		n;
+
+		/*
+		 * Honor a termination signal that arrived between reads: at that point no
+		 * EINTR is pending to interrupt the upcoming blocking read, so check the
+		 * flag here as well as in the EINTR branch below.
+		 */
+		if (walredo_shutdown_requested)
+			proc_exit(1);
+
+		n = read(STDIN_FILENO, p, len);
+
+		if (n < 0)
+		{
+			if (errno == EINTR)
+			{
+				/* a termination signal delivered while we block here interrupts
+				 * the read; honor it instead of silently retrying */
+				if (walredo_shutdown_requested)
+					proc_exit(1);
+				continue;
+			}
+			return false;
+		}
+		if (n == 0)
+			return false;		/* EOF */
+		p += n;
+		len -= (size_t) n;
+	}
+	return true;
+}
+
+static void
+write_fully(const void *buf, size_t len)
+{
+	const char *p = (const char *) buf;
+
+	while (len > 0)
+	{
+		ssize_t		n;
+
+		/* honor a termination signal that arrived between writes (e.g. while the
+		 * controller has stopped draining stdout), as read_fully() does */
+		if (walredo_shutdown_requested)
+			proc_exit(1);
+
+		n = write(STDOUT_FILENO, p, len);
+
+		if (n < 0)
+		{
+			if (errno == EINTR)
+			{
+				/* a termination signal interrupted the write; act on it rather
+				 * than retrying into a full pipe forever */
+				if (walredo_shutdown_requested)
+					proc_exit(1);
+				continue;
+			}
+			proc_exit(1);
+		}
+		p += n;
+		len -= (size_t) n;
+	}
+}
+
+static bool
+read_u32(uint32 *v)
+{
+	return read_fully(v, sizeof(*v));
+}
+
+static bool
+read_u64(uint64 *v)
+{
+	return read_fully(v, sizeof(*v));
+}
+
+/* ---- 4b: buffer redirect so rm_redo mutates the held page ----------------- */
+
+bool		am_walredo = false;
+
+/* the BEGIN target page identity */
+static RelFileLocator wr_target_rloc;
+static ForkNumber wr_target_fork;
+static BlockNumber wr_target_blk;
+static bool wr_have_target = false;
+
+/*
+ * Real (backend-local) buffers backing the redirect: wr_target_buf holds the
+ * page being materialized; wr_scratch_buf absorbs any other block a record
+ * references (we only ever read wr_target_buf back, so scratch redo is
+ * discarded).  Both are blocks of a private temp relation, so nothing is written
+ * to the cluster.
+ */
+static Buffer wr_target_buf = InvalidBuffer;
+static Buffer wr_scratch_buf = InvalidBuffer;
+static SMgrRelation wr_smgr = NULL;
+
+/* release the long-lived buffer pins at process exit, before the buffer manager's
+ * own leak check (registered with before_shmem_exit so it runs first) */
+static void
+wr_release_buffers(int code, Datum arg)
+{
+	(void) code;
+	(void) arg;
+	if (wr_target_buf != InvalidBuffer)
+	{
+		ReleaseBuffer(wr_target_buf);
+		wr_target_buf = InvalidBuffer;
+	}
+	if (wr_scratch_buf != InvalidBuffer)
+	{
+		ReleaseBuffer(wr_scratch_buf);
+		wr_scratch_buf = InvalidBuffer;
+	}
+	/* remove the backing temp file so a later helper reusing this datadir does
+	 * not trip over a leftover relation */
+	if (wr_smgr != NULL)
+	{
+		smgrdounlinkall(&wr_smgr, 1, false);
+		wr_smgr = NULL;
+	}
+}
+
+static void
+wr_ensure_buffers(void)
+{
+	RelFileLocator tmp;
+
+	if (wr_target_buf != InvalidBuffer)
+		return;
+
+	tmp.spcOid = 1663;			/* pg_default */
+	tmp.dbOid = 1;				/* template1 (its base dir always exists) */
+	tmp.relNumber = 0x7e000001; /* arbitrary, private to this backend */
+	wr_smgr = smgropen(tmp, MyProcNumber);
+	/* isRedo=true: tolerate a file left behind by a previously crashed helper */
+	smgrcreate(wr_smgr, MAIN_FORKNUM, true);
+	wr_target_buf = ExtendBufferedRel(BMR_SMGR(wr_smgr, RELPERSISTENCE_TEMP),
+									  MAIN_FORKNUM, NULL, EB_SKIP_EXTENSION_LOCK);
+	wr_scratch_buf = ExtendBufferedRel(BMR_SMGR(wr_smgr, RELPERSISTENCE_TEMP),
+									   MAIN_FORKNUM, NULL, EB_SKIP_EXTENSION_LOCK);
+	before_shmem_exit(wr_release_buffers, (Datum) 0);
+}
+
+/*
+ * A pinned scratch buffer for redo code that reads a fork the helper does not
+ * model (e.g. visibilitymap_pin needs a buffer its caller will ReleaseBuffer).
+ * The content is irrelevant and never read back.
+ */
+Buffer
+WalRedoScratchBuffer(void)
+{
+	wr_ensure_buffers();
+	IncrBufferRefCount(wr_scratch_buf);
+	return wr_scratch_buf;
+}
+
+Buffer
+WalRedoReadBuffer(RelFileLocator rlocator, ForkNumber forknum,
+				  BlockNumber blkno, ReadBufferMode mode)
+{
+	Buffer		b;
+
+	if (wr_have_target &&
+		RelFileLocatorEquals(rlocator, wr_target_rloc) &&
+		forknum == wr_target_fork && blkno == wr_target_blk)
+		b = wr_target_buf;
+	else
+	{
+		/*
+		 * Any block other than the BEGIN target only needs to keep the redo
+		 * routine happy; its result is never read back.  For a WILL_INIT block
+		 * (zero mode) hand back a zeroed page for the routine to initialize.
+		 * Otherwise give the scratch page an LSN newer than any record so
+		 * XLogReadBufferForRedo() classifies it as BLK_DONE and skips it -- a
+		 * zero-LSN page would be treated as BLK_NEEDS_REDO and the routine would
+		 * apply the record to bogus contents (e.g. a cross-page heap UPDATE
+		 * panicking on the old tuple's block).
+		 */
+		b = wr_scratch_buf;
+		if (mode == RBM_ZERO_AND_LOCK || mode == RBM_ZERO_AND_CLEANUP_LOCK ||
+			mode == RBM_ZERO_ON_ERROR)
+			memset(BufferGetPage(b), 0, BLCKSZ);
+		else
+			PageSetLSN(BufferGetPage(b), PG_UINT64_MAX);
+	}
+
+	/*
+	 * The redo caller will UnlockReleaseBuffer() this, dropping one pin; add that
+	 * reference so our long-lived buffer survives.  (LockBuffer is a no-op on
+	 * these local buffers.)
+	 */
+	IncrBufferRefCount(b);
+	return b;
+}
+
+void
+WalRedoMain(int argc, char *argv[])
+{
+#ifdef WIN32
+	/* the protocol is binary; keep the CRT from translating \n/\r\n/0x1a on the
+	 * inherited stdin/stdout, which would corrupt PUSHBASE/GET page bytes */
+	_setmode(_fileno(stdin), _O_BINARY);
+	_setmode(_fileno(stdout), _O_BINARY);
+#endif
+
+	/*
+	 * Drop the leading "--wal-redo" dispatch token so the shared standalone
+	 * bring-up sees a normal argv (process_postgres_switches only special-cases
+	 * "--single").  argv[0] is preserved as the program name.
+	 */
+	if (argc > 1)
+	{
+		argv[1] = argv[0];
+		argv++;
+		argc--;
+	}
+
+	/*
+	 * Bring up a standalone backend: switches (incl. -D), config, control file,
+	 * shared memory and a PGPROC -- everything the buffer manager needs.  This
+	 * runs against a private, throwaway data directory, never the live cluster's
+	 * (whose lock file is held by the postmaster): the helper only ever mutates
+	 * pages handed to it over the protocol, so a generic scratch cluster of the
+	 * same BLCKSZ is sufficient for redo.
+	 *
+	 * Pass a NULL dbname: this mode opens no database, and a non-NULL pointer
+	 * would let process_postgres_switches() consume a stray positional argument as
+	 * a database name (e.g. "--wal-redo scratch" silently falling back to PGDATA
+	 * instead of the intended -D directory).
+	 */
+	InitStandaloneBackend(argc, argv, NULL, NULL, false, true);
+
+	/*
+	 * BaseInit() sets up smgr and the buffer manager (InitBufferManagerAccess),
+	 * which need the shared memory + MyProc that InitStandaloneBackend created.
+	 */
+	BaseInit();
+	SetProcessingMode(NormalProcessing);
+
+	/*
+	 * We skip InitPostgres (no database is opened), so adopt a regular backend
+	 * type explicitly: the buffer manager's pgstat I/O accounting asserts that
+	 * MyBackendType tracks the I/O ops our scratch buffers perform.
+	 */
+	MyBackendType = B_BACKEND;
+
+	/* index rmgrs (btree/GIN/GiST/SP-GiST) allocate recovery contexts here */
+	RmgrStartup();
+
+	/* buffer pins are tracked against a resource owner */
+	CurrentResourceOwner = ResourceOwnerCreate(NULL, "wal-redo");
+
+	/*
+	 * InitStandaloneProcess() leaves the signal mask blocked (BlockSig).  Install
+	 * handlers and unblock so a long-lived/pooled helper can be stopped with
+	 * SIGINT/SIGTERM rather than getting stuck until stdin closes; die() sets a
+	 * pending interrupt that read_fully() acts on via CHECK_FOR_INTERRUPTS() when
+	 * the blocking read returns EINTR, giving a clean proc_exit().
+	 */
+	{
+		struct sigaction act;
+		int			diesigs[] = {SIGINT, SIGTERM, SIGQUIT};
+
+		/*
+		 * Install the termination handler deliberately *without* SA_RESTART (so
+		 * not via pqsignal): the helper blocks in read(), and we need that read to
+		 * return EINTR on a termination signal so the loop can shut down.  With
+		 * SA_RESTART the read would silently resume and the process would stay
+		 * stuck until stdin closed.  The handler only sets a flag, so it is
+		 * async-signal-safe; proc_exit() runs later from read_fully().
+		 */
+		memset(&act, 0, sizeof(act));
+		act.sa_handler = walredo_term_handler;
+		sigemptyset(&act.sa_mask);
+		act.sa_flags = 0;
+		for (int i = 0; i < (int) lengthof(diesigs); i++)
+			sigaction(diesigs[i], &act, NULL);
+	}
+	pqsignal(SIGHUP, SIG_IGN);
+	pqsignal(SIGPIPE, SIG_IGN);
+	sigprocmask(SIG_SETMASK, &UnBlockSig, NULL);
+
+	/* the control file supplies the cluster's real WAL segment size */
+	if (wal_segment_size == 0)
+		wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
+
+	for (;;)
+	{
+		unsigned char tag;
+
+		if (!read_fully(&tag, 1))
+		{
+			/* EOF: clean shutdown -- match RmgrStartup() so the index rmgrs'
+			 * recovery contexts are torn down */
+			RmgrCleanup();
+			proc_exit(0);
+		}
+
+		switch (tag)
+		{
+			case WALREDO_BEGIN:
+				{
+					uint32		ident[5];	/* spc,db,rel,fork,block */
+
+					for (int i = 0; i < 5; i++)
+						if (!read_u32(&ident[i]))
+							proc_exit(1);
+					wr_target_rloc.spcOid = ident[0];
+					wr_target_rloc.dbOid = ident[1];
+					wr_target_rloc.relNumber = ident[2];
+					wr_target_fork = (ForkNumber) ident[3];
+					wr_target_blk = (BlockNumber) ident[4];
+					wr_have_target = true;
+					memset(held_page.data, 0, BLCKSZ);
+					break;
+				}
+
+			case WALREDO_PUSHBASE:
+				{
+					uint64		base_end_lsn;
+					uint32		len;
+
+					if (!read_u64(&base_end_lsn) || !read_u32(&len))
+						proc_exit(1);
+					if (len == BLCKSZ)
+					{
+						if (!read_fully(held_page.data, BLCKSZ))
+							proc_exit(1);
+
+						/*
+						 * RestoreBlockImage (on the driver side) copies only the
+						 * image bytes; PostgreSQL stamps a restored page's LSN
+						 * separately.  Do the same here so a base-only GET, and the
+						 * BLK_DONE/BLK_NEEDS_REDO gating once 4b replays deltas, see
+						 * the correct pd_lsn.  Leave an uninitialized (new) page
+						 * alone, as redo does.
+						 *
+						 * This invalidates pd_checksum, but the helper deliberately
+						 * does not recompute it: without backend initialisation it
+						 * cannot know whether data checksums are enabled.  The caller
+						 * persists/serves the page in a normal backend (with cluster
+						 * context and the block number it issued in BEGIN), and
+						 * recomputes pd_checksum there before storing or serving.
+						 */
+						if (!PageIsNew((Page) held_page.data))
+							PageSetLSN((Page) held_page.data, (XLogRecPtr) base_end_lsn);
+					}
+					else if (len == 0)
+						memset(held_page.data, 0, BLCKSZ);
+					else
+						proc_exit(1);	/* malformed base length */
+					break;
+				}
+
+			case WALREDO_APPLY:
+				{
+					uint64		start_lsn,
+								end_lsn;
+					uint32		len;
+					char	   *recbuf;
+					DecodedXLogRecord *decoded;
+					char	   *errm = NULL;
+
+					if (!read_u64(&start_lsn) || !read_u64(&end_lsn) ||
+						!read_u32(&len))
+						proc_exit(1);
+					if (len < SizeOfXLogRecord)
+						proc_exit(1);
+					recbuf = palloc(len);
+					if (!read_fully(recbuf, len))
+						proc_exit(1);
+
+					/*
+					 * This path feeds the bytes straight to DecodeXLogRecord,
+					 * which (unlike XLogReadRecord) does not validate the record,
+					 * so replicate the checks XLogReadRecord would make before
+					 * trusting the record:
+					 *
+					 *  - the header length must equal the framed length, or the
+					 *    decoder could run off the end of recbuf;
+					 *  - the resource manager id must be valid;
+					 *  - the CRC must match, so a damaged chunk that still frames
+					 *    correctly is rejected rather than (once rm_redo is wired)
+					 *    applied as if it were good WAL.
+					 */
+					{
+						XLogRecord *rec = (XLogRecord *) recbuf;
+						pg_crc32c	crc;
+
+						if (rec->xl_tot_len != len)
+							proc_exit(1);
+						if (!RmgrIdIsValid(rec->xl_rmid))
+							proc_exit(1);
+
+						INIT_CRC32C(crc);
+						COMP_CRC32C(crc, recbuf + SizeOfXLogRecord,
+									len - SizeOfXLogRecord);
+						COMP_CRC32C(crc, rec, offsetof(XLogRecord, xl_crc));
+						FIN_CRC32C(crc);
+						if (!EQ_CRC32C(crc, rec->xl_crc))
+							proc_exit(1);
+					}
+
+					if (wr_reader == NULL)
+					{
+						wr_reader = XLogReaderAllocate(wal_segment_size, NULL,
+													   XL_ROUTINE(.page_read = NULL,
+																  .segment_open = NULL,
+																  .segment_close = NULL),
+													   NULL);
+						if (wr_reader == NULL)
+							proc_exit(1);
+					}
+
+					decoded = palloc(DecodeXLogRecordRequiredSpace(
+										 ((XLogRecord *) recbuf)->xl_tot_len));
+					if (!DecodeXLogRecord(wr_reader, decoded, (XLogRecord *) recbuf,
+										  (XLogRecPtr) end_lsn, &errm))
+						proc_exit(1);
+
+					/*
+					 * Populate the reader so the XLogRecGet* accessors and (once
+					 * wired) rm_redo see a consistent record, including the start
+					 * and end LSNs used for page-LSN decisions.
+					 */
+					wr_reader->ReadRecPtr = (XLogRecPtr) start_lsn;
+					wr_reader->EndRecPtr = (XLogRecPtr) end_lsn;
+					wr_reader->record = decoded;
+
+					/*
+					 * Run the record's resource-manager redo against the held page.
+					 * Stage the held page into the target buffer (its pd_lsn drives
+					 * the BLK_DONE/BLK_NEEDS_REDO gating), zero the scratch buffer,
+					 * then dispatch rm_redo with the buffer manager redirected
+					 * (am_walredo) so XLogReadBufferExtended resolves to those
+					 * buffers.  Read the materialized page back for GET.
+					 */
+					wr_ensure_buffers();
+
+					/*
+					 * Make the target buffer report the WAL block identity, so redo
+					 * that writes the buffer's block number into the page (e.g.
+					 * heap lock/confirm resetting t_ctid via BufferGetBlockNumber)
+					 * records the real block, not the temp relation's block 0.  We
+					 * never look these buffers up by tag, so retagging the local
+					 * descriptor in place is safe.
+					 */
+					InitBufferTag(&GetLocalBufferDescriptor(-wr_target_buf - 1)->tag,
+								  &wr_target_rloc, wr_target_fork, wr_target_blk);
+
+					memcpy(BufferGetPage(wr_target_buf), held_page.data, BLCKSZ);
+					memset(BufferGetPage(wr_scratch_buf), 0, BLCKSZ);
+
+					am_walredo = true;
+					RmgrTable[XLogRecGetRmid(wr_reader)].rm_redo(wr_reader);
+					am_walredo = false;
+
+					memcpy(held_page.data, BufferGetPage(wr_target_buf), BLCKSZ);
+
+					/*
+					 * Free this record's allocations; a long-lived/pooled helper
+					 * applies many records and would otherwise grow without bound.
+					 */
+					wr_reader->record = NULL;
+					pfree(decoded);
+					pfree(recbuf);
+					break;
+				}
+
+			case WALREDO_GET:
+				write_fully(held_page.data, BLCKSZ);
+				break;
+
+			default:
+				proc_exit(1);		/* protocol error */
+		}
+	}
+}

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4055,14 +4055,21 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
  * process queries. Single user mode specific setup should go here, rather
  * than PostgresMain() or InitPostgres() when reasonably possible.
  */
+/*
+ * Bring up a standalone (no-postmaster) backend's process and shared-memory
+ * environment, in the order these prerequisites require: parse switches, read
+ * config + control file, size and create shared memory, and attach a PGPROC.
+ * Shared by PostgresSingleUserMain() and the wal-redo helper (WalRedoMain()),
+ * so the load-bearing init sequence lives in one place.  On return shared memory
+ * exists and MyProc is set, so the caller may run BaseInit().  *dbname receives
+ * the parsed database name; with need_dbname it defaults to username (FATAL if
+ * also NULL).  Callers that must not silently fall back to PGDATA (the wal-redo
+ * helper) pass require_datadir = true to require an explicit -D.
+ */
 void
-PostgresSingleUserMain(int argc, char *argv[],
-					   const char *username)
+InitStandaloneBackend(int argc, char *argv[], const char *username,
+					  const char **dbname, bool need_dbname, bool require_datadir)
 {
-	const char *dbname = NULL;
-
-	Assert(!IsUnderPostmaster);
-
 	/* Initialize startup process environment. */
 	InitStandaloneProcess(argv[0]);
 
@@ -4074,18 +4081,28 @@ PostgresSingleUserMain(int argc, char *argv[],
 	/*
 	 * Parse command-line options.
 	 */
-	process_postgres_switches(argc, argv, PGC_POSTMASTER, &dbname);
+	process_postgres_switches(argc, argv, PGC_POSTMASTER, dbname);
 
 	/* Must have gotten a database name, or have a default (the username) */
-	if (dbname == NULL)
+	if (need_dbname && *dbname == NULL)
 	{
-		dbname = username;
-		if (dbname == NULL)
+		*dbname = username;
+		if (*dbname == NULL)
 			ereport(FATAL,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("%s: no database nor user name specified",
 							progname)));
 	}
+
+	/*
+	 * Callers that must not silently fall back to PGDATA (e.g. the wal-redo
+	 * helper, which runs against an explicit private scratch directory and never
+	 * the live cluster) require an explicit -D.
+	 */
+	if (require_datadir && userDoption == NULL)
+		ereport(FATAL,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("%s: -D / --pgdata must be specified", progname)));
 
 	/* Acquire configuration parameters */
 	if (!SelectConfigFiles(userDoption, progname))
@@ -4164,6 +4181,21 @@ PostgresSingleUserMain(int argc, char *argv[],
 	 * before we can use LWLocks.
 	 */
 	InitProcess();
+}
+
+void
+PostgresSingleUserMain(int argc, char *argv[],
+					   const char *username)
+{
+	const char *dbname = NULL;
+
+	Assert(!IsUnderPostmaster);
+
+	/*
+	 * Shared standalone-backend bring-up (switches, config, shmem, PGPROC).
+	 * Single-user keeps the historical PGDATA fallback (require_datadir = false).
+	 */
+	InitStandaloneBackend(argc, argv, username, &dbname, true, false);
 
 	/*
 	 * Now that sufficient infrastructure has been initialized, PostgresMain()

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -137,6 +137,7 @@ typedef enum DispatchOption
 	DISPATCH_FORKCHILD,
 	DISPATCH_DESCRIBE_CONFIG,
 	DISPATCH_SINGLE,
+	DISPATCH_WALREDO,
 	DISPATCH_POSTMASTER,		/* must be last */
 } DispatchOption;
 

--- a/src/include/postmaster/walredo.h
+++ b/src/include/postmaster/walredo.h
@@ -1,0 +1,44 @@
+/*-------------------------------------------------------------------------
+ *
+ * walredo.h
+ *	  single-page WAL-redo helper process (postgres --wal-redo)
+ *
+ * Portions Copyright (c) 1996-2026, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/postmaster/walredo.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef WALREDO_H
+#define WALREDO_H
+
+#include "storage/block.h"
+#include "storage/bufmgr.h"
+#include "storage/relfilelocator.h"
+#include "common/relpath.h"
+
+pg_noreturn extern void WalRedoMain(int argc, char *argv[]);
+
+/*
+ * Set while a record's rm_redo runs in the wal-redo helper, so that
+ * XLogReadBufferExtended() is redirected to the helper's held/scratch buffers
+ * instead of the (absent) on-disk relation.  Defined in walredo.c; always false
+ * in a normal backend.
+ */
+extern PGDLLIMPORT bool am_walredo;
+
+/*
+ * Redirect target for XLogReadBufferExtended() while am_walredo is set: returns
+ * the held page's buffer for the BEGIN target block, a scratch buffer otherwise.
+ */
+extern Buffer WalRedoReadBuffer(RelFileLocator rlocator, ForkNumber forknum,
+								BlockNumber blkno, ReadBufferMode mode);
+
+/*
+ * A pinned scratch buffer for redo paths that read a fork the helper does not
+ * model (e.g. visibilitymap_pin, whose caller will ReleaseBuffer it).
+ */
+extern Buffer WalRedoScratchBuffer(void);
+
+#endif							/* WALREDO_H */

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -78,6 +78,9 @@ extern void ProcessClientWriteInterrupt(bool blocked);
 
 extern void process_postgres_switches(int argc, char *argv[],
 									  GucContext ctx, const char **dbname);
+extern void InitStandaloneBackend(int argc, char *argv[], const char *username,
+								  const char **dbname, bool need_dbname,
+								  bool require_datadir);
 pg_noreturn extern void PostgresSingleUserMain(int argc, char *argv[],
 											   const char *username);
 pg_noreturn extern void PostgresMain(const char *dbname,


### PR DESCRIPTION
**Phase 0 of the architecture plan: get everything onto one base that builds end-to-end, and add CI that builds the PG module.**

## Problem
The work was split across three diverged branches that never met:
- this base (`feat/pagestore-cache`) — daemon/LSM/sharding + the `f_smgr`/`smgr_register` core export + the smgr-shim PG module (`pagestore.so`);
- the redo line (`…walredo-4b-rmredo`) — the wal-redo engine, stacked on an **older PG base without `f_smgr`**, so its `pagestore.c` wouldn't compile;
- `branchdb_18` — the PG-18 base with the export.

Net: the redo engine lived where the smgr shim won't build, and the export lived where the redo engine wasn't — nothing ran end-to-end, and CI never compiled the PG module.

## What this does
Brings the **backend wal-redo helper** onto this base — the self-contained files verbatim, the 6 hooks re-applied to *this tree's* PG-18 versions (not the older base's):
- `walredo.c`/`walredo.h` — the `postgres --wal-redo` standalone-backend helper.
- `main.c`/`postmaster.h` — `DISPATCH_WALREDO`.
- `postgres.c`/`tcopprot.h` — factor `InitStandaloneBackend` out of `PostgresSingleUserMain` (using **this tree's** init sequence, which differs from the redo line's) so the helper reuses it.
- `xlogutils.c` — `am_walredo` redirect + INIT_FORKNUM flush guard.
- `visibilitymap.c` — VM pin/clear no-ops under `am_walredo`.
- `postmaster/{meson.build,Makefile}` — build `walredo.c`.

**CI:** the `walredo` workflow now does a full build+install (so `pagestore.so` is built) and **asserts the module is present** — closing the gap where the PG module was never compiled in CI — then runs the wal-redo protocol + redo e2e tests.

## Verified locally
`postgres` + `pagestore.so` build on this base; single-user mode works (init-refactor regression check); the wal-redo redo test passes **both** cases (heap INSERT delta and VM-clearing UPDATE delta).

After this lands, the read path can be completed on one base (Phase 1: `tl_walk`/branch-aware layer lookup, `walidx_get` `(timeline,lsn)`+pagination, then the `redo_page_asof` driver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)