### PR TITLE
Store-backed WAL reader for redo_page_asof (phase 2)

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -560,6 +560,37 @@ pagestore_localsvc_wal_append(uint64 start_lsn, const void *data, uint32 len)
 	ls_exec(ch);
 }
 
+/*
+ * Read up to 'len' bytes of shipped WAL starting at 'start_lsn' from a SPECIFIC
+ * timeline's log on the store (not necessarily this backend's).  Used to serve a
+ * branch's ancestor WAL records for cross-branch redo.  Returns the byte count.
+ */
+int
+pagestore_localsvc_wal_read(uint32 timeline, uint64 start_lsn, uint32 len,
+							void *out)
+{
+	PsChannel  *ch = ls_chan();
+	int			n;
+
+	ch->timeline = timeline;
+	ch->opcode = PS_OP_WAL_READ;
+	ch->req_lsn = start_lsn;
+	ch->datalen = len;
+	ls_exec(ch);
+	n = (int) ch->result;
+	if (n > (int) len)
+		n = (int) len;
+	memcpy(out, ch->data, (size_t) n);
+	return n;
+}
+
+/* This backend's current timeline (0 = main, >0 = a branch). */
+uint32
+pagestore_localsvc_timeline(void)
+{
+	return (uint32) localsvc_timeline;
+}
+
 /* Record in the store that the WAL record at 'lsn' modifies (key, block). */
 void
 pagestore_localsvc_walidx_add(const PageStoreRelKey *key, BlockNumber block,

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -231,6 +231,25 @@ assert "$live_before" "t" "redo_page_asof materializes the block while it is liv
 live_after=$($P -c "SELECT pagestore_redo_page_asof('trunc',0,0,'$tl_after') IS NULL;")
 assert "$live_after" "t" "redo_page_asof returns NULL for a block truncated away as of the LSN (liveness)"
 
+# --- 14. store-backed redo: replay base+deltas from the store's shipped WAL ------
+# With pagestore.redo_wal_from_store on, redo_page_asof reads its WAL records from
+# the daemon's shipped per-timeline log instead of local files -- so a compute with
+# no local WAL (a fresh branch) can materialize a page.  Ship the segment first.
+sw0=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "CREATE TABLE swal(id int, v text) WITH (autovacuum_enabled=off);
+       INSERT INTO swal VALUES (1,'sw_base');
+       CHECKPOINT;" >/dev/null
+$P -c "UPDATE swal SET v='sw_fpi' WHERE id=1;" >/dev/null   # FPI of block 0 after the checkpoint
+$P -c "INSERT INTO swal VALUES (2,'sw_delta');" >/dev/null  # a delta on block 0
+sw1=$($P -c "SELECT pg_current_wal_lsn();")
+$P -c "SELECT pg_switch_wal();" >/dev/null                  # complete the segment -> shipped to the store
+sleep 2
+$P -c "SELECT pagestore_index_wal('$sw0', '$sw1');" >/dev/null
+sw_store=$($P -c "SET pagestore.redo_wal_from_store = on;
+  SELECT position('sw_fpi'::bytea   in pagestore_redo_page_asof('swal',0,0,'$sw1')) > 0
+     AND position('sw_delta'::bytea in pagestore_redo_page_asof('swal',0,0,'$sw1')) > 0;" | tail -1)
+assert "$sw_store" "t" "redo_page_asof replays base+deltas read from the store's shipped WAL (store-backed reader)"
+
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
 exit $fail

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -904,6 +904,10 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		XLogRecord *rec;
 
 		ps_redo_cur_timeline = recs[i].timeline;
+		/* the reader caches a page by (segno,offset) only -- not timeline -- so a
+		 * same-offset page on another timeline would be a false hit; invalidate it
+		 * whenever the source timeline may change (cross-branch redo). */
+		reader->readLen = 0;
 		XLogBeginRead(reader, recs[i].lsn);
 		rec = XLogReadRecord(reader, &errm);
 		if (rec == NULL)
@@ -947,16 +951,22 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	 * at/below lsn.
 	 */
 	{
-		bool		from_store = pagestore_redo_wal_from_store;
 		bool		dead;
 
-		/* the truncate scan walks this compute's own recent WAL (local) */
-		pagestore_redo_wal_from_store = false;
-		ps_redo_cur_timeline = ps_redo_local_timeline;
+		/*
+		 * The truncate scan walks the WAL after the block's last write.  Read it
+		 * from that record's source timeline (an ancestor in cross-branch redo)
+		 * and from the store when store-backed -- so DON'T force local/off here, or
+		 * a no-local-WAL (store-backed) compute would skip the truncate check.
+		 * Invalidate the reader's page cache first since the timeline may differ
+		 * from the record loop above.  (A scan range that itself crosses a branch
+		 * point spans timelines and is a known limitation.)
+		 */
+		ps_redo_cur_timeline = recs[n - 1].timeline;
+		reader->readLen = 0;
 		dead = redo_block_truncated_away(reader, rloc, forknum,
 										 (BlockNumber) blocknum,
 										 (XLogRecPtr) recs[n - 1].lsn, lsn);
-		pagestore_redo_wal_from_store = from_store;
 		if (dead)
 		{
 			XLogReaderFree(reader);
@@ -982,6 +992,10 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		char	   *raw;
 
 		ps_redo_cur_timeline = recs[i].timeline;
+		/* the reader caches a page by (segno,offset) only -- not timeline -- so a
+		 * same-offset page on another timeline would be a false hit; invalidate it
+		 * whenever the source timeline may change (cross-branch redo). */
+		reader->readLen = 0;
 		XLogBeginRead(reader, recs[i].lsn);
 		rec = XLogReadRecord(reader, &errm);
 		if (rec == NULL)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -793,27 +793,49 @@ ps_redo_page_read(XLogReaderState *state, XLogRecPtr targetPagePtr, int reqLen,
  *
  * Cost: a linear pass over (from_lsn, to_lsn].  redo_page_asof is off the read hot
  * path; a daemon-side fork-size-at-lsn index would make this O(1) -- a later step.
+ *
+ * Tri-state so an unreadable scan fails closed rather than passing as "live":
  */
-static bool
+typedef enum
+{
+	REDO_BLOCK_LIVE = 0,		/* scanned cleanly through to_lsn, no truncate */
+	REDO_BLOCK_TRUNCATED,		/* truncated away at/below the block, not re-extended */
+	REDO_BLOCK_SCAN_INCOMPLETE, /* WAL unreadable through to_lsn -- fail closed */
+} RedoBlockLiveness;
+
+static RedoBlockLiveness
 redo_block_truncated_away(XLogReaderState *reader, RelFileLocator rloc,
 						  ForkNumber forknum, BlockNumber block,
 						  XLogRecPtr from_lsn, XLogRecPtr to_lsn)
 {
+	XLogRecPtr	scanned_through;
+
 	if (forknum != MAIN_FORKNUM || from_lsn >= to_lsn)
-		return false;
+		return REDO_BLOCK_LIVE;
 
 	XLogBeginRead(reader, from_lsn);
+	scanned_through = from_lsn;
 	for (;;)
 	{
 		char	   *errm;
 		XLogRecord *rec = XLogReadRecord(reader, &errm);
 
+		/*
+		 * End of readable WAL.  If the read cursor already advanced through to_lsn
+		 * the range was fully scanned and no truncate was found -- the block is
+		 * live.  Otherwise the WAL could not be read through to_lsn (e.g. the
+		 * shipped log has not reached this segment; the archive callback ships only
+		 * completed segments), so a truncate in the unread tail would be silently
+		 * missed: report the scan incomplete and let the caller fail closed.
+		 */
 		if (rec == NULL)
-			break;
+			return scanned_through >= to_lsn ? REDO_BLOCK_LIVE
+				: REDO_BLOCK_SCAN_INCOMPLETE;
+		scanned_through = reader->EndRecPtr;
 		if (reader->ReadRecPtr <= from_lsn)
 			continue;			/* skip the block's own last-write record */
 		if (reader->ReadRecPtr > to_lsn)
-			break;
+			return REDO_BLOCK_LIVE;	/* scanned cleanly past to_lsn, no truncate */
 		if (XLogRecGetRmid(reader) == RM_SMGR_ID &&
 			(XLogRecGetInfo(reader) & ~XLR_INFO_MASK) == XLOG_SMGR_TRUNCATE)
 		{
@@ -822,10 +844,9 @@ redo_block_truncated_away(XLogReaderState *reader, RelFileLocator rloc,
 			if (RelFileLocatorEquals(xlrec->rlocator, rloc) &&
 				(xlrec->flags & SMGR_TRUNCATE_HEAP) &&
 				xlrec->blkno <= block)
-				return true;
+				return REDO_BLOCK_TRUNCATED;
 		}
 	}
-	return false;
 }
 
 /*
@@ -951,7 +972,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	 * at/below lsn.
 	 */
 	{
-		bool		dead;
+		RedoBlockLiveness liveness;
 
 		/*
 		 * The truncate scan walks the WAL after the block's last write.  Read it
@@ -964,10 +985,15 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		 */
 		ps_redo_cur_timeline = recs[n - 1].timeline;
 		reader->readLen = 0;
-		dead = redo_block_truncated_away(reader, rloc, forknum,
-										 (BlockNumber) blocknum,
-										 (XLogRecPtr) recs[n - 1].lsn, lsn);
-		if (dead)
+		liveness = redo_block_truncated_away(reader, rloc, forknum,
+											 (BlockNumber) blocknum,
+											 (XLogRecPtr) recs[n - 1].lsn, lsn);
+		/*
+		 * Fail closed unless the scan proved the block live: a confirmed truncate
+		 * and an incomplete scan (the WAL could not be read through lsn) both mean
+		 * we must not return a possibly-stale FPI for a block that may be gone.
+		 */
+		if (liveness != REDO_BLOCK_LIVE)
 		{
 			XLogReaderFree(reader);
 			pfree(pd);

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -64,6 +64,7 @@ static bool pagestore_route_all = false;
 static bool pagestore_route_user_tablespaces = false;
 static char *pagestore_backend_name = NULL;
 static char *pagestore_walredo_datadir = NULL;
+static bool pagestore_redo_wal_from_store = false;
 
 /* "which" index assigned to our smgr implementation by smgr_register() */
 static int	pagestore_smgr_which = -1;
@@ -755,6 +756,35 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 }
 
 /*
+ * Store-backed WAL page reader for redo.  The records that materialize a page
+ * can live on ancestor timelines (a branch's deltas predate the branch point);
+ * a branch compute may not have that ancestor WAL locally.  This page_read
+ * callback serves a WAL page from the store's shipped per-timeline log when the
+ * record's source timeline (ps_redo_cur_timeline, set per record from the walidx
+ * tag) is not this compute's own, or when pagestore.redo_wal_from_store forces it
+ * (a compute with no local WAL at all); otherwise it reads the local WAL.
+ */
+static uint32 ps_redo_cur_timeline;		/* timeline of the record being read */
+static uint32 ps_redo_local_timeline;	/* this compute's own timeline */
+
+static int
+ps_redo_page_read(XLogReaderState *state, XLogRecPtr targetPagePtr, int reqLen,
+				  XLogRecPtr targetRecPtr, char *readBuf)
+{
+	if (pagestore_redo_wal_from_store ||
+		ps_redo_cur_timeline != ps_redo_local_timeline)
+	{
+		int			n = pagestore_localsvc_wal_read(ps_redo_cur_timeline,
+													(uint64) targetPagePtr,
+													(uint32) reqLen, readBuf);
+
+		return (n >= reqLen) ? reqLen : -1;
+	}
+	return read_local_xlog_page_no_wait(state, targetPagePtr, reqLen,
+										targetRecPtr, readBuf);
+}
+
+/*
  * Liveness: scan local WAL in (from_lsn, to_lsn] for an smgr truncate of
  * (rloc, forknum) down to <= block.  If found, the block was truncated away after
  * its last write and not re-extended, so it is not live as of to_lsn and must not
@@ -852,7 +882,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 
 	pd = palloc0(sizeof(ReadLocalXLogPageNoWaitPrivate));
 	reader = XLogReaderAllocate(wal_segment_size, NULL,
-								XL_ROUTINE(.page_read = &read_local_xlog_page_no_wait,
+								XL_ROUTINE(.page_read = &ps_redo_page_read,
 										   .segment_open = &wal_segment_open,
 										   .segment_close = &wal_segment_close),
 								pd);
@@ -862,6 +892,8 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		pfree(recs);
 		PG_RETURN_NULL();
 	}
+	/* records on ancestor timelines are served from the store's shipped WAL */
+	ps_redo_local_timeline = pagestore_localsvc_timeline();
 	base = palloc(BLCKSZ);
 	page = palloc(BLCKSZ);
 
@@ -871,6 +903,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		char	   *errm;
 		XLogRecord *rec;
 
+		ps_redo_cur_timeline = recs[i].timeline;
 		XLogBeginRead(reader, recs[i].lsn);
 		rec = XLogReadRecord(reader, &errm);
 		if (rec == NULL)
@@ -913,15 +946,26 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	 * materialize a stale page for it.  recs[n - 1].lsn is the block's newest record
 	 * at/below lsn.
 	 */
-	if (redo_block_truncated_away(reader, rloc, forknum, (BlockNumber) blocknum,
-								  (XLogRecPtr) recs[n - 1].lsn, lsn))
 	{
-		XLogReaderFree(reader);
-		pfree(pd);
-		pfree(recs);
-		pfree(base);
-		pfree(page);
-		PG_RETURN_NULL();
+		bool		from_store = pagestore_redo_wal_from_store;
+		bool		dead;
+
+		/* the truncate scan walks this compute's own recent WAL (local) */
+		pagestore_redo_wal_from_store = false;
+		ps_redo_cur_timeline = ps_redo_local_timeline;
+		dead = redo_block_truncated_away(reader, rloc, forknum,
+										 (BlockNumber) blocknum,
+										 (XLogRecPtr) recs[n - 1].lsn, lsn);
+		pagestore_redo_wal_from_store = from_store;
+		if (dead)
+		{
+			XLogReaderFree(reader);
+			pfree(pd);
+			pfree(recs);
+			pfree(base);
+			pfree(page);
+			PG_RETURN_NULL();
+		}
 	}
 
 	/* replay: base image, then every record after it, through the helper */
@@ -937,6 +981,7 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 		uint32		firstpage;
 		char	   *raw;
 
+		ps_redo_cur_timeline = recs[i].timeline;
 		XLogBeginRead(reader, recs[i].lsn);
 		rec = XLogReadRecord(reader, &errm);
 		if (rec == NULL)
@@ -1147,6 +1192,16 @@ _PG_init(void)
 							   PGC_SUSET,
 							   0,
 							   NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("pagestore.redo_wal_from_store",
+							 "Read redo_page_asof's WAL records from the store's shipped WAL, not local files.",
+							 "Ancestor-timeline records always come from the store; this forces it for "
+							 "all records, so a compute with no local WAL (a fresh branch) can replay deltas.",
+							 &pagestore_redo_wal_from_store,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
 
 	MarkGUCPrefixReserved("pagestore");
 

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -156,6 +156,9 @@ extern int	pagestore_localsvc_walidx_count(const PageStoreRelKey *key,
 extern int	pagestore_localsvc_walidx_get(const PageStoreRelKey *key,
 										  BlockNumber block, uint64 lsn_max,
 										  PsWalRec *out, int maxn);
+extern int	pagestore_localsvc_wal_read(uint32 timeline, uint64 start_lsn,
+										uint32 len, void *out);
+extern uint32 pagestore_localsvc_timeline(void);
 extern void pagestore_localsvc_obj_write(uint32 klass, const PageStoreRelKey *key,
 										 BlockNumber block, const void *page);
 extern void pagestore_localsvc_obj_read(uint32 klass, const PageStoreRelKey *key,


### PR DESCRIPTION
Phase 2 — closes branch-aware store-served WAL. The **consumer** of #52's timeline tags. Stacked on #52.

`redo_page_asof` can now read its base FPI and delta records from the store's shipped **per-timeline** WAL instead of local files. This is the cross-branch read path: a branch's deltas can predate the branch point and live on an ancestor timeline whose WAL a branch compute has no local copy of; and a compute with no local WAL at all can still materialize a page.

## Change
- `backend_localsvc.c`: `pagestore_localsvc_wal_read(timeline, lsn, len)` reads a byte range from a **specific** timeline's shipped log (`PS_OP_WAL_READ`); `pagestore_localsvc_timeline()` exposes this compute's own timeline.
- `pagestore.c`: `ps_redo_page_read` — an XLogReader `page_read` callback that serves a WAL page from the store (`wal_read`) when the record's source timeline (`ps_redo_cur_timeline`, set per record from the walidx tag) is not this compute's own, or when `pagestore.redo_wal_from_store` forces it for all records. The XLogReader does the de-framing (page headers); the callback just supplies pages. `redo_page_asof` sets the per-record timeline around each `XLogBeginRead`; the truncate-liveness scan is pinned to local (recent truncates aren't shipped yet).

## Verified (integration test)
Ship a segment carrying a block's FPI + delta, then with `redo_wal_from_store` on, `redo_page_asof` materializes the page **entirely from the store's shipped WAL**.

## The arc
`walidx_get` tags records with their timeline (#52) → redo now fetches each from that timeline's store WAL (this). A branch compute can replay ancestor deltas from the shared store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)