### PR TITLE
Per-shard + map locking for concurrent shards (phase 2)

### DIFF
--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1096,9 +1096,20 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 		hdr.lsn = page_lsn(page);
 	else
 	{
-		PageVer    *cur = read_through(timeline, key, block, UINT64_MAX);
+		PageVer    *cur;
 
+		/*
+		 * Deriving an object's monotonic version walks the cross-shard timeline
+		 * ancestry (read_through), which PS_OP_CREATE_BRANCH mutates under map_wr.
+		 * The caller holds only this shard's write lock, so take map_rd for the
+		 * walk -- otherwise an object write on a branch can race branch creation
+		 * and read a partially updated parent/branch_lsn chain.  Drop it before
+		 * the flush below re-takes map_wr; shard -> map order is preserved.
+		 */
+		ps_lock_map_rd();
+		cur = read_through(timeline, key, block, UINT64_MAX);
 		hdr.lsn = cur ? cur->lsn + 1 : 1;
+		ps_unlock_map();
 	}
 	hdr.len = page_size;
 

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -27,6 +27,7 @@
  *
  *-------------------------------------------------------------------------
  */
+#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -94,6 +95,59 @@ typedef struct Shard
 } Shard;
 
 static Shard g_shards[MAX_SHARDS];
+
+/*
+ * Concurrency.  A per-shard rwlock guards each shard's in-memory state
+ * (g_shards[i]: the page/fork/walidx indexes, memtable, append cursor and
+ * layer-id cursor).  A single map_lock guards the cross-shard state: the global
+ * ps_layer_map and the timelines[] array.  Lock order is always shard (outer)
+ * then map (inner), never the reverse, so there is no deadlock.
+ *
+ * Each daemon worker owns exactly one shard and only ever touches its own
+ * g_shards[]; the sole cross-worker accessor of another shard is maintenance
+ * (worker 0), which takes the target shard's lock plus map_lock before
+ * compacting it.  Reads take shard-rd + map-rd; ordinary writes take only
+ * shard-wr, escalating to a brief map-wr inside append_page when a flush or
+ * inline compaction mutates the map; branch creation takes map-wr alone.
+ */
+static pthread_rwlock_t shard_locks[MAX_SHARDS];
+static pthread_rwlock_t map_lock = PTHREAD_RWLOCK_INITIALIZER;
+
+void
+ps_lock_shard_rd(uint32_t shard)
+{
+	pthread_rwlock_rdlock(&shard_locks[shard]);
+}
+
+void
+ps_lock_shard_wr(uint32_t shard)
+{
+	pthread_rwlock_wrlock(&shard_locks[shard]);
+}
+
+void
+ps_unlock_shard(uint32_t shard)
+{
+	pthread_rwlock_unlock(&shard_locks[shard]);
+}
+
+void
+ps_lock_map_rd(void)
+{
+	pthread_rwlock_rdlock(&map_lock);
+}
+
+void
+ps_lock_map_wr(void)
+{
+	pthread_rwlock_wrlock(&map_lock);
+}
+
+void
+ps_unlock_map(void)
+{
+	pthread_rwlock_unlock(&map_lock);
+}
 
 static uint32_t
 core_shards(void)
@@ -1051,6 +1105,11 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 		ps_memtable_put(s->memtable, timeline, key, block, hdr.lsn, page);
 		if (ps_memtable_full(s->memtable))
 		{
+			/* A flush (and any inline compaction) mutates the cross-shard
+			 * ps_layer_map, so take map_lock here -- only on the rare flush, not
+			 * on every write.  The caller already holds this shard's write lock,
+			 * preserving the shard -> map order. */
+			ps_lock_map_wr();
 			ps_memtable_flush(s->memtable, alloc_layer_id, record_layer, s);
 			/* backpressure only: normal compaction runs off the write path in
 			 * ps_core_maintenance() when the daemon is idle.  Compact inline
@@ -1058,6 +1117,7 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 			 * threshold (writes outpacing background compaction). */
 			if (count_image_layers(timeline, s->id) > (uint32_t) compact_layers * 4)
 				compact_timeline(timeline, s->id);
+			ps_unlock_map();
 		}
 	}
 	return 0;
@@ -1392,20 +1452,46 @@ int
 ps_core_maintenance(void)
 {
 	uint32_t	ns;
+	uint32_t	ftl = 0,
+				fsh = 0;
+	int			found = 0;
 
 	if (!use_layers)
 		return 0;
 	ns = core_shards();
 
-	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)
+	/*
+	 * Phase 1: scan under map read-lock to pick a timeline+shard whose image
+	 * layers are due for compaction.  A shared lock here lets reads proceed.
+	 */
+	ps_lock_map_rd();
+	for (uint32_t tl = 0; tl < MAX_TIMELINES && !found; tl++)
 		for (uint32_t sh = 0; sh < ns; sh++)
 			if ((tl == 0 || timelines[tl].defined) &&
 				count_image_layers(tl, sh) > (uint32_t) compact_layers)
 			{
-				compact_timeline(tl, sh);
-				return 1;
+				ftl = tl;
+				fsh = sh;
+				found = 1;
+				break;
 			}
-	return 0;
+	ps_unlock_map();
+
+	if (!found)
+		return 0;
+
+	/*
+	 * Phase 2: compact the chosen shard under shard-wr + map-wr (the order other
+	 * paths use), which excludes that shard's worker and other map mutators.
+	 * Re-check under the write lock since the count may have changed.
+	 */
+	ps_lock_shard_wr(fsh);
+	ps_lock_map_wr();
+	if (count_image_layers(ftl, fsh) > (uint32_t) compact_layers)
+		compact_timeline(ftl, fsh);
+	ps_unlock_map();
+	ps_unlock_shard(fsh);
+	return 1;
 }
 
 /*
@@ -1432,13 +1518,14 @@ ps_core_open(const char *store_dir)
 	if (use_layers)
 		gc_resume();			/* finish any GC interrupted by a crash */
 
-	/* initialize per-shard state and layer-id cursors */
+	/* initialize per-shard state, locks and layer-id cursors */
 	for (uint32_t i = 0; i < ns; i++)
 	{
 		g_shards[i].id = i;
 		g_shards[i].cur_seg = -1;
 		g_shards[i].cur_off = 0;
 		g_shards[i].next_layer_id = 1;
+		pthread_rwlock_init(&shard_locks[i], NULL);
 	}
 	/* layer ids continue past the highest one restored per shard */
 	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -186,6 +186,21 @@ shard_for(const PsKey *key)
 	return &g_shards[ps_key_shard(key, ns)];
 }
 
+/*
+ * Shard index that will actually be touched for 'key' (klass-aware), so the
+ * frontend can take the matching per-shard lock from the FINAL request key
+ * rather than trusting a client-supplied channel shard.
+ */
+uint32_t
+ps_shard_of(const PsKey *key)
+{
+	uint32_t	ns = core_shards();
+
+	if (ns == 1 || !key)
+		return 0;
+	return ps_key_shard(key, ns);
+}
+
 uint32_t
 ps_core_layer_count(void)
 {
@@ -204,9 +219,9 @@ ps_core_read_stats(uint64_t *mem, uint64_t *layer, uint64_t *seg)
 
 	for (uint32_t i = 0; i < ns; i++)
 	{
-		m += g_shards[i].rr_mem;
-		l += g_shards[i].rr_layer;
-		s += g_shards[i].rr_seg;
+		m += __atomic_load_n(&g_shards[i].rr_mem, __ATOMIC_RELAXED);
+		l += __atomic_load_n(&g_shards[i].rr_layer, __ATOMIC_RELAXED);
+		s += __atomic_load_n(&g_shards[i].rr_seg, __ATOMIC_RELAXED);
 	}
 	if (mem)
 		*mem = m;
@@ -1206,18 +1221,18 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 				ps_memtable_lookup(s->memtable, tl, key, block, rl, &l, out) &&
 				l == pv->lsn)
 			{
-				s->rr_mem++;
+				__atomic_fetch_add(&s->rr_mem, 1, __ATOMIC_RELAXED);
 				served = 1;		/* served from the memtable */
 			}
 			else if (layer_map_lookup(tl, key, block, rl, &l, out) &&
 					 l == pv->lsn)
 			{
-				s->rr_layer++;
+				__atomic_fetch_add(&s->rr_layer, 1, __ATOMIC_RELAXED);
 				served = 1;		/* served from an image layer */
 			}
 			else
 			{
-				s->rr_seg++;
+				__atomic_fetch_add(&s->rr_seg, 1, __ATOMIC_RELAXED);
 				served = (read_version(pv, out) == 0);	/* segment fallback */
 			}
 			if (served)

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -82,4 +82,17 @@ extern int	read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 						 uint64_t read_lsn, unsigned char *out);
 extern void fork_grow(uint32_t timeline, const PsKey *key, uint32_t to_nblocks);
 
+/*
+ * Concurrency locks (defined in pagestore_core.c).  A per-shard rwlock guards
+ * each shard's in-memory state; a single map_lock guards the cross-shard
+ * ps_layer_map + timelines[].  Callers MUST take them in the order shard
+ * (outer) -> map (inner), never the reverse.
+ */
+extern void ps_lock_shard_rd(uint32_t shard);
+extern void ps_lock_shard_wr(uint32_t shard);
+extern void ps_unlock_shard(uint32_t shard);
+extern void ps_lock_map_rd(void);
+extern void ps_lock_map_wr(void);
+extern void ps_unlock_map(void);
+
 #endif							/* PAGESTORE_CORE_H */

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -95,4 +95,8 @@ extern void ps_lock_map_rd(void);
 extern void ps_lock_map_wr(void);
 extern void ps_unlock_map(void);
 
+/* Shard index that will be touched for 'key' (klass-aware); the frontend takes
+ * the per-shard lock from the final request key, not a client-supplied shard. */
+extern uint32_t ps_shard_of(const PsKey *key);
+
 #endif							/* PAGESTORE_CORE_H */

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -34,7 +34,6 @@
 #include "pagestore_pgcache.h"
 
 static volatile sig_atomic_t stop_requested = 0;
-static pthread_rwlock_t core_rwlock = PTHREAD_RWLOCK_INITIALIZER;
 
 typedef struct WorkerArgs
 {
@@ -145,17 +144,44 @@ request_is_write(PsOpcode opcode)
 static void
 run_request(PsChannel *ch)
 {
-	int			is_write = request_is_write((PsOpcode) ch->opcode);
+	PsOpcode	op = (PsOpcode) ch->opcode;
 
-	if (is_write)
-		pthread_rwlock_wrlock(&core_rwlock);
+	/*
+	 * Branch creation mutates only the cross-shard timelines[]; take map_lock
+	 * alone (no shard lock), so it serializes against map readers/writers but
+	 * not against per-shard work on unrelated shards.
+	 */
+	if (op == PS_OP_CREATE_BRANCH)
+	{
+		ps_lock_map_wr();
+		handle_request(ch);
+		ps_store_release(&ch->state, PS_STATE_DONE);
+		ps_unlock_map();
+		return;
+	}
+
+	if (request_is_write(op))
+	{
+		/*
+		 * Writes touch only this shard's state; append_page escalates to a brief
+		 * map_wr itself when a flush/compaction mutates the map.  Per-shard locks
+		 * let writes on different shards run concurrently.
+		 */
+		ps_lock_shard_wr(ch->shard);
+		handle_request(ch);
+		ps_store_release(&ch->state, PS_STATE_DONE);
+		ps_unlock_shard(ch->shard);
+	}
 	else
-		pthread_rwlock_rdlock(&core_rwlock);
-
-	handle_request(ch);
-	ps_store_release(&ch->state, PS_STATE_DONE);
-
-	pthread_rwlock_unlock(&core_rwlock);
+	{
+		/* Reads consult this shard's indexes plus the cross-shard map/timelines. */
+		ps_lock_shard_rd(ch->shard);
+		ps_lock_map_rd();
+		handle_request(ch);
+		ps_store_release(&ch->state, PS_STATE_DONE);
+		ps_unlock_map();
+		ps_unlock_shard(ch->shard);
+	}
 }
 
 static void *
@@ -184,11 +210,9 @@ shard_worker(void *arg)
 
 		if (!did_work && shard == 0)
 		{
-			int			do_maint = 0;
+			/* maintenance takes the shard + map locks it needs internally */
+			int			do_maint = ps_core_maintenance();
 
-			pthread_rwlock_wrlock(&core_rwlock);
-			do_maint = ps_core_maintenance();
-			pthread_rwlock_unlock(&core_rwlock);
 			if (!do_maint)
 			{
 				struct timespec ts = {0, 20000};	/* 20us */

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -160,27 +160,55 @@ run_request(PsChannel *ch)
 		return;
 	}
 
-	if (request_is_write(op))
+	/*
+	 * IMMEDSYNC fsyncs the shared segment-fd cache; the POSIX backend serializes
+	 * that internally (seg_fds_lock), so no per-shard lock is needed (and a single
+	 * shard lock would not have excluded the other shards' fd-cache mutations).
+	 */
+	if (op == PS_OP_IMMEDSYNC)
 	{
-		/*
-		 * Writes touch only this shard's state; append_page escalates to a brief
-		 * map_wr itself when a flush/compaction mutates the map.  Per-shard locks
-		 * let writes on different shards run concurrently.
-		 */
-		ps_lock_shard_wr(ch->shard);
 		handle_request(ch);
 		ps_store_release(&ch->state, PS_STATE_DONE);
-		ps_unlock_shard(ch->shard);
+		return;
 	}
-	else
+
 	{
-		/* Reads consult this shard's indexes plus the cross-shard map/timelines. */
-		ps_lock_shard_rd(ch->shard);
-		ps_lock_map_rd();
-		handle_request(ch);
-		ps_store_release(&ch->state, PS_STATE_DONE);
-		ps_unlock_map();
-		ps_unlock_shard(ch->shard);
+		uint32_t	shard;
+
+		/*
+		 * Derive the shard from the FINAL request key (klass-aware), not a
+		 * client-supplied ch->shard: object I/O claims its channel before setting
+		 * ch->key.klass, and freestanding IPC clients don't populate ch->shard at
+		 * all -- trusting it would lock one shard while handle_request() mutates
+		 * shard_for(&ch->key).  The shipped-WAL byte ops (append/size/read) are not
+		 * keyed (they touch the per-timeline WAL log), so serialize them on shard 0.
+		 */
+		if (op == PS_OP_WAL_APPEND || op == PS_OP_WAL_SIZE || op == PS_OP_WAL_READ)
+			shard = 0;
+		else
+			shard = ps_shard_of(&ch->key);
+
+		if (request_is_write(op))
+		{
+			/*
+			 * Writes touch only this shard's state; append_page escalates to a
+			 * brief map_wr itself when a flush/compaction mutates the map.
+			 */
+			ps_lock_shard_wr(shard);
+			handle_request(ch);
+			ps_store_release(&ch->state, PS_STATE_DONE);
+			ps_unlock_shard(shard);
+		}
+		else
+		{
+			/* Reads consult this shard's indexes plus the cross-shard map/timelines. */
+			ps_lock_shard_rd(shard);
+			ps_lock_map_rd();
+			handle_request(ch);
+			ps_store_release(&ch->state, PS_STATE_DONE);
+			ps_unlock_map();
+			ps_unlock_shard(shard);
+		}
 	}
 }
 

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -164,11 +164,28 @@ run_request(PsChannel *ch)
 	 * IMMEDSYNC fsyncs the shared segment-fd cache; the POSIX backend serializes
 	 * that internally (seg_fds_lock), so no per-shard lock is needed (and a single
 	 * shard lock would not have excluded the other shards' fd-cache mutations).
+	 *
+	 * SPDK's sync(), however, flushes every shard's in-memory curbuf, which a
+	 * concurrent shard write mutates -- with per-shard locking there is no single
+	 * write lock to exclude that, so for such backends hold every shard's write
+	 * lock (ascending, the established shard order) around the sync.
 	 */
 	if (op == PS_OP_IMMEDSYNC)
 	{
-		handle_request(ch);
-		ps_store_release(&ch->state, PS_STATE_DONE);
+		if (ps_storage->sync_needs_write_lock)
+		{
+			for (uint32_t s = 0; s < ps_nshards; s++)
+				ps_lock_shard_wr(s);
+			handle_request(ch);
+			ps_store_release(&ch->state, PS_STATE_DONE);
+			for (uint32_t s = ps_nshards; s-- > 0;)
+				ps_unlock_shard(s);
+		}
+		else
+		{
+			handle_request(ch);
+			ps_store_release(&ch->state, PS_STATE_DONE);
+		}
 		return;
 	}
 

--- a/contrib/pagestore/pagestore_storage.h
+++ b/contrib/pagestore/pagestore_storage.h
@@ -41,6 +41,15 @@ typedef struct PsStorage
 	void		(*close) (void);
 	int			(*sync) (void);
 
+	/*
+	 * If nonzero, sync() flushes in-memory write buffers shared with seg_write
+	 * (e.g. SPDK's per-shard curbuf) and is NOT internally serialized against
+	 * concurrent writes, so the daemon must hold every shard's write lock around
+	 * IMMEDSYNC.  POSIX leaves this 0: its sync() only fsyncs fds under its own
+	 * lock, so the lock-free IMMEDSYNC path is safe.
+	 */
+	int			sync_needs_write_lock;
+
 	/* segment log (page-version data); seg_write creates the segment lazily */
 	int			(*seg_write) (uint32_t shard, int seg, uint64_t off,
 						 const void *buf, uint32_t len);

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -1022,6 +1022,136 @@ run_concurrency_suite(const char *daemon_path, const char *tmpbase)
 #undef NKIDS
 }
 
+/*
+ * Stress the per-shard + map locking.  Writers hammer their own rels (distinct
+ * shards) hard enough to trigger repeated memtable flushes and compactions (each
+ * of which takes map_wr), while readers continuously re-read a write-once shared
+ * dataset (taking shard_rd + map_rd).  The shared dataset is never rewritten, so
+ * a reader must ALWAYS see the correct page; any mismatch means a concurrent map
+ * mutation corrupted a read -- i.e. the map lock is wrong.  Run with nshards>1
+ * (the test's optional argv[2]) to exercise true cross-shard concurrency.
+ */
+static int
+stress_writer_child(const char *shm_name, uint32_t ps, int id)
+{
+	uint32_t	rel = 30000 + (uint32_t) id;
+	unsigned char *p = malloc(ps);
+
+	client_attach(shm_name, ps);
+	/* 3 passes x 200 blocks: flush-pages=8 -> ~75 flushes -> many compactions */
+	for (int pass = 0; pass < 3; pass++)
+		for (uint32_t b = 0; b < 200; b++)
+		{
+			fill_page(p, ps, 7000 + b, (unsigned char) (id * 11 + pass + b + 1));
+			op_write_one(rel, FORK0, b, p);
+		}
+	client_detach();
+	free(p);
+	return 0;
+}
+
+static int
+stress_reader_child(const char *shm_name, uint32_t ps, uint32_t rel,
+					uint32_t nblocks, unsigned char tagbase)
+{
+	unsigned char *r = malloc(ps);
+	int			rc = 0;
+
+	client_attach(shm_name, ps);
+	for (int iter = 0; iter < 150 && rc == 0; iter++)
+		for (uint32_t b = 0; b < nblocks; b++)
+		{
+			op_read_one(rel, FORK0, b, r);
+			if (!page_has_tag(r, ps, (unsigned char) (tagbase + b)))
+				rc = 2;				/* concurrent map mutation corrupted a read */
+		}
+	client_detach();
+	free(r);
+	return rc;
+}
+
+static int
+stress_populate_child(const char *shm_name, uint32_t ps, uint32_t rel,
+					  uint32_t nblocks, unsigned char tagbase)
+{
+	unsigned char *p = malloc(ps);
+
+	client_attach(shm_name, ps);
+	for (uint32_t b = 0; b < nblocks; b++)
+	{
+		fill_page(p, ps, 5000 + b, (unsigned char) (tagbase + b));
+		op_write_one(rel, FORK0, b, p);
+	}
+	client_detach();
+	free(p);
+	return 0;
+}
+
+static void
+run_stress_suite(const char *daemon_path, const char *tmpbase)
+{
+#define NWRITERS 8
+#define NREADERS 8
+	char		shm[64];
+	char		store[256];
+	pid_t		dpid;
+	pid_t		pop;
+	pid_t		kids[NWRITERS + NREADERS];
+	int			st = 1;
+	uint32_t	ps = 8192;
+	uint32_t	shared_rel = 29999;
+	uint32_t	shared_n = 64;
+	unsigned char tagbase = 100;
+
+	fprintf(stderr, "== stress (%d writers + %d readers, nshards=%u) ==\n",
+			NWRITERS, NREADERS, test_nshards);
+	snprintf(shm, sizeof(shm), "/pstest_%d_stress", (int) getpid());
+	snprintf(store, sizeof(store), "%s/store_stress", tmpbase);
+	rm_rf(store);
+	shm_unlink(shm);
+
+	dpid = spawn_daemon(daemon_path, shm, store, ps, test_nshards);
+	wait_ready(shm, ps);
+
+	/* populate the write-once shared dataset before the concurrent phase */
+	pop = fork();
+	if (pop == 0)
+		_exit(stress_populate_child(shm, ps, shared_rel, shared_n, tagbase));
+	waitpid(pop, &st, 0);
+	check(WIFEXITED(st) && WEXITSTATUS(st) == 0, "stress: shared dataset populated");
+
+	for (int i = 0; i < NWRITERS; i++)
+	{
+		pid_t		pid = fork();
+
+		if (pid == 0)
+			_exit(stress_writer_child(shm, ps, i));
+		kids[i] = pid;
+	}
+	for (int i = 0; i < NREADERS; i++)
+	{
+		pid_t		pid = fork();
+
+		if (pid == 0)
+			_exit(stress_reader_child(shm, ps, shared_rel, shared_n, tagbase));
+		kids[NWRITERS + i] = pid;
+	}
+	for (int i = 0; i < NWRITERS + NREADERS; i++)
+	{
+		int			s = 1;
+
+		waitpid(kids[i], &s, 0);
+		check(WIFEXITED(s) && WEXITSTATUS(s) == 0,
+			  "stress: client %d finished clean (no deadlock, no map corruption)", i);
+	}
+
+	stop_daemon(dpid);
+	rm_rf(store);
+	shm_unlink(shm);
+#undef NWRITERS
+#undef NREADERS
+}
+
 int
 main(int argc, char **argv)
 {
@@ -1068,6 +1198,9 @@ main(int argc, char **argv)
 
 	/* many concurrent clients */
 	run_concurrency_suite(daemon_path, tmpbase);
+
+	/* stress the per-shard + map locking under sustained flush/compaction load */
+	run_stress_suite(daemon_path, tmpbase);
 
 	rmdir(tmpbase);
 

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -195,6 +195,15 @@ posix_close(void)
 static int
 posix_sync(void)
 {
+	int			rc = 0;
+
+	/*
+	 * Walk the shared seg-fd cache under seg_fds_lock so a concurrent shard
+	 * worker cannot lazily open a segment and realloc seg_fds[]/seg_fds_caps[]
+	 * while we iterate (with per-shard locking the caller no longer holds a
+	 * global write lock that would have excluded that).
+	 */
+	pthread_mutex_lock(&seg_fds_lock);
 	for (int shard = 0; shard < seg_shards_cap; shard++)
 	{
 		int *fds = seg_fds[shard];
@@ -204,9 +213,14 @@ posix_sync(void)
 			continue;
 		for (int id = 0; id < cap; id++)
 			if (fds[id] >= 0 && fsync(fds[id]) != 0)
-				return -1;
+			{
+				rc = -1;
+				goto out;
+			}
 	}
-	return 0;
+out:
+	pthread_mutex_unlock(&seg_fds_lock);
+	return rc;
 }
 
 static int

--- a/contrib/pagestore/storage_spdk.c
+++ b/contrib/pagestore/storage_spdk.c
@@ -837,6 +837,8 @@ const PsStorage PsStorageSpdk = {
 	.open = spdk_open,
 	.close = spdk_close,
 	.sync = spdk_sync,
+	/* sync flushes per-shard curbufs; serialize IMMEDSYNC against all writes */
+	.sync_needs_write_lock = 1,
 	.seg_write = spdk_seg_write,
 	.seg_read = spdk_seg_read,
 	.seg_size = spdk_seg_size,


### PR DESCRIPTION
Phase 2 — the concurrency payoff. Stacked on #47 (object-class seam).

## Problem
The daemon used a single global `core_rwlock`: every write took it exclusively, so a write on **any** shard blocked **all** reads on **every** shard. With sharding scaffolding in place (`nshards`), that lock was the wall between us and real cross-shard parallelism.

## Change
Two finer-grained locks, replacing the global one:
- **per-shard rwlock** (`shard_locks[]`) — each shard's in-memory state (page/fork/walidx indexes, memtable, append + layer-id cursors);
- **one `map_lock`** — the cross-shard state: global `ps_layer_map` + `timelines[]`.

Strict order **shard (outer) → map (inner)**, never reversed → no deadlock. The insight that makes it safe + cheap: each worker owns one shard and only touches its own `g_shards[]`; the *only* cross-worker accessor is maintenance (worker 0), which now takes the target shard's lock + `map_lock` before compacting.

Policy:
| path | locks |
|---|---|
| reads | shard-rd + map-rd → concurrent across shards |
| writes | shard-wr only; brief map-wr inside `append_page` *only* on the rare flush/compaction |
| branch create | map-wr alone (timelines only) |
| maintenance | map-rd scan → shard-wr + map-wr compact |

WAL byte ops route to channel 0 (single worker) → `wal_end[]`/`wal_buf` need no extra lock; walidx is per-shard.

## Validation (three ways)
1. **Functional**: standalone suite passes at `nshards=1/4/8` (1 = behavior-preserving). 133 checks, 0 failed.
2. **Stress** (new `run_stress_suite`): 8 writers driving sustained flush/compaction load on distinct shards while 8 readers continuously verify a write-once shared dataset — any map corruption under concurrent `map_wr` would fail a read. Passes at 1/4/8.
3. **ThreadSanitizer**: **zero** data races / lock-order inversions in the locked core (`g_shards`/`ps_layer_map`/`timelines`). The only TSan warnings are the pre-existing signal-handler flag (`stop_requested` in `on_signal`), untouched by this change.

Engine-level integration test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)