### PR TITLE
Timeline-tagged, LSN-ordered walidx_get (phase 2)

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -592,7 +592,7 @@ pagestore_localsvc_walidx_count(const PageStoreRelKey *key, BlockNumber block)
  * returns how many.  Ascending order. */
 int
 pagestore_localsvc_walidx_get(const PageStoreRelKey *key, BlockNumber block,
-							  uint64 lsn_max, uint64 *out, int maxn)
+							  uint64 lsn_max, PsWalRec *out, int maxn)
 {
 	PsChannel  *ch = ls_chan_for_key(key);
 	int			n;
@@ -605,7 +605,7 @@ pagestore_localsvc_walidx_get(const PageStoreRelKey *key, BlockNumber block,
 	n = (int) ch->result;
 	if (n > maxn)
 		n = maxn;
-	memcpy(out, ch->data, (size_t) n * sizeof(uint64));
+	memcpy(out, ch->data, (size_t) n * sizeof(PsWalRec));
 	return n;
 }
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -677,7 +677,7 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 	XLogRecPtr	lsn = PG_GETARG_LSN(3);
 	Relation	rel;
 	PageStoreRelKey key;
-	uint64	   *lsns;
+	PsWalRec  *recs;
 	int			n;
 	ReadLocalXLogPageNoWaitPrivate *pd;
 	XLogReaderState *reader;
@@ -691,9 +691,9 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 	key.forkNum = forknum;
 	relation_close(rel, AccessShareLock);
 
-	lsns = palloc(sizeof(uint64) * PS_REDO_MAX_RECS);
+	recs = palloc(sizeof(PsWalRec) * PS_REDO_MAX_RECS);
 	n = pagestore_localsvc_walidx_get(&key, (BlockNumber) blocknum, (uint64) lsn,
-									  lsns, PS_REDO_MAX_RECS);
+									  recs, PS_REDO_MAX_RECS);
 	if (n == 0)
 		PG_RETURN_NULL();
 
@@ -716,7 +716,7 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 		char	   *errm;
 		XLogRecord *rec;
 
-		XLogBeginRead(reader, lsns[i]);
+		XLogBeginRead(reader, recs[i].lsn);
 		rec = XLogReadRecord(reader, &errm);
 		if (rec == NULL)
 			continue;
@@ -746,7 +746,7 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 
 	XLogReaderFree(reader);
 	pfree(pd);
-	pfree(lsns);
+	pfree(recs);
 	pfree(page);
 
 	if (result == NULL)
@@ -821,7 +821,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	Relation	rel;
 	PageStoreRelKey key;
 	RelFileLocator rloc;
-	uint64	   *lsns;
+	PsWalRec  *recs;
 	int			n;
 	int			base_idx = -1;
 	XLogRecPtr	base_end_lsn = InvalidXLogRecPtr;
@@ -844,9 +844,9 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	key.relNumber = rloc.relNumber;
 	key.forkNum = forknum;
 
-	lsns = palloc(sizeof(uint64) * PS_REDO_MAX_RECS);
+	recs = palloc(sizeof(PsWalRec) * PS_REDO_MAX_RECS);
 	n = pagestore_localsvc_walidx_get(&key, (BlockNumber) blocknum, (uint64) lsn,
-									  lsns, PS_REDO_MAX_RECS);
+									  recs, PS_REDO_MAX_RECS);
 	if (n == 0)
 		PG_RETURN_NULL();
 
@@ -859,7 +859,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	if (reader == NULL)
 	{
 		pfree(pd);
-		pfree(lsns);
+		pfree(recs);
 		PG_RETURN_NULL();
 	}
 	base = palloc(BLCKSZ);
@@ -871,7 +871,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		char	   *errm;
 		XLogRecord *rec;
 
-		XLogBeginRead(reader, lsns[i]);
+		XLogBeginRead(reader, recs[i].lsn);
 		rec = XLogReadRecord(reader, &errm);
 		if (rec == NULL)
 			continue;
@@ -901,7 +901,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		/* no base image indexed for this block; cannot materialize yet */
 		XLogReaderFree(reader);
 		pfree(pd);
-		pfree(lsns);
+		pfree(recs);
 		pfree(base);
 		pfree(page);
 		PG_RETURN_NULL();
@@ -910,15 +910,15 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	/*
 	 * Liveness: if the block was truncated away after its last write and at or
 	 * before lsn (and not re-extended), it is not live as of lsn -- do not
-	 * materialize a stale page for it.  lsns[n - 1] is the block's newest record
+	 * materialize a stale page for it.  recs[n - 1].lsn is the block's newest record
 	 * at/below lsn.
 	 */
 	if (redo_block_truncated_away(reader, rloc, forknum, (BlockNumber) blocknum,
-								  (XLogRecPtr) lsns[n - 1], lsn))
+								  (XLogRecPtr) recs[n - 1].lsn, lsn))
 	{
 		XLogReaderFree(reader);
 		pfree(pd);
-		pfree(lsns);
+		pfree(recs);
 		pfree(base);
 		pfree(page);
 		PG_RETURN_NULL();
@@ -937,14 +937,14 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		uint32		firstpage;
 		char	   *raw;
 
-		XLogBeginRead(reader, lsns[i]);
+		XLogBeginRead(reader, recs[i].lsn);
 		rec = XLogReadRecord(reader, &errm);
 		if (rec == NULL)
 		{
 			walredo_stop(p);
 			ereport(ERROR,
 					(errmsg("could not read WAL record at %X/%08X for redo: %s",
-							LSN_FORMAT_ARGS(lsns[i]), errm ? errm : "(unknown)")));
+							LSN_FORMAT_ARGS(recs[i].lsn), errm ? errm : "(unknown)")));
 		}
 
 		/*
@@ -974,7 +974,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 
 	XLogReaderFree(reader);
 	pfree(pd);
-	pfree(lsns);
+	pfree(recs);
 	pfree(base);
 	pfree(page);
 	PG_RETURN_BYTEA_P(result);

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -29,6 +29,8 @@
 #include "storage/relfilelocator.h"
 #include "storage/smgr.h"
 
+#include "pagestore_ipc.h"		/* PsWalRec */
+
 /*
  * Version-neutral physical identity of a relation fork.  Deliberately built
  * from plain OIDs / numbers rather than RelFileLocator so the on-the-wire
@@ -153,7 +155,7 @@ extern int	pagestore_localsvc_walidx_count(const PageStoreRelKey *key,
 											BlockNumber block);
 extern int	pagestore_localsvc_walidx_get(const PageStoreRelKey *key,
 										  BlockNumber block, uint64 lsn_max,
-										  uint64 *out, int maxn);
+										  PsWalRec *out, int maxn);
 extern void pagestore_localsvc_obj_write(uint32 klass, const PageStoreRelKey *key,
 										 BlockNumber block, const void *page);
 extern void pagestore_localsvc_obj_read(uint32 klass, const PageStoreRelKey *key,

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1020,8 +1020,17 @@ walidx_add(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 /* Copy the record LSNs for (tl,key,block) that are <= lsn_max into out (cap
  * max_out); return how many.  Walks the timeline ancestry. */
 static int
+walrec_cmp(const void *a, const void *b)
+{
+	uint64_t	la = ((const PsWalRec *) a)->lsn;
+	uint64_t	lb = ((const PsWalRec *) b)->lsn;
+
+	return (la > lb) - (la < lb);
+}
+
+static int
 walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
-		   uint64_t *out, int max_out)
+		   PsWalRec *out, int max_out)
 {
 	Shard	   *s = shard_for(key);	/* same shard across the ancestry walk */
 	int			got = 0;
@@ -1035,12 +1044,21 @@ walidx_get(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn_max,
 		for (e = s->walidx[h & IDX_MASK]; e; e = e->next)
 			if (e->timeline == w.tl && e->block == block && key_eq(&e->key, key))
 			{
+				/* tag each record with the timeline it lives on (w.tl) */
 				for (int i = 0; i < e->n && got < max_out; i++)
 					if (e->lsns[i] <= w.lsn)
-						out[got++] = e->lsns[i];
+					{
+						out[got].lsn = e->lsns[i];
+						out[got].timeline = w.tl;
+						got++;
+					}
 				break;
 			}
 	} while (tl_walk_next(&w));
+
+	/* gathered newest-timeline-first across the ancestry; redo (and the base
+	 * search) need them in ascending LSN order */
+	qsort(out, (size_t) got, sizeof(PsWalRec), walrec_cmp);
 	return got;
 }
 
@@ -1400,8 +1418,8 @@ ps_handle_meta(PsChannel *ch)
 
 		case PS_OP_WAL_INDEX_GET:
 			ch->result = (uint32_t) walidx_get(tl, &ch->key, ch->blocknum,
-											   ch->req_lsn, (uint64_t *) ch->data,
-											   (int) (PS_IO_UNIT / sizeof(uint64_t)));
+											   ch->req_lsn, (PsWalRec *) ch->data,
+											   (int) (PS_IO_UNIT / sizeof(PsWalRec)));
 			break;
 
 		case PS_OP_IMMEDSYNC:

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 #define PS_SHM_MAGIC		0x50414753	/* "PAGS" */
-#define PS_SHM_VERSION		6	/* 6: PsKey gained the klass discriminator */
+#define PS_SHM_VERSION		7	/* 7: walidx_get returns timeline-tagged PsWalRec */
 
 /* Default logical page size (overridable via the daemon's --page-size). */
 #define PS_DEFAULT_PAGE_SIZE	8192
@@ -102,6 +102,19 @@ typedef struct PsKey
 	int32_t		forkNum;
 	uint32_t	klass;			/* PsObjClass; 0 = relation (default) */
 } PsKey;
+
+/*
+ * A per-page WAL-index record: one WAL record that touched the page, tagged with
+ * the timeline it lives on.  walidx_get returns these in ascending LSN order,
+ * merging a branch's records with its ancestors' (the timeline tag tells a reader
+ * which timeline's shipped WAL to fetch each record from -- the cross-branch
+ * store-served read path).
+ */
+typedef struct PsWalRec
+{
+	uint64_t	lsn;			/* record start LSN (ReadRecPtr) */
+	uint32_t	timeline;		/* source timeline the record lives on */
+} PsWalRec;
 
 /* Shared hash helper for key routing.  FNV-1a over bytes keeps this cheap and
  * stable enough for shard selection, and it is reused for client+daemon key->shard.

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -432,7 +432,7 @@ op_walidx_add(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block, uint64_t 
 /* Returns count; fills out[] with the record LSNs <= lsn_max. */
 static int
 op_walidx_get(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
-			  uint64_t lsn_max, uint64_t *out)
+			  uint64_t lsn_max, PsWalRec *out)
 {
 	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
 	int			n;
@@ -443,7 +443,7 @@ op_walidx_get(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
 	ch->blocknum = block;
 	ch->req_lsn = lsn_max;
 	n = (int) cl_exec()->result;
-	memcpy(out, ch->data, (size_t) n * sizeof(uint64_t));
+	memcpy(out, ch->data, (size_t) n * sizeof(PsWalRec));
 	return n;
 }
 
@@ -852,7 +852,7 @@ run_walidx_suite(const char *daemon_path, const char *tmpbase)
 	char		store[256];
 	pid_t		dpid;
 	uint32_t	ps = 8192;
-	uint64_t	out[16];
+	PsWalRec	out[16];
 	int		n;
 
 	fprintf(stderr, "== per-page WAL index ==\n");
@@ -872,13 +872,15 @@ run_walidx_suite(const char *daemon_path, const char *tmpbase)
 	op_walidx_add(0, REL_A, FORK0, 1, 150);
 
 	n = op_walidx_get(0, REL_A, FORK0, 0, 250, out);
-	check(n == 2 && out[0] == 100 && out[1] == 200,
+	check(n == 2 && out[0].lsn == 100 && out[1].lsn == 200,
 		  "index returns records <= lsn (block 0 as-of 250 -> [100,200])");
 	n = op_walidx_get(0, REL_A, FORK0, 0, 1000000, out);
-	check(n == 3 && out[2] == 300, "index returns all records up to a high lsn");
+	check(n == 3 && out[2].lsn == 300, "index returns all records up to a high lsn");
+	check(out[0].timeline == 0 && out[2].timeline == 0,
+		  "records on the root timeline are tagged timeline 0");
 	check(op_walidx_get(0, REL_A, FORK0, 0, 50, out) == 0, "no records below the first lsn");
 	n = op_walidx_get(0, REL_A, FORK0, 1, 200, out);
-	check(n == 1 && out[0] == 150, "per-block separation (block 1 -> [150])");
+	check(n == 1 && out[0].lsn == 150, "per-block separation (block 1 -> [150])");
 	check(op_walidx_get(0, REL_A, FORK0, 9, 1000000, out) == 0, "unindexed block -> empty");
 
 	/* a branch sees its own records plus the parent's, capped at the fork LSN */
@@ -887,6 +889,12 @@ run_walidx_suite(const char *daemon_path, const char *tmpbase)
 	n = op_walidx_get(1, REL_A, FORK0, 0, 1000000, out);
 	/* branch's 400, plus parent's <= branch_lsn 250 (100,200; not 300) */
 	check(n == 3, "branch index reads through to parent capped at the branch lsn");
+	/* merged in ascending LSN order across the ancestry */
+	check(out[0].lsn == 100 && out[1].lsn == 200 && out[2].lsn == 400,
+		  "branch records are merged in ascending LSN order");
+	/* each record is tagged with the timeline it lives on: parent's on 0, branch's on 1 */
+	check(out[0].timeline == 0 && out[1].timeline == 0 && out[2].timeline == 1,
+		  "each record carries its source timeline tag (parent=0, branch=1)");
 
 	client_detach();
 	stop_daemon(dpid);


### PR DESCRIPTION
Phase 2 — the foundation for serving WAL deltas **across branches** from the store. Stacked on #51.

`walidx_get` now returns `PsWalRec` records — each WAL record's LSN tagged with the **timeline it lives on** — merged in ascending LSN order across the ancestry walk.

## Two changes vs the old "uint64 LSN list"
- **Per-record source-timeline tag.** `walidx_get` already walks the timeline ancestry (`tl_walk`); it now records `w.tl` alongside each LSN. A reader can use the tag to fetch each record from the right timeline's shipped WAL on the store — the cross-branch store-served read path (consumer is a later step).
- **Global LSN ordering.** Records were gathered newest-timeline-first (a branch's before its parent's) — not globally sorted. They're now qsorted ascending. This is also a **correctness fix** for `redo_page_asof` across a branch: its base search and delta replay assume ascending LSN order.

Plumbed through the IPC (`PS_OP_WAL_INDEX_GET` returns `PsWalRec[]`; `PS_SHM_VERSION` 6→7), the localsvc accessor, and `redo_page_asof`/`pagestore_redo_page` (which use `recs[i].lsn`; the tag is now available for the follow-up).

## Verified
Standalone daemon suite asserts, across a branch, that records **merge in ascending LSN order** and **each carries its source-timeline tag** (parent=0, branch=1). 136 checks, 0 failed. Full integration test still passes.

## Next (the consumer)
A store-backed XLogReader whose `page_read` fetches WAL pages from the daemon (`wal_read`) per a record's source timeline, so `redo_page_asof` on a branch can replay ancestor deltas it has no local WAL for — using these tags. (Has archive-timing considerations, hence split out.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)