### PR TITLE
[codex] Document branch PostgreSQL milestone plan

### DIFF
--- a/contrib/pagestore/BRANCH_POSTGRES_MILESTONES.md
+++ b/contrib/pagestore/BRANCH_POSTGRES_MILESTONES.md
@@ -1,0 +1,364 @@
+# Branch PostgreSQL milestone plan
+
+This document defines the milestone plan for evolving `contrib/pagestore` from a
+branchable relation-page prototype into a complete branch-capable PostgreSQL
+system.
+
+The plan is intentionally staged.  Relation-page branching should be made
+correct first.  Bootable branch computes, SLRU, pg_control, retention, GC, and
+production operations should be added only after the core storage and WAL/redo
+semantics are stable.
+
+## Current high-level assessment
+
+Current implementation is closest to a branchable relation-storage prototype:
+
+- timeline metadata exists;
+- branch reads can fall back through parent timelines;
+- relation pages are stored as versioned page images;
+- WAL shipping, WAL indexing, and single-page redo are partially implemented;
+- object-class keys, locking, SLRU, pg_control, and store-backed WAL work have
+  been explored in the stacked PRs.
+
+It is not yet a complete branch PostgreSQL system.
+
+The largest remaining gaps are:
+
+- timeline/WAL/redo correctness across branch boundaries;
+- durable or rebuildable WAL indexes;
+- SLRU transaction-status lifecycle;
+- pg_control bootstrap and restore protocol;
+- startup/recovery for a branch compute;
+- branch retention, compaction, and garbage collection;
+- operational tooling and production hardening.
+
+## Milestone overview
+
+```text
+M0  current PR stack cleanup
+M1  branchable relation storage MVP
+M2  timeline WAL and redo correctness
+M3  durable layer and manifest foundation
+M4  bootable branch compute MVP
+M5  branch lifecycle, retention, and GC
+M6  production hardening
+```
+
+Recommended commitment boundary:
+
+- commit near-term engineering to M0-M2;
+- design M3 in parallel because it affects storage durability;
+- do not resume SLRU or pg_control production work until M4 design is explicit.
+
+## M0: current PR stack cleanup
+
+### Goal
+
+Turn the current stacked PRs into a reviewable, mergeable main route.
+
+### Scope
+
+Keep and complete:
+
+- `#46`: read path, timeline walk, wal-redo client, `redo_page_asof`;
+- `#47`: object-class discriminator in `PsKey`;
+- `#48`: per-shard and map locking;
+- `#51`: drop/truncate liveness;
+- `#52`: timeline-tagged, LSN-ordered `walidx_get`.
+
+Keep as draft or redesign:
+
+- `#49`: SLRU on the store;
+- `#50`: pg_control on the store;
+- `#53`: broad store-backed WAL reader.
+
+### Required stack shape
+
+The healthy near-term branch should be:
+
+```text
+#46 -> #47 -> #48 -> #51' -> #52'
+```
+
+`#51` and `#52` should be rebased or recreated on top of `#48`, not left behind
+frozen SLRU and pg_control PRs.
+
+### Non-goals
+
+M0 should not include:
+
+- SLRU read-from-store production semantics;
+- pg_control production restore;
+- full store-backed WAL reader across all object classes;
+- object-storage tiering;
+- branch compute bootstrap.
+
+### Completion criteria
+
+- The mergeable PR chain does not depend on draft PRs.
+- `#46` handles base FPI selection before redo-chain caps.
+- wal-redo helper I/O is interrupt-safe enough not to strand helpers or locks.
+- ancestry WAL replay order is correct for relation pages.
+- `#48` preserves `IMMEDSYNC` and map-lock invariants.
+- `#51/#52` are reviewable as relation-page correctness work.
+
+## M1: branchable relation storage MVP
+
+### Goal
+
+Provide a reliable storage-level branch for relation forks.
+
+This milestone answers: can pagestore maintain branch-isolated relation pages,
+without yet booting a separate PostgreSQL compute from that branch?
+
+### Scope
+
+- Metadata-only branch creation.
+- Branch-local relation writes.
+- Parent fallback reads at the branch point.
+- Relation fork support for heap, index, toast, FSM, and VM forks.
+- Branch-aware fork size, extend, truncate, and drop behavior.
+- Relation-page materialization at a target LSN.
+- Durable branch metadata across daemon restart.
+
+### Non-goals
+
+M1 should not include:
+
+- branch compute startup;
+- SLRU bootstrapping from the store;
+- pg_control restore;
+- full PostgreSQL crash recovery on a branch;
+- remote object storage;
+- production GC.
+
+### Completion criteria
+
+- A child branch can read parent data visible at the fork point.
+- Parent and child writes do not contaminate each other.
+- Child branch can overwrite, extend, truncate, and drop relation forks without
+  corrupting parent visibility.
+- Daemon restart preserves branch metadata and relation-page visibility.
+- Relation fork reads either return the correct visible page or fail closed.
+
+## M2: timeline WAL and redo correctness
+
+### Goal
+
+Make relation-page materialization correct across timelines and WAL sources.
+
+This milestone answers: can pagestore reconstruct relation pages as of a target
+LSN in a branch-aware way?
+
+### Scope
+
+- Durable or reliably rebuildable per-page WAL index.
+- Source timeline attached to each WAL index record.
+- Replay-safe global order across timeline ancestry.
+- Newest usable FPI selection before applying redo-chain caps.
+- Drop/truncate liveness scans for relation pages.
+- Relation-page store-backed WAL reader only.
+- WAL reader cache invalidation when source or timeline changes.
+- Fail-closed behavior when WAL is missing, incomplete, or ambiguous.
+
+### Non-goals
+
+M2 should not include:
+
+- SLRU WAL replay or SLRU read-from-store;
+- pg_control restore;
+- generic object bootstrapping;
+- SPDK-specific object semantics beyond contracts used by included code;
+- helper pooling or performance optimization except where required for safety.
+
+### Completion criteria
+
+- `redo_page_asof(timeline, relation, fork, block, lsn)` returns the correct page
+  or fails closed.
+- A hot page with long total history remains readable when a recent FPI bounds
+  the replay chain.
+- Parent and branch WAL records are replayed in the correct order.
+- A truncate or drop between the base image and target LSN is honored.
+- Missing local or shipped WAL does not produce a stale page.
+- Switching from local WAL to store WAL cannot reuse a stale reader cache page.
+
+## M3: durable layer and manifest foundation
+
+### Goal
+
+Move pagestore from prototype in-memory indexes and append-only segments toward a
+durable layer/manifest model that can support long-running branches.
+
+This milestone answers: can pagestore recover its storage metadata and compacted
+state safely after restart or crash?
+
+### Scope
+
+- Manifest as the source of truth for layer metadata.
+- Image layer descriptor encode/decode.
+- Layer map rebuilt from manifest.
+- Memtable flush into immutable image layers.
+- Manifest state transitions for add, seal, replace, delete, and remove.
+- Local compaction replacement protocol.
+- Local GC protocol.
+- `PsKey.klass` persistence through layer and manifest metadata.
+- Crash-safe manifest replay.
+
+### Non-goals
+
+M3 should not include:
+
+- remote object storage as the primary storage tier;
+- remote range reads;
+- production branch-drop GC across all object classes;
+- delta layers unless relation-page redo already requires them in a bounded
+  local form.
+
+### Completion criteria
+
+- Daemon restart can rebuild the layer map from durable manifest metadata.
+- Compaction can install replacement layers without exposing partial results.
+- Interrupted compaction or GC is recoverable.
+- Branch-visible parent layers are not removed while still referenced.
+- Relation-page reads remain correct through memtable, image layers, and compacted
+  layers.
+
+## M4: bootable branch compute MVP
+
+### Goal
+
+Allow a PostgreSQL compute to start on a branch timeline and run normal read/write
+workloads.
+
+This milestone answers: can a branch become an independently bootable PostgreSQL
+compute, not just a storage view?
+
+### Scope
+
+- Branch compute bootstrap protocol.
+- pg_control restore design and implementation.
+- SLRU lifecycle design and implementation.
+- WAL restore from pagestore.
+- Startup/recovery flow for a branch timeline.
+- Branch-local transaction status handling.
+- Safe inheritance of parent transaction status at the fork point.
+- Atomic and durable restore of control files and required bootstrap state.
+
+### Non-goals
+
+M4 should not include:
+
+- multiple active computes sharing the same writable branch;
+- production-grade branch deletion and retention;
+- remote object storage eviction;
+- cross-version upgrade support.
+
+### Completion criteria
+
+- A branch can be created at a consistent LSN.
+- A new compute can start on that branch timeline.
+- The branch compute can run ordinary table reads and writes.
+- Restarting the branch compute preserves consistency.
+- pg_control restore is atomic and directory-durable.
+- SLRU read, write, truncate, existence, and cache semantics are complete enough
+  for normal transaction processing.
+- Missing or incomplete bootstrap state fails closed rather than silently
+  starting an inconsistent branch.
+
+## M5: branch lifecycle, retention, and GC
+
+### Goal
+
+Support long-lived branches with safe deletion, retention, compaction, and
+reclamation.
+
+This milestone answers: can pagestore manage a branch graph over time without
+leaking storage or deleting still-visible history?
+
+### Scope
+
+- Persistent branch graph metadata.
+- Branch drop.
+- Retention horizon calculation.
+- Active read tracking.
+- WAL retention across branch ancestry.
+- SLRU/control retention once M4 exists.
+- Layer GC across branches.
+- Compaction across branch-visible history.
+- Consistency checker for branch graph, manifest, layer, and WAL metadata.
+
+### Non-goals
+
+M5 should not include:
+
+- full multi-tenant product API;
+- automatic remote-tier cost optimization;
+- cross-cluster replication unless explicitly required by product scope.
+
+### Completion criteria
+
+- Dropping a branch eventually reclaims its exclusive data.
+- Parent data referenced by child branches is not reclaimed prematurely.
+- GC and compaction preserve historical reads required by retention.
+- Crashes during branch drop, GC, or compaction are recoverable.
+- Tooling can inspect and validate branch graph, manifest, layers, WAL, and
+  object-class metadata.
+
+## M6: production hardening
+
+### Goal
+
+Turn the branch-capable prototype into an operationally usable system.
+
+### Scope
+
+- Performance tuning and benchmarking.
+- wal-redo helper pooling or a redo service.
+- Observability: metrics, logs, tracing, and debug endpoints.
+- Failpoint and crash-injection tests.
+- Corruption detection and repair tooling.
+- Upgrade and migration story.
+- POSIX, SPDK, and object-tier contract parity.
+- Object storage tiering and local cache policy.
+- Branch create, drop, list, inspect, and repair APIs.
+
+### Completion criteria
+
+- Long-running stress tests are stable.
+- Crash/restart/failover tests cover the critical branch lifecycle.
+- Performance envelope is known and documented.
+- Operational metrics can explain latency, redo work, branch retention, GC,
+  compaction, and storage growth.
+- Repair tooling can diagnose common inconsistencies without manual data surgery.
+- POSIX, SPDK, and object-tier backends provide equivalent correctness contracts.
+
+## Suggested execution strategy
+
+### Near-term engineering focus
+
+Work only on M0-M2 until the relation-page route is stable.
+
+Recommended order:
+
+```text
+1. Rebase or recreate #51/#52 on top of #48.
+2. Finish #46 review issues.
+3. Finish #47/#48 implementation completeness issues.
+4. Merge the healthy relation-page correctness chain.
+5. Split #53 and keep only relation-page store-backed WAL in the first revival.
+```
+
+### Parallel design work
+
+Design M3-M4 in documents before resuming broad implementation:
+
+- M3 layer/manifest durability and compaction protocol;
+- M4 SLRU lifecycle;
+- M4 pg_control bootstrap and restore protocol.
+
+### Work to avoid for now
+
+Do not keep adding fixes to SLRU, pg_control, and broad store-backed WAL inside
+the current stack.  Those paths cross PostgreSQL recovery, transaction-status,
+and critical-section invariants; they need explicit protocols before more code is
+useful.

--- a/contrib/pagestore/READ_PATH_PR_STACK_PLAN.md
+++ b/contrib/pagestore/READ_PATH_PR_STACK_PLAN.md
@@ -1,0 +1,342 @@
+# pagestore read-path PR stack plan
+
+This document records the current plan for the stacked pagestore read-path PRs
+`#46` through `#53` after review.  The goal is to preserve the parts of the
+route that are structurally sound, stop accumulating semantic debt in the parts
+that are not ready, and define clear criteria for bringing the deferred work
+back.
+
+## Summary decision
+
+Keep the core read-path direction, but narrow the mergeable scope.
+
+The following direction is worth preserving:
+
+- timeline-aware WAL indexing;
+- relation-page `redo_page_asof`;
+- object-class key discrimination as a storage seam;
+- per-shard locking once its synchronization invariants are complete;
+- liveness and timeline ordering fixes that make relation-page redo correct.
+
+The following work should remain draft or experimental until its semantics are
+redesigned:
+
+- store-backed SLRU reads and writes;
+- pg_control mirroring and restore;
+- broad store-backed WAL reading that mixes relation redo, SLRU/control object
+  semantics, SPDK foundness, manifest replay, and branch-boundary liveness in a
+  single PR.
+
+This is not a rejection of the overall read-path route.  It is a scope boundary:
+relation-page redo and timeline-aware WAL lookup should become reliable first;
+SLRU, pg_control, and broader object bootstrapping need separate lifecycle
+contracts before they become mergeable production paths.
+
+## PR stack state
+
+The current stack is:
+
+```text
+#46 feat/pagestore-readpath
+  -> #47 feat/pagestore-objclass
+  -> #48 feat/pagestore-pershard-lock
+  -> #49 feat/pagestore-slru
+  -> #50 feat/pagestore-control
+  -> #51 feat/pagestore-liveness
+  -> #52 feat/pagestore-branchwal
+  -> #53 feat/pagestore-storewal
+```
+
+Because these PRs are stacked, an unresolved semantic problem in an early or
+middle layer expands the review surface of every later PR.  The plan below keeps
+that dependency chain short enough for review and correctness reasoning.
+
+## Keep and finish
+
+### PR #46: relation read path and `redo_page_asof`
+
+Keep this PR as the base of the route.
+
+Remaining work should focus on correctness of relation-page materialization:
+
+- locate the newest usable base full-page image before applying any history cap;
+- make wal-redo helper writes interruptible, not just reads;
+- sort ancestry WAL records by the replay order required by timeline and LSN;
+- keep helper lifetime cleanup robust under errors and interrupts.
+
+Mergeability criterion:
+
+- a relation-page read at a target LSN either returns the correct as-of page or
+  fails closed;
+- hot pages with long history remain usable when a recent FPI bounds the replay
+  chain;
+- branch ancestry does not change replay order incorrectly;
+- query cancel and statement timeout cannot strand helper processes or locks.
+
+### PR #47: object-class discriminator in `PsKey`
+
+Keep this PR.
+
+The review feedback here points to implementation completeness rather than a
+wrong direction.  The `klass` seam is necessary if relation pages, SLRU pages,
+pg_control, and future object classes share storage infrastructure without key
+collisions.
+
+Mergeability criterion:
+
+- `klass` participates in all key comparisons and lookups;
+- manifest encode/decode preserves `klass`;
+- on-disk and shared-memory format changes are gated or rejected safely;
+- non-relation object writes use a real monotonic version, not arbitrary payload
+  bytes.
+
+### PR #48: per-shard and map locking
+
+Keep this PR, but do not let it hide synchronization exceptions.
+
+Remaining work:
+
+- object writes that walk or update timeline state must take the map lock;
+- `IMMEDSYNC` must remain serialized with shard writes, including SPDK storage;
+- shard selection must use the final request key and class.
+
+Mergeability criterion:
+
+- single-shard and multi-shard behavior are equivalent for correctness;
+- immediate sync cannot race with shard-local writes;
+- object requests are routed and locked by their actual key class.
+
+### PR #51: drop/truncate liveness
+
+Keep this PR.
+
+Current review found no major issues.  This PR is part of making
+`redo_page_asof` fail correctly when a relation block was dropped or truncated.
+
+Mergeability criterion:
+
+- liveness checks preserve relation-page as-of semantics;
+- unreadable WAL ranges do not silently imply that a block is still live.
+
+### PR #52: timeline-tagged, LSN-ordered `walidx_get`
+
+Keep this PR.
+
+Current review found no major issues.  This PR directly supports the core route:
+relation-page redo needs timeline-aware records returned in a replay-safe order.
+
+Mergeability criterion:
+
+- returned WAL records are tagged with their source timeline;
+- records across ancestry are ordered for replay, not merely grouped by ancestry;
+- callers can distinguish parent and branch records when applying liveness or
+  source-specific WAL reads.
+
+## Freeze and redesign
+
+### PR #49: SLRU on the store
+
+Keep as draft.  Do not continue treating this as a mergeable production path
+until the SLRU lifecycle is designed explicitly.
+
+Reason:
+
+The review feedback is not concentrated in one function.  It points to missing
+SLRU object semantics across the lifecycle:
+
+- write mirroring must not depend on unstable buffers or arbitrary payload LSNs;
+- critical-section SLRU writes cannot perform fallible store I/O, but dropping
+  the mirror can make the store permanently stale;
+- truncation and segment deletion need durable tombstone semantics;
+- existence probes such as `SimpleLruDoesPhysicalPageExist()` must consult the
+  same source of truth as reads;
+- cached local SLRU pages must be revalidated before store-backed reads trust
+  old copies;
+- hook error paths must not rethrow while SLRU slots or bank locks are in states
+  that require core cleanup.
+
+Required design before revival:
+
+- define SLRU object identity and version ordering;
+- define write, truncate, and existence semantics together;
+- define whether mirroring is synchronous, deferred, or log-shipped;
+- define how critical-section writes are queued without losing durability;
+- define cache invalidation and stale local page handling;
+- define interrupt behavior for hooks called while core SLRU locks or slots are
+  in transitional states.
+
+Acceptable near-term scope:
+
+- leave mirror-only or read-from-store code behind an experimental flag;
+- keep tests that demonstrate known limitations;
+- avoid presenting store-backed SLRU as complete until truncate, existence, and
+  critical-section semantics are implemented.
+
+### PR #50: pg_control on the store
+
+Keep as draft.  Do not treat the current hook-based pg_control mirroring as a
+mergeable production path.
+
+Reason:
+
+pg_control is on a conservative recovery-critical path.  The remaining feedback
+is about production invariants:
+
+- mirroring currently happens inside checkpoint or shutdown critical sections;
+- mirrored pg_control durability is not fully specified;
+- restore should write atomically using a temporary file and rename, not truncate
+  an existing control file in place;
+- restore must fsync the containing directory;
+- any previously installed control-file hook must be preserved.
+
+Required design before revival:
+
+- move fallible mirror work out of checkpoint/shutdown critical sections;
+- define a checkpoint-completion or async shipper handoff;
+- define the durability contract for the mirrored control object;
+- make restore atomic and directory-durable;
+- define hook chaining behavior.
+
+Acceptable near-term scope:
+
+- keep prototype code documented as non-production;
+- keep restore tooling only if it fails safely and does not claim durability
+  beyond what it implements.
+
+### PR #53: store-backed WAL reader
+
+Keep as draft and split before revival.
+
+Reason:
+
+This PR currently combines too many invariants in one review surface:
+
+- local WAL and store WAL source switching;
+- WAL reader cache invalidation across source and timeline changes;
+- fail-closed truncate scans when shipped WAL is incomplete;
+- branch-boundary liveness semantics;
+- manifest `klass` replay for non-relation objects;
+- SPDK object-read foundness;
+- SLRU read/write hook safety inherited from `#49`;
+- pg_control/object concerns inherited from `#50`.
+
+The relation-page part of store-backed WAL is valuable, but it should be reviewed
+without SLRU/control/object lifecycle debt attached to it.
+
+Required split:
+
+- relation-page store-backed WAL reader;
+- manifest/object foundness fixes;
+- SPDK foundness contract;
+- SLRU-specific store-backed reads and writes;
+- pg_control-specific restore/mirror work.
+
+Mergeability criterion for the relation-page split:
+
+- switching between local and store WAL invalidates all relevant reader caches;
+- timeline changes cannot reuse a WAL page from the wrong source;
+- truncate scans fail closed if WAL cannot be read through the requested LSN;
+- branch-boundary scans respect parent and branch visibility separately;
+- no SLRU or pg_control production semantics are included in the same PR.
+
+## Recommended near-term sequence
+
+### Step 1: stabilize the mergeable base
+
+Finish `#46`, `#47`, `#48`, `#51`, and `#52` as the narrow relation-page read
+path.
+
+The intended capability at the end of this step is:
+
+```text
+relation page + target timeline + target LSN
+  -> timeline-aware WAL index
+  -> bounded base FPI selection
+  -> ordered WAL redo
+  -> liveness/drop/truncate check
+  -> correct page or fail-closed result
+```
+
+Do not include SLRU, pg_control, or broad object bootstrapping in this acceptance
+scope.
+
+### Step 2: split `#53`
+
+Extract a small relation-page store-backed WAL reader PR.
+
+This PR should depend only on the stable base and should not contain SLRU or
+pg_control changes.  It should prove the source-switching and timeline-switching
+contracts for WAL reads first.
+
+### Step 3: write SLRU design before reviving `#49`
+
+Before more SLRU implementation work, write down the object lifecycle:
+
+```text
+SLRU write
+  -> version assignment
+  -> mirror or deferred mirror
+  -> truncate tombstone
+  -> existence check
+  -> read fallback
+  -> cache revalidation
+```
+
+No single hook should be considered sufficient until the whole chain is defined.
+
+### Step 4: write pg_control design before reviving `#50`
+
+Before more pg_control implementation work, write down the critical-section-safe
+mirror and restore protocol:
+
+```text
+control file update
+  -> critical-section-safe handoff
+  -> durable mirror object
+  -> atomic restore file creation
+  -> directory fsync
+  -> hook chaining
+```
+
+### Step 5: reintroduce object bootstrapping one object class at a time
+
+After relation-page store-backed WAL is correct, reintroduce object classes in
+separate PRs:
+
+- SLRU;
+- pg_control;
+- future object classes.
+
+Each object class should have its own lifecycle, fallback, existence, truncation,
+and durability rules.
+
+## Non-goals for the current mergeable path
+
+The current mergeable path should not attempt to solve:
+
+- complete SLRU bootstrapping from store;
+- pg_control production restore;
+- object-storage tiering or remote range reads;
+- SPDK object-read foundness beyond the contracts required by included code;
+- all object classes sharing one generic read hook without per-class lifecycle
+  semantics.
+
+## Review interpretation rule
+
+A review thread should be treated as architecture-level feedback, not a local
+bug, when fixing it requires defining behavior across more than one of these
+boundaries:
+
+- WAL source and timeline;
+- object version ordering;
+- truncation or tombstone semantics;
+- existence checks;
+- critical-section behavior;
+- PostgreSQL lock or slot cleanup;
+- durability or crash recovery;
+- local cache freshness;
+- SPDK and POSIX backend contract parity.
+
+`#49`, `#50`, and the broad form of `#53` crossed several of these boundaries at
+once.  That is why they should remain draft until their scope is split and their
+invariants are documented.


### PR DESCRIPTION
## Summary

- Add a read-path PR stack plan for #46-#53, including which PRs should be kept, frozen, or split.
- Add a macro milestone plan for evolving pagestore toward branch-capable PostgreSQL.
- Define near-term focus on relation-page branching before SLRU, pg_control, and bootable branch compute work resumes.

## Validation

- Not run; documentation-only change.