### PR TITLE
Drop/truncate liveness in redo_page_asof (phase 2)

### DIFF
--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -213,6 +213,24 @@ assert "$rt0" "t" "relation-class object with the same id round-trips"
 iso=$($P -c "SELECT pagestore_object_get(1, 42) = repeat('A',8192)::bytea;")
 assert "$iso" "t" "klass discriminates: same id, different klass = different objects"
 
+# --- 9. liveness: redo_page_asof must not materialize a truncated-away block -----
+# A block truncated away (VACUUM truncation -> XLOG_SMGR_TRUNCATE) at/below the
+# requested LSN is not live and must not be reconstructed from its stale FPI.
+$P -c "CREATE TABLE trunc(id int, v text) WITH (autovacuum_enabled=off);
+       INSERT INTO trunc SELECT g, 'row'||g FROM generate_series(1,50) g;
+       CHECKPOINT;" >/dev/null
+tl0=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "UPDATE trunc SET v=v||'!' WHERE id=1;" >/dev/null  # first change after checkpoint -> FPI of block 0
+tl_before=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "DELETE FROM trunc;" >/dev/null
+$P -c "VACUUM trunc;" >/dev/null                     # empties block 0 -> truncates it away
+tl_after=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "SELECT pagestore_index_wal('$tl0', '$tl_after');" >/dev/null
+live_before=$($P -c "SELECT pagestore_redo_page_asof('trunc',0,0,'$tl_before') IS NOT NULL;")
+assert "$live_before" "t" "redo_page_asof materializes the block while it is live (before truncation)"
+live_after=$($P -c "SELECT pagestore_redo_page_asof('trunc',0,0,'$tl_after') IS NULL;")
+assert "$live_after" "t" "redo_page_asof returns NULL for a block truncated away as of the LSN (liveness)"
+
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
 exit $fail

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -34,11 +34,13 @@
 #include <unistd.h>
 
 #include "access/relation.h"
+#include "access/rmgr.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"
 #include "access/xlogutils.h"
 #include "archive/archive_module.h"
 #include "catalog/pg_tablespace_d.h"
+#include "catalog/storage_xlog.h"
 #include "fmgr.h"
 #include "miscadmin.h"
 #include "pagestore_backend.h"
@@ -753,6 +755,50 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 }
 
 /*
+ * Liveness: scan local WAL in (from_lsn, to_lsn] for an smgr truncate of
+ * (rloc, forknum) down to <= block.  If found, the block was truncated away after
+ * its last write and not re-extended, so it is not live as of to_lsn and must not
+ * be materialized.  Only the main fork is checked -- the truncate record carries
+ * only the main-fork size; other forks are conservatively treated as live.
+ *
+ * Cost: a linear pass over (from_lsn, to_lsn].  redo_page_asof is off the read hot
+ * path; a daemon-side fork-size-at-lsn index would make this O(1) -- a later step.
+ */
+static bool
+redo_block_truncated_away(XLogReaderState *reader, RelFileLocator rloc,
+						  ForkNumber forknum, BlockNumber block,
+						  XLogRecPtr from_lsn, XLogRecPtr to_lsn)
+{
+	if (forknum != MAIN_FORKNUM || from_lsn >= to_lsn)
+		return false;
+
+	XLogBeginRead(reader, from_lsn);
+	for (;;)
+	{
+		char	   *errm;
+		XLogRecord *rec = XLogReadRecord(reader, &errm);
+
+		if (rec == NULL)
+			break;
+		if (reader->ReadRecPtr <= from_lsn)
+			continue;			/* skip the block's own last-write record */
+		if (reader->ReadRecPtr > to_lsn)
+			break;
+		if (XLogRecGetRmid(reader) == RM_SMGR_ID &&
+			(XLogRecGetInfo(reader) & ~XLR_INFO_MASK) == XLOG_SMGR_TRUNCATE)
+		{
+			xl_smgr_truncate *xlrec = (xl_smgr_truncate *) XLogRecGetData(reader);
+
+			if (RelFileLocatorEquals(xlrec->rlocator, rloc) &&
+				(xlrec->flags & SMGR_TRUNCATE_HEAP) &&
+				xlrec->blkno <= block)
+				return true;
+		}
+	}
+	return false;
+}
+
+/*
  * pagestore_redo_page_asof(relid, forknum, blocknum, lsn) returns bytea
  *
  * Materialize a page as of 'lsn' (the 5b driver): find the newest full-page
@@ -853,6 +899,23 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	if (base_idx < 0)
 	{
 		/* no base image indexed for this block; cannot materialize yet */
+		XLogReaderFree(reader);
+		pfree(pd);
+		pfree(lsns);
+		pfree(base);
+		pfree(page);
+		PG_RETURN_NULL();
+	}
+
+	/*
+	 * Liveness: if the block was truncated away after its last write and at or
+	 * before lsn (and not re-extended), it is not live as of lsn -- do not
+	 * materialize a stale page for it.  lsns[n - 1] is the block's newest record
+	 * at/below lsn.
+	 */
+	if (redo_block_truncated_away(reader, rloc, forknum, (BlockNumber) blocknum,
+								  (XLogRecPtr) lsns[n - 1], lsn))
+	{
 		XLogReaderFree(reader);
 		pfree(pd);
 		pfree(lsns);


### PR DESCRIPTION
Phase 2 — closes the Phase-1 follow-up. Stacked on #50.

## Bug
`redo_page_asof()` found the newest FPI at/below the LSN and replayed deltas, but never checked whether the block was still **live** as of that LSN. A block truncated away (VACUUM truncation → `XLOG_SMGR_TRUNCATE`) after its last write would be reconstructed from its stale full-page image — wrong.

## Fix
After locating the base, scan local WAL in `(block's-last-record, lsn]` for an smgr truncate of this rel/fork down to `<= block`. If found, the block was truncated away and not re-extended → not live → return NULL instead of a stale page. Only the main fork is checked (the truncate record carries only the main-fork size); other forks are conservatively treated as live.

The scan is a linear pass over the LSN range; `redo_page_asof` is off the read hot path, and a daemon-side fork-size-at-lsn index would make it O(1) — a later step.

## Verified (integration test)
A table whose block 0 has an FPI, then `DELETE` + `VACUUM` truncates it away:
- `redo_page_asof` at an LSN **before** the truncation still materializes the block;
- at an LSN **after** it returns NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)