### PR TITLE
M4 design: SLRU + pg_control on the store (gates #49/#50)

### DIFF
--- a/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
@@ -1,0 +1,148 @@
+# pg_control on the store: mirror + bootstrap-restore protocol (M4)
+
+Status: design. The PR-#50 prototype (`feat/pagestore-control`) mirrors
+`pg_control` to the store on every write and restores it before startup with a
+freestanding tool. Review (5 P1 / 11 P2) showed the prototype runs fallible work
+inside recovery-critical sections and restores non-atomically. Per the read-path
+stack plan, store-backed pg_control stays frozen until this protocol is defined.
+This document is the gate; implementation resumes against it.
+
+## Scope
+
+`pg_control` (`global/pg_control`) is the cluster's root metadata: state, latest
+checkpoint location and its redo pointer, timeline, system identifier, and format
+versions. A bootable branch compute needs a consistent `pg_control` to start
+recovery on its branch timeline. Putting it on the store lets a branch compute
+bootstrap that metadata without a pre-seeded local file.
+
+In scope: the control object model, a critical-section-safe mirror protocol, and
+an atomic, durable restore protocol. Out of scope: full branch startup/recovery
+flow (the rest of M4) and retention (M5).
+
+## Why the prototype is not mergeable
+
+`pg_control` sits on the most conservative recovery path. The prototype hooks
+`UpdateControlFile()` and calls `obj_write(PS_KLASS_CONTROL, ...)` synchronously.
+The findings reduce to five invariants the prototype breaks:
+
+1. **Critical-section mirroring.** `UpdateControlFile()` is called from
+   `CreateCheckPoint()` / shutdown inside a critical section. A fallible daemon
+   write there means a daemon error becomes a PANIC, and the prototype itself
+   documents this as a "known prototype risk."
+2. **Version key.** The control object is written at a fixed block with a version
+   derived like any object; repeated control writes must carry a real changing
+   version so a later image cannot compare equal-or-lower and be dropped.
+3. **Mirror durability.** A mirrored control image is only useful for restore if it
+   is durable on the store before the corresponding local control update is relied
+   on; the prototype does not define or enforce that ordering.
+4. **Atomic restore.** The restore tool truncates the existing `global/pg_control`
+   in place and rewrites it. A crash mid-write leaves a torn control file -- the
+   one file that must never be torn.
+5. **Restore durability + correctness.** Restore does not fsync the containing
+   directory, may read a different timeline than the one written, and leaks the
+   claimed daemon channel on some exit paths. An installed prior control-file hook
+   is also clobbered rather than chained.
+
+## Control object model
+
+- **Identity.** `PsKey{ klass = PS_KLASS_CONTROL, spcOid = dbOid = relNumber =
+  forkNum = 0, block = 0 }`. `pg_control` fits in one block
+  (`PG_CONTROL_FILE_SIZE <= BLCKSZ`); the image is zero-padded to `BLCKSZ`.
+- **Version order.** Each mirror write gets a daemon-assigned monotonic version
+  (`max across ancestry + 1`), never derived from the control bytes. The control
+  file's own `time`/checkpoint fields are not a reliable version source (fix for
+  finding 2).
+- **Timeline.** The control object is written on the writer's timeline; restore
+  reads it from the timeline the branch was created on (see restore).
+
+## Mirror protocol (critical-section-safe)
+
+The core decision: **the mirror never does fallible work inside a checkpoint or
+shutdown critical section.** `UpdateControlFile()`'s synchronous `obj_write` is
+removed.
+
+### Checkpoint-completion handoff
+
+- `UpdateControlFile()` (and the hook) under the critical section only **records
+  intent**: it snapshots the just-written `ControlFileData` image (or just the
+  fact that pg_control changed, plus the bytes) into a small in-process slot. This
+  is allocation-free and cannot fail the checkpoint.
+- The actual `obj_write` of the control image runs at a **post-critical-section
+  point**: a checkpoint-completion callback (after `CreateCheckPoint()` leaves its
+  critical section) or a dedicated async shipper. Shutdown's final control update
+  ships from the shutdown path *after* the critical section, before the postmaster
+  exits.
+- **Durability contract.** The mirrored control object is shipped and the daemon
+  `sync`'d before the checkpoint is considered complete-on-store. Restore-after-
+  crash therefore sees a control image no newer than the last completed checkpoint
+  -- exactly the recovery contract local `pg_control` already provides. Define the
+  ordering as: local `update_controlfile(..., do_sync=true)` first (unchanged),
+  then store mirror + store sync; a compute that restores from the store replays
+  from the mirrored checkpoint's redo pointer.
+- **Hook chaining.** Installing `control_file_write_hook` must save and call any
+  previously installed hook (fix for finding 5), so the seam composes with other
+  extensions.
+
+## Restore protocol (bootstrap before shared_preload)
+
+`pg_control` is read and CRC-checked *before* `shared_preload_libraries` load, so
+the module's hooks cannot serve it. A compute with no local control file restores
+it with the freestanding `pagestore_control_restore` tool, then starts normally.
+
+The restore must be atomic and durable:
+
+1. **Select the timeline.** Restore reads the control object from the timeline the
+   branch was created on (passed in / derived from branch metadata), not a fixed
+   timeline 0 (fix: "Read the same timeline that pg_control was written to").
+2. **Fetch + verify.** Read the control object via the daemon channel; verify the
+   CRC of the restored `ControlFileData` before writing anything. A bad/missing
+   image fails closed (the compute does not start on a half-known cluster).
+3. **Write atomically.** Write to `global/pg_control.tmp`, fsync it, then
+   `rename()` over `global/pg_control` -- never truncate the live file in place
+   (fix for finding 4). `rename` within a directory is atomic.
+4. **Directory-durable.** fsync the `global/` directory after the rename so the
+   rename survives a crash (fix: "Make restored pg_control durable in its
+   directory").
+5. **Release the channel.** Release the claimed daemon channel on every exit path,
+   including error paths (fix: "Release the daemon channel before exiting").
+6. **Fail closed, claim no durability it lacks.** If any step fails, leave no
+   `global/pg_control` (or the pre-existing one) and exit non-zero; the tool never
+   reports success for a torn or unverified control file.
+
+## Sequencing
+
+1. Core: `UpdateControlFile()` records intent only; add the post-critical-section
+   ship point (checkpoint-completion callback / shutdown ship) and chain the hook.
+2. Daemon/module: control object monotonic version + `sync` before
+   checkpoint-complete-on-store.
+3. Tool: atomic temp+rename, dir fsync, timeline selection, channel release,
+   CRC-verify, fail-closed.
+4. Tests: the acceptance scenarios below.
+
+## Acceptance criteria
+
+- No fallible store I/O runs inside a checkpoint or shutdown critical section; a
+  daemon error during mirror cannot PANIC the checkpoint.
+- After a completed checkpoint, the store's control image carries that
+  checkpoint's redo pointer, and is durable (survives daemon restart).
+- Restore produces a CRC-valid `global/pg_control` via temp+rename with a fsync'd
+  directory; a crash mid-restore never leaves a torn control file.
+- A compute with no local `pg_control` restores from the correct branch timeline
+  and boots into recovery from the mirrored checkpoint.
+- A previously installed control-file write hook still runs after ours.
+- Every restore exit path releases the daemon channel; failure exits non-zero and
+  leaves no half-written control file.
+
+## Open questions
+
+- Whether to ship the control image from the checkpointer's completion callback or
+  a separate shipper process, and how that interacts with the SLRU drain
+  (SLRU_ON_STORE_DESIGN.md) which also drains at checkpoint.
+- How branch metadata names the timeline restore should read (depends on the
+  branch-create protocol in the rest of M4).
+- Whether `pg_control` restore and the first WAL restore for a branch should be one
+  tool or two.
+
+See also: the read-path PR stack plan and the branch-PostgreSQL milestone plan
+(M4: bootable branch compute), and [SLRU_ON_STORE_DESIGN.md] for the sibling SLRU
+protocol.

--- a/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
@@ -55,16 +55,24 @@ The findings reduce to five invariants the prototype breaks:
   build (the default 8192 satisfies it). Splitting `pg_control` across multiple
   object blocks is possible but deferred -- it buys nothing on real deployments.
   Where it fits, the image is zero-padded to `BLCKSZ`.
-- **Version order (branch-aware).** Like SLRU objects (see SLRU_ON_STORE_DESIGN.md),
-  the control object's version is a WAL LSN supplied by the writer and stored
-  verbatim -- not a daemon `max+1` counter (not comparable to a branch cutoff) and
-  not the control bytes. The LSN must be the **checkpoint/control-update record's
-  LSN** (`ProcLastRecPtr`, i.e. `ControlFile->checkPoint`), **not the redo pointer**
-  (`checkPointCopy.redo`). For an online checkpoint that spans a branch point the
-  redo pointer is *before* the branch while the checkpoint completion record is
-  *after* it; versioning by redo would make that just-completed checkpoint visible
-  to an as-of-branch read and restore the branch to post-branch state. Versioning by
-  the checkpoint record's own LSN keeps restore-as-of-branch-point (below) correct.
+- **Version order (branch-aware), per update.** Like SLRU objects (see
+  SLRU_ON_STORE_DESIGN.md), the control object's version is a WAL LSN supplied by the
+  writer and stored verbatim -- not a daemon `max+1` counter (not comparable to a
+  branch cutoff) and not the control bytes. It must be the **LSN of the specific
+  update that caused this control write**, passed in by the caller, **not
+  `ControlFile->checkPoint` unconditionally** and **not the redo pointer**
+  (`checkPointCopy.redo`):
+  - a checkpoint writes its **checkpoint-record LSN** (`ProcLastRecPtr`). The redo
+    pointer would be wrong -- for an online checkpoint spanning a branch point the
+    redo is *before* the branch but the completion record is *after* it, so an
+    as-of-branch read would restore post-branch state.
+  - non-checkpoint updates that do **not** advance `ControlFile->checkPoint` --
+    `CreateEndOfRecoveryRecord()` (sets `minRecoveryPoint` to its `recptr`),
+    promotion (`DB_IN_PRODUCTION`), and `minRecoveryPoint`/backup-state writes --
+    must pass **their own** LSN. Versioning these by the stale `checkPoint` LSN
+    would let an as-of-branch restore pick control bytes written after the branch,
+    or coalesce distinct updates at one version. So the write hook takes an explicit
+    `update_lsn` from each `UpdateControlFile()` caller.
 - **Timeline.** The control object is written on the writer's timeline; restore
   reads it as of the branch-creation LSN on the branch's ancestry (see restore).
 
@@ -97,6 +105,16 @@ removed.
   ordering as: local `update_controlfile(..., do_sync=true)` first (unchanged),
   then store mirror + store sync; a compute that restores from the store replays
   from the mirrored checkpoint's redo pointer.
+- **Gate WAL recycling on mirror durability.** A checkpoint removes old WAL (using
+  the new `RedoRecPtr`) *after* `UpdateControlFile()`. If the store mirror/sync
+  fails or lags after the local control file advanced, the store's control image is
+  older -- its redo pointer needs WAL that the completed local checkpoint is now
+  free to recycle, so a branch restoring that image would have a valid old
+  `pg_control` but **missing WAL**. The store mirror is therefore on the checkpoint
+  durability path for branch purposes: a failed/blocked store sync must **block old
+  WAL removal** (hold the retention horizon), or the pagestore must explicitly
+  retain shipped WAL back to the **last mirrored control redo pointer**, never past
+  it. WAL the store has not caught up to is not recyclable from the branch's view.
 - **Hook chaining.** Installing `control_file_write_hook` must save and call any
   previously installed hook (fix for finding 5), so the seam composes with other
   extensions.
@@ -144,13 +162,17 @@ The restore must be atomic and durable:
    smaller-block builds.
 2. Core: `UpdateControlFile()` records intent only; add the post-critical-section
    ship point (checkpoint-completion callback / shutdown ship) and chain the hook.
-3. Daemon/module: control object version = the checkpoint **record** LSN
-   (writer-supplied, not the redo pointer) + `sync` before checkpoint-complete-on-
-   store. Same-process completion callback, or a shared-memory handoff slot if a
-   separate shipper is used.
-4. Tool: atomic temp+rename **at `PG_CONTROL_FILE_SIZE`**, dir fsync,
+3. Core: each `UpdateControlFile()` caller passes the **LSN of its own update**
+   (checkpoint-record LSN, end-of-recovery `recptr`, promotion LSN, ...); the hook
+   versions the object by that, never `ControlFile->checkPoint` unconditionally.
+4. Daemon/module: store the writer-supplied version + `sync` before
+   checkpoint-complete-on-store; same-process completion callback, or a
+   shared-memory handoff slot if a separate shipper is used.
+5. Core: gate old-WAL removal / retention horizon on the store mirror being durable
+   to the last mirrored control redo (a failed store sync blocks WAL recycling).
+6. Tool: atomic temp+rename **at `PG_CONTROL_FILE_SIZE`**, dir fsync,
    **as-of-branch-LSN** read, channel release, CRC-verify, fail-closed.
-5. Tests: the acceptance scenarios below.
+7. Tests: the acceptance scenarios below.
 
 ## Acceptance criteria
 
@@ -161,6 +183,12 @@ The restore must be atomic and durable:
   durable (survives daemon restart).
 - An online checkpoint whose completion record is after a branch point is **not**
   restored by that branch (versioned by the record LSN, not the redo pointer).
+- A non-checkpoint control update (end-of-recovery, promotion) after a branch point
+  is not restored by that branch -- it is versioned by its own update LSN, not the
+  stale `checkPoint` LSN.
+- A branch restored from the store never has a control redo pointer whose WAL was
+  recycled: store-mirror durability gates old-WAL removal (or WAL is retained back
+  to the last mirrored control redo).
 - Restore produces a CRC-valid `global/pg_control` of exactly
   `PG_CONTROL_FILE_SIZE` bytes via temp+rename with a fsync'd directory; a crash
   mid-restore never leaves a torn control file, and length-checking tools accept it.

--- a/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
@@ -46,14 +46,23 @@ The findings reduce to five invariants the prototype breaks:
 ## Control object model
 
 - **Identity.** `PsKey{ klass = PS_KLASS_CONTROL, spcOid = dbOid = relNumber =
-  forkNum = 0, block = 0 }`. `pg_control` fits in one block
-  (`PG_CONTROL_FILE_SIZE <= BLCKSZ`); the image is zero-padded to `BLCKSZ`.
-- **Version order.** Each mirror write gets a daemon-assigned monotonic version
-  (`max across ancestry + 1`), never derived from the control bytes. The control
-  file's own `time`/checkpoint fields are not a reliable version source (fix for
-  finding 2).
+  forkNum = 0, block = 0 }`.
+- **Block-size requirement.** `PG_CONTROL_FILE_SIZE` is fixed at 8192 bytes, but
+  `BLCKSZ` can be 1024/2048/4096 on `--with-blocksize` builds, where a single
+  object block cannot hold the control file. The model therefore **requires
+  `BLCKSZ >= PG_CONTROL_FILE_SIZE`** for control mirroring: the mirror/restore code
+  asserts it and the module refuses to enable control-on-store on a smaller-block
+  build (the default 8192 satisfies it). Splitting `pg_control` across multiple
+  object blocks is possible but deferred -- it buys nothing on real deployments.
+  Where it fits, the image is zero-padded to `BLCKSZ`.
+- **Version order (branch-aware).** Like SLRU objects (see SLRU_ON_STORE_DESIGN.md),
+  the control object's version is the **WAL LSN at the time of the control update**
+  supplied by the writer, stored verbatim -- not a daemon `max+1` counter (which
+  would not be comparable to a branch cutoff) and not the control bytes. Using the
+  update's checkpoint redo LSN makes restore-as-of-branch-point (below) well
+  defined.
 - **Timeline.** The control object is written on the writer's timeline; restore
-  reads it from the timeline the branch was created on (see restore).
+  reads it as of the branch-creation LSN on the branch's ancestry (see restore).
 
 ## Mirror protocol (critical-section-safe)
 
@@ -91,9 +100,16 @@ it with the freestanding `pagestore_control_restore` tool, then starts normally.
 
 The restore must be atomic and durable:
 
-1. **Select the timeline.** Restore reads the control object from the timeline the
-   branch was created on (passed in / derived from branch metadata), not a fixed
-   timeline 0 (fix: "Read the same timeline that pg_control was written to").
+1. **Read as of the branch point, not just the source timeline.** Selecting the
+   source/parent timeline is not enough: if the parent advances after the branch is
+   created, its *latest* control object carries a checkpoint redo pointer **beyond
+   the branch point**, and restoring that would start the branch compute recovering
+   from WAL/state it must not see. Restore must read the control object **as of the
+   branch-creation LSN** -- either through the new branch timeline (whose ancestry
+   walk already caps the parent at the branch LSN) or as an explicit as-of read of
+   the source timeline at that LSN. The LSN-based control version (above) is what
+   makes this cap meaningful (fixes "read pg_control at the branch point"; supersedes
+   the earlier "just pick the source timeline" wording).
 2. **Fetch + verify.** Read the control object via the daemon channel; verify the
    CRC of the restored `ControlFileData` before writing anything. A bad/missing
    image fails closed (the compute does not start on a half-known cluster).
@@ -111,13 +127,15 @@ The restore must be atomic and durable:
 
 ## Sequencing
 
-1. Core: `UpdateControlFile()` records intent only; add the post-critical-section
+1. Module: assert `BLCKSZ >= PG_CONTROL_FILE_SIZE`; refuse control-on-store on
+   smaller-block builds.
+2. Core: `UpdateControlFile()` records intent only; add the post-critical-section
    ship point (checkpoint-completion callback / shutdown ship) and chain the hook.
-2. Daemon/module: control object monotonic version + `sync` before
+3. Daemon/module: control object LSN version (writer-supplied) + `sync` before
    checkpoint-complete-on-store.
-3. Tool: atomic temp+rename, dir fsync, timeline selection, channel release,
+4. Tool: atomic temp+rename, dir fsync, **as-of-branch-LSN** read, channel release,
    CRC-verify, fail-closed.
-4. Tests: the acceptance scenarios below.
+5. Tests: the acceptance scenarios below.
 
 ## Acceptance criteria
 
@@ -127,8 +145,11 @@ The restore must be atomic and durable:
   checkpoint's redo pointer, and is durable (survives daemon restart).
 - Restore produces a CRC-valid `global/pg_control` via temp+rename with a fsync'd
   directory; a crash mid-restore never leaves a torn control file.
-- A compute with no local `pg_control` restores from the correct branch timeline
-  and boots into recovery from the mirrored checkpoint.
+- A compute with no local `pg_control` restores the control image **as of its
+  branch-creation LSN** -- even if the parent advanced afterward -- and boots into
+  recovery from the checkpoint visible at the branch point, never a later one.
+- Control-on-store is refused on a `BLCKSZ < PG_CONTROL_FILE_SIZE` build rather
+  than silently truncating the image.
 - A previously installed control-file write hook still runs after ours.
 - Every restore exit path releases the daemon channel; failure exits non-zero and
   leaves no half-written control file.

--- a/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
@@ -85,19 +85,23 @@ removed.
 ### Checkpoint-completion handoff
 
 - `UpdateControlFile()` (and the hook) under the critical section only **records
-  intent**: it snapshots the just-written `ControlFileData` image plus the
-  checkpoint-record LSN into a small handoff slot (in-process for a same-process
-  shipper, shared memory for a separate one -- see below). This is allocation-free
-  and cannot fail the checkpoint.
-- The actual `obj_write` of the control image runs at a **post-critical-section
-  point**. The recorded-intent slot is read by whoever ships it, so it must be
+  intent**: it appends the just-written `ControlFileData` image plus that update's
+  LSN to an **ordered handoff queue**, not a single replaceable slot. Two control
+  updates can occur before the shipper drains (e.g. an end-of-recovery update then a
+  `DB_IN_PRODUCTION` update); a single slot would coalesce them to the latest image,
+  so a branch point between their LSNs could restore post-branch control bytes. Each
+  LSN-versioned image must survive until shipped -- hence a queue (with backpressure
+  if it fills), or a synchronous drain at each post-critical point. Appending is
+  allocation-free and cannot fail the checkpoint.
+- The actual `obj_write` of each queued image runs at a **post-critical-section
+  point**, in LSN order. The queue is read by whoever ships it, so it must be
   reachable by that process: either ship from a **same-process completion callback**
   (after `CreateCheckPoint()` leaves its critical section, in the checkpointer/
   startup process that recorded it) -- the default -- or, if a **separate** shipper
-  process is used, put the handoff slot in **shared memory**, never a private
-  per-process buffer (a private slot would be invisible to the shipper and the
-  image would be dropped). Shutdown's final control update ships from the shutdown
-  path *after* the critical section, before the postmaster exits.
+  process is used, put the queue in **shared memory**, never a private per-process
+  buffer (a private queue would be invisible to the shipper and the images dropped).
+  Shutdown's final control update ships from the shutdown path *after* the critical
+  section, before the postmaster exits.
 - **Durability contract.** The mirrored control object is shipped and the daemon
   `sync`'d before the checkpoint is considered complete-on-store. Restore-after-
   crash therefore sees a control image no newer than the last completed checkpoint
@@ -105,19 +109,25 @@ removed.
   ordering as: local `update_controlfile(..., do_sync=true)` first (unchanged),
   then store mirror + store sync; a compute that restores from the store replays
   from the mirrored checkpoint's redo pointer.
-- **Gate WAL recycling on mirror durability.** A checkpoint removes old WAL (using
-  the new `RedoRecPtr`) *after* `UpdateControlFile()`. If the store mirror/sync
-  fails or lags after the local control file advanced, the store's control image is
-  older -- its redo pointer needs WAL that the completed local checkpoint is now
-  free to recycle, so a branch restoring that image would have a valid old
-  `pg_control` but **missing WAL**. The store mirror is therefore on the checkpoint
-  durability path for branch purposes: a failed/blocked store sync must **block old
-  WAL removal** (hold the retention horizon), or the pagestore must explicitly
-  retain shipped WAL back to the **last mirrored control redo pointer**, never past
-  it. WAL the store has not caught up to is not recyclable from the branch's view.
+- **Gate WAL recycling on mirror durability, with a durable horizon.** A checkpoint
+  removes old WAL (using the new `RedoRecPtr`) *after* `UpdateControlFile()`. If the
+  store mirror/sync fails or lags after the local control file advanced, the store's
+  control image is older -- its redo pointer needs WAL that the completed local
+  checkpoint is now free to recycle, so a branch restoring that image would have a
+  valid old `pg_control` but **missing WAL**. So shipped-WAL retention must never
+  drop below the redo pointer of the control image **currently on the store**.
+  - **The horizon lives on the store and must be durable.** An in-memory "block WAL
+    removal" flag is lost if the process crashes after the local `pg_control` sync
+    but before the store mirror finishes -- on restart, ordinary checkpoint/
+    restartpoint cleanup would recycle WAL using the newer local redo while the store
+    still holds the older control image. The pagestore daemon (itself durable) is the
+    authority: it retains shipped WAL at/above the redo pointer of the control object
+    it currently holds, and refuses to GC below it, independent of what the
+    transient local compute decided. Branch restore uses the store's WAL + the
+    store's control, both governed by this one durable horizon, so the crash window
+    cannot strand a branch.
 - **Hook chaining.** Installing `control_file_write_hook` must save and call any
-  previously installed hook (fix for finding 5), so the seam composes with other
-  extensions.
+  previously installed hook, so the seam composes with other extensions.
 
 ## Restore protocol (bootstrap before shared_preload)
 
@@ -160,16 +170,18 @@ The restore must be atomic and durable:
 
 1. Module: assert `BLCKSZ >= PG_CONTROL_FILE_SIZE`; refuse control-on-store on
    smaller-block builds.
-2. Core: `UpdateControlFile()` records intent only; add the post-critical-section
-   ship point (checkpoint-completion callback / shutdown ship) and chain the hook.
+2. Core: `UpdateControlFile()` appends to an **ordered handoff queue** only; add the
+   post-critical-section ship point (checkpoint-completion callback / shutdown ship,
+   draining in LSN order) and chain the hook.
 3. Core: each `UpdateControlFile()` caller passes the **LSN of its own update**
    (checkpoint-record LSN, end-of-recovery `recptr`, promotion LSN, ...); the hook
    versions the object by that, never `ControlFile->checkPoint` unconditionally.
 4. Daemon/module: store the writer-supplied version + `sync` before
    checkpoint-complete-on-store; same-process completion callback, or a
-   shared-memory handoff slot if a separate shipper is used.
-5. Core: gate old-WAL removal / retention horizon on the store mirror being durable
-   to the last mirrored control redo (a failed store sync blocks WAL recycling).
+   shared-memory queue if a separate shipper is used.
+5. Daemon: a **durable** retention horizon -- the daemon retains shipped WAL at/above
+   the redo of the control image it currently holds and refuses to GC below it,
+   surviving a compute crash between local sync and store mirror.
 6. Tool: atomic temp+rename **at `PG_CONTROL_FILE_SIZE`**, dir fsync,
    **as-of-branch-LSN** read, channel release, CRC-verify, fail-closed.
 7. Tests: the acceptance scenarios below.
@@ -186,9 +198,11 @@ The restore must be atomic and durable:
 - A non-checkpoint control update (end-of-recovery, promotion) after a branch point
   is not restored by that branch -- it is versioned by its own update LSN, not the
   stale `checkPoint` LSN.
+- Two control updates between drains are both preserved (ordered queue), so a branch
+  point between their LSNs restores the correct pre-branch image, not the later one.
 - A branch restored from the store never has a control redo pointer whose WAL was
-  recycled: store-mirror durability gates old-WAL removal (or WAL is retained back
-  to the last mirrored control redo).
+  recycled -- the daemon's **durable** retention horizon holds even across a compute
+  crash between local `pg_control` sync and the store mirror.
 - Restore produces a CRC-valid `global/pg_control` of exactly
   `PG_CONTROL_FILE_SIZE` bytes via temp+rename with a fsync'd directory; a crash
   mid-restore never leaves a torn control file, and length-checking tools accept it.

--- a/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
@@ -56,11 +56,15 @@ The findings reduce to five invariants the prototype breaks:
   object blocks is possible but deferred -- it buys nothing on real deployments.
   Where it fits, the image is zero-padded to `BLCKSZ`.
 - **Version order (branch-aware).** Like SLRU objects (see SLRU_ON_STORE_DESIGN.md),
-  the control object's version is the **WAL LSN at the time of the control update**
-  supplied by the writer, stored verbatim -- not a daemon `max+1` counter (which
-  would not be comparable to a branch cutoff) and not the control bytes. Using the
-  update's checkpoint redo LSN makes restore-as-of-branch-point (below) well
-  defined.
+  the control object's version is a WAL LSN supplied by the writer and stored
+  verbatim -- not a daemon `max+1` counter (not comparable to a branch cutoff) and
+  not the control bytes. The LSN must be the **checkpoint/control-update record's
+  LSN** (`ProcLastRecPtr`, i.e. `ControlFile->checkPoint`), **not the redo pointer**
+  (`checkPointCopy.redo`). For an online checkpoint that spans a branch point the
+  redo pointer is *before* the branch while the checkpoint completion record is
+  *after* it; versioning by redo would make that just-completed checkpoint visible
+  to an as-of-branch read and restore the branch to post-branch state. Versioning by
+  the checkpoint record's own LSN keeps restore-as-of-branch-point (below) correct.
 - **Timeline.** The control object is written on the writer's timeline; restore
   reads it as of the branch-creation LSN on the branch's ancestry (see restore).
 
@@ -73,14 +77,19 @@ removed.
 ### Checkpoint-completion handoff
 
 - `UpdateControlFile()` (and the hook) under the critical section only **records
-  intent**: it snapshots the just-written `ControlFileData` image (or just the
-  fact that pg_control changed, plus the bytes) into a small in-process slot. This
-  is allocation-free and cannot fail the checkpoint.
+  intent**: it snapshots the just-written `ControlFileData` image plus the
+  checkpoint-record LSN into a small handoff slot (in-process for a same-process
+  shipper, shared memory for a separate one -- see below). This is allocation-free
+  and cannot fail the checkpoint.
 - The actual `obj_write` of the control image runs at a **post-critical-section
-  point**: a checkpoint-completion callback (after `CreateCheckPoint()` leaves its
-  critical section) or a dedicated async shipper. Shutdown's final control update
-  ships from the shutdown path *after* the critical section, before the postmaster
-  exits.
+  point**. The recorded-intent slot is read by whoever ships it, so it must be
+  reachable by that process: either ship from a **same-process completion callback**
+  (after `CreateCheckPoint()` leaves its critical section, in the checkpointer/
+  startup process that recorded it) -- the default -- or, if a **separate** shipper
+  process is used, put the handoff slot in **shared memory**, never a private
+  per-process buffer (a private slot would be invisible to the shipper and the
+  image would be dropped). Shutdown's final control update ships from the shutdown
+  path *after* the critical section, before the postmaster exits.
 - **Durability contract.** The mirrored control object is shipped and the daemon
   `sync`'d before the checkpoint is considered complete-on-store. Restore-after-
   crash therefore sees a control image no newer than the last completed checkpoint
@@ -113,9 +122,13 @@ The restore must be atomic and durable:
 2. **Fetch + verify.** Read the control object via the daemon channel; verify the
    CRC of the restored `ControlFileData` before writing anything. A bad/missing
    image fails closed (the compute does not start on a half-known cluster).
-3. **Write atomically.** Write to `global/pg_control.tmp`, fsync it, then
-   `rename()` over `global/pg_control` -- never truncate the live file in place
-   (fix for finding 4). `rename` within a directory is atomic.
+3. **Write atomically, at the fixed file size.** Write exactly the first
+   `PG_CONTROL_FILE_SIZE` (8192) bytes of the object image -- **not** the
+   `BLCKSZ`-padded object -- to `global/pg_control.tmp`, fsync it, then `rename()`
+   over `global/pg_control` (never truncate the live file in place). On a
+   `BLCKSZ > 8192` build the object carries trailing pad that must be dropped, or
+   tools that check the control-file length (pg_rewind, backup verification) reject
+   the data directory. `rename` within a directory is atomic.
 4. **Directory-durable.** fsync the `global/` directory after the rename so the
    rename survives a crash (fix: "Make restored pg_control durable in its
    directory").
@@ -131,10 +144,12 @@ The restore must be atomic and durable:
    smaller-block builds.
 2. Core: `UpdateControlFile()` records intent only; add the post-critical-section
    ship point (checkpoint-completion callback / shutdown ship) and chain the hook.
-3. Daemon/module: control object LSN version (writer-supplied) + `sync` before
-   checkpoint-complete-on-store.
-4. Tool: atomic temp+rename, dir fsync, **as-of-branch-LSN** read, channel release,
-   CRC-verify, fail-closed.
+3. Daemon/module: control object version = the checkpoint **record** LSN
+   (writer-supplied, not the redo pointer) + `sync` before checkpoint-complete-on-
+   store. Same-process completion callback, or a shared-memory handoff slot if a
+   separate shipper is used.
+4. Tool: atomic temp+rename **at `PG_CONTROL_FILE_SIZE`**, dir fsync,
+   **as-of-branch-LSN** read, channel release, CRC-verify, fail-closed.
 5. Tests: the acceptance scenarios below.
 
 ## Acceptance criteria
@@ -142,9 +157,13 @@ The restore must be atomic and durable:
 - No fallible store I/O runs inside a checkpoint or shutdown critical section; a
   daemon error during mirror cannot PANIC the checkpoint.
 - After a completed checkpoint, the store's control image carries that
-  checkpoint's redo pointer, and is durable (survives daemon restart).
-- Restore produces a CRC-valid `global/pg_control` via temp+rename with a fsync'd
-  directory; a crash mid-restore never leaves a torn control file.
+  checkpoint's redo pointer, is versioned by the checkpoint **record** LSN, and is
+  durable (survives daemon restart).
+- An online checkpoint whose completion record is after a branch point is **not**
+  restored by that branch (versioned by the record LSN, not the redo pointer).
+- Restore produces a CRC-valid `global/pg_control` of exactly
+  `PG_CONTROL_FILE_SIZE` bytes via temp+rename with a fsync'd directory; a crash
+  mid-restore never leaves a torn control file, and length-checking tools accept it.
 - A compute with no local `pg_control` restores the control image **as of its
   branch-creation LSN** -- even if the parent advanced afterward -- and boots into
   recovery from the checkpoint visible at the branch point, never a later one.

--- a/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/PGCONTROL_ON_STORE_DESIGN.md
@@ -62,17 +62,28 @@ The findings reduce to five invariants the prototype breaks:
   update that caused this control write**, passed in by the caller, **not
   `ControlFile->checkPoint` unconditionally** and **not the redo pointer**
   (`checkPointCopy.redo`):
-  - a checkpoint writes its **checkpoint-record LSN** (`ProcLastRecPtr`). The redo
-    pointer would be wrong -- for an online checkpoint spanning a branch point the
-    redo is *before* the branch but the completion record is *after* it, so an
-    as-of-branch read would restore post-branch state.
+  - a checkpoint writes its **checkpoint-record END LSN** -- the value `XLogInsert()`
+    *returned* for the checkpoint record (`recptr`), not `ProcLastRecPtr`, which is
+    the record's **start**. A branch cutoff that falls between the record's start and
+    end would otherwise restore a control image for a record not fully in the
+    branch's WAL stream. (`ControlFile->checkPoint` itself stays the start pointer;
+    only the object *version* uses the end.) The redo pointer is likewise wrong --
+    it precedes the branch while the completion record follows it.
   - non-checkpoint updates that do **not** advance `ControlFile->checkPoint` --
     `CreateEndOfRecoveryRecord()` (sets `minRecoveryPoint` to its `recptr`),
     promotion (`DB_IN_PRODUCTION`), and `minRecoveryPoint`/backup-state writes --
-    must pass **their own** LSN. Versioning these by the stale `checkPoint` LSN
-    would let an as-of-branch restore pick control bytes written after the branch,
-    or coalesce distinct updates at one version. So the write hook takes an explicit
+    must pass **their own** LSN. Versioning these by the stale `checkPoint` LSN would
+    let an as-of-branch restore pick control bytes written after the branch, or
+    coalesce distinct updates at one version. So the write hook takes an explicit
     `update_lsn` from each `UpdateControlFile()` caller.
+  - **promotion has no inserted record**: reaching `DB_IN_PRODUCTION` sets
+    `ControlFile->state` and calls `UpdateControlFile()` after recovery cleanup with
+    no WAL record at that point. Its `update_lsn` must be a **durable end-of-log LSN
+    captured after promotion cleanup** (the current insert position, which is `>=`
+    all replayed WAL), or an explicit promotion marker record must be emitted to
+    carry the LSN. Falling back to the previous checkpoint/`minRecoveryPoint` LSN is
+    wrong -- it would make the `DB_IN_PRODUCTION` image visible to an as-of-branch
+    cut taken before the state transition, or coalesce it with earlier control bytes.
 - **Timeline.** The control object is written on the writer's timeline; restore
   reads it as of the branch-creation LSN on the branch's ancestry (see restore).
 
@@ -90,9 +101,17 @@ removed.
   updates can occur before the shipper drains (e.g. an end-of-recovery update then a
   `DB_IN_PRODUCTION` update); a single slot would coalesce them to the latest image,
   so a branch point between their LSNs could restore post-branch control bytes. Each
-  LSN-versioned image must survive until shipped -- hence a queue (with backpressure
-  if it fills), or a synchronous drain at each post-critical point. Appending is
-  allocation-free and cannot fail the checkpoint.
+  LSN-versioned image must survive until shipped.
+- **The in-critical enqueue must never block or fail.** It runs inside the
+  checkpoint/shutdown critical section, so it cannot apply backpressure when the
+  store shipper is stalled -- blocking there would hang, and erroring would PANIC,
+  the very critical section this design keeps fallible-free. The queue must
+  therefore **pre-reserve capacity for every control write that can occur between
+  two mandatory drains** (a small, bounded count: checkpoint + the handful of
+  recovery/promotion/backup updates), so the append is always a guaranteed
+  non-blocking slot; alternatively, drain-before-entry guarantees a free slot. All
+  backpressure/draining happens only at the post-critical ship points, never inside
+  the critical section. Appending is allocation-free and cannot fail the checkpoint.
 - The actual `obj_write` of each queued image runs at a **post-critical-section
   point**, in LSN order. The queue is read by whoever ships it, so it must be
   reachable by that process: either ship from a **same-process completion callback**
@@ -170,12 +189,15 @@ The restore must be atomic and durable:
 
 1. Module: assert `BLCKSZ >= PG_CONTROL_FILE_SIZE`; refuse control-on-store on
    smaller-block builds.
-2. Core: `UpdateControlFile()` appends to an **ordered handoff queue** only; add the
-   post-critical-section ship point (checkpoint-completion callback / shutdown ship,
-   draining in LSN order) and chain the hook.
-3. Core: each `UpdateControlFile()` caller passes the **LSN of its own update**
-   (checkpoint-record LSN, end-of-recovery `recptr`, promotion LSN, ...); the hook
-   versions the object by that, never `ControlFile->checkPoint` unconditionally.
+2. Core: `UpdateControlFile()` appends to an **ordered, pre-reserved handoff queue**
+   (capacity for every in-critical control write between drains, so the enqueue never
+   blocks/fails in the critical section); add the post-critical ship point
+   (checkpoint-completion callback / shutdown ship, draining in LSN order) and chain
+   the hook.
+3. Core: each `UpdateControlFile()` caller passes the **LSN of its own update** --
+   checkpoint **record-end** LSN (the `XLogInsert()` return, not `ProcLastRecPtr`),
+   end-of-recovery `recptr`, and for promotion a durable **end-of-log LSN captured
+   after cleanup** (or a marker record); never `ControlFile->checkPoint`.
 4. Daemon/module: store the writer-supplied version + `sync` before
    checkpoint-complete-on-store; same-process completion callback, or a
    shared-memory queue if a separate shipper is used.
@@ -194,12 +216,16 @@ The restore must be atomic and durable:
   checkpoint's redo pointer, is versioned by the checkpoint **record** LSN, and is
   durable (survives daemon restart).
 - An online checkpoint whose completion record is after a branch point is **not**
-  restored by that branch (versioned by the record LSN, not the redo pointer).
+  restored by that branch; the image is versioned by the checkpoint **record-end**
+  LSN, so a branch cut between the record's start and end also excludes it.
 - A non-checkpoint control update (end-of-recovery, promotion) after a branch point
-  is not restored by that branch -- it is versioned by its own update LSN, not the
-  stale `checkPoint` LSN.
+  is not restored by that branch -- it is versioned by its own update LSN (promotion
+  by a durable end-of-log LSN, since it inserts no record), not the stale
+  `checkPoint` LSN.
 - Two control updates between drains are both preserved (ordered queue), so a branch
   point between their LSNs restores the correct pre-branch image, not the later one.
+- A stalled store shipper never blocks or PANICs a checkpoint/shutdown: the
+  in-critical enqueue uses pre-reserved capacity and never applies backpressure.
 - A branch restored from the store never has a control redo pointer whose WAL was
   recycled -- the daemon's **durable** retention horizon holds even across a compute
   crash between local `pg_control` sync and the store mirror.

--- a/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
@@ -68,9 +68,10 @@ The seed is a **base snapshot + forward replay** (the same base-image-plus-redo
 pattern relation pages use), not replay into empty segments. At branch creation (or
 first start of the branch compute):
 
-- **Base snapshot.** Start from a **consistent SLRU segment snapshot at a checkpoint
-  `C <= L`** -- the parent's actual `pg_xact` / `pg_multixact` / commit-ts segment
-  contents as of `C`. WAL alone is not enough: an xid committed *before* `C` but
+- **Base snapshot.** Start from a **consistent SLRU segment snapshot with a proven
+  cutoff `C <= L`** -- the parent's actual `pg_xact` / `pg_multixact` / commit-ts
+  segment contents as of `C` (see "`C` is not the checkpoint redo LSN" below for how
+  `C` is established). WAL alone is not enough: an xid committed *before* `C` but
   still within the retained clog/multixact range has **no** record in `(C, L]`
   (`CheckPointCLOG()` / `SimpleLruWriteAll()` only flush pages, `CLOG_TRUNCATE` only
   removes them), so replaying into empty segments would leave its status unset and
@@ -111,7 +112,7 @@ first start of the branch compute):
 
 Why this dissolves the round-1/2/3 findings:
 
-- The base is a consistent checkpoint image and everything after it is per-update
+- The base is a consistent as-of-`C` image and everything after it is per-update
   WAL, so there is no flushed-page coalescing and no single-image-answers-as-of-`L`
   problem.
 - The result's "version" is intrinsic -- base at `C` plus exactly the WAL through
@@ -126,7 +127,8 @@ Why this dissolves the round-1/2/3 findings:
   before `L` but ends after it is not part of the as-of-`L` state (same rule
   `redo_page_asof` already applies for relation pages).
 - multixact needs both `offsets` and `members` replayed together to a consistent
-  point; commit-ts only if `track_commit_timestamp` was on in the parent.
+  point; commit-ts is reconstructed for whatever intervals `track_commit_timestamp`
+  was on, per the `XLOG_PARAMETER_CHANGE` records the applier replays.
 - Fail closed: if either the base snapshot at `C` or the parent WAL across `(C, L]`
   is unavailable on the store, branch creation fails rather than seeding partial or
   zeroed status -- a half-known clog must never boot.

--- a/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
@@ -15,9 +15,28 @@ transaction-status state (clog, commit-ts, multixact) it has no local copy of,
 and lets a writer's SLRU updates become visible to other computes of the same
 branch.
 
+**M4 covers only the WAL-logged, branch-relevant SLRUs: `pg_xact` (clog),
+`pg_multixact/{offsets,members}`, and `pg_commit_ts`.** The rest are explicitly
+out of scope for M4, for two concrete reasons surfaced in review:
+
+- **Non-WAL truncation.** `pg_subtrans`, `pg_notify`, and the serializable SLRU
+  (`pg_serial`) truncate during checkpoint/cleanup with **no truncate WAL record**,
+  so there is no LSN to version a tombstone with (see truncation). The in-scope
+  three all truncate via WAL (`XLOG_*_TRUNCATE`-style records), giving a real LSN.
+- **Page-number width.** `SimpleLru` page numbers are `int64`, and `pg_notify`'s
+  queue page is unbounded `int64`, but the pagestore object `block` key is
+  `uint32`. The in-scope three have page numbers bounded by the 32-bit xid /
+  multixact-id space, so they fit `uint32`; `pg_notify` does not. Supporting
+  int64-pageno SLRUs requires widening the object key first (out of scope here).
+
+Also out of scope for M4: these are transient/derivable (`pg_subtrans` is rebuilt,
+`pg_notify`/`pg_serial` are not needed to read a branch's transaction status).
+
 In scope: identity/versioning, the write/mirror protocol, truncation, existence
 probes, the read path and cache coherence, and interrupt/lock safety. Out of
-scope: cross-branch SLRU retention/GC (M5) and any SLRU-specific compaction.
+scope: cross-branch SLRU retention/GC (M5), SLRU-specific compaction, and the
+non-WAL/int64 SLRUs above (need a per-SLRU truncate-version source and a wider
+object key before they can be added).
 
 ## Why the prototype is not mergeable
 
@@ -61,18 +80,23 @@ to seven lifecycle questions the prototype answers unsafely or not at all:
   block = pageno }`, `spcOid = dbOid = forkNum = 0`. `slru_klass_id(Dir)` maps a
   stable small integer per SLRU directory (`pg_xact` = 1, `pg_multixact/offsets`
   = 2, ...). The mapping is fixed and versioned; adding an SLRU appends an id.
-- **Version order (branch-aware).** The store resolves branch reads by walking
-  timeline ancestry and capping parent versions at the branch-creation LSN
-  (`read_through`). An SLRU object version must therefore be comparable to that
-  cap, so the daemon-local `max+1` counter the relation prototype uses is **wrong
-  for objects**: a parent SLRU write that happens *after* a branch is created still
-  gets a small counter value, compares below the branch LSN, and leaks post-branch
-  parent transaction status into the branch. Instead the **writer supplies the
-  version = the WAL insert LSN captured under the SLRU bank lock at write time**,
-  and the daemon stores that value verbatim (no daemon-assigned counter for
-  objects). The LSN is cluster-global, so versions are monotonic, globally ordered
-  across backends, and directly comparable to the branch cutoff -- branch ancestry
-  visibility is then correct, and the read cutoff for objects is this LSN.
+- **Version order (branch-aware), captured at dirty time.** The store resolves
+  branch reads by walking timeline ancestry and capping parent versions at the
+  branch-creation LSN (`read_through`). An SLRU object version must be comparable to
+  that cap, so the daemon-local `max+1` counter the relation prototype uses is
+  **wrong for objects**: a parent SLRU write after a branch is created still gets a
+  small counter value, compares below the branch LSN, and leaks post-branch parent
+  status into the branch. The version is therefore the **WAL LSN of the change that
+  dirtied the page** -- recorded **per slot when the buffer is dirtied**, not the
+  LSN read at physical-write time. Physical writes happen later at
+  checkpoint/eviction, where there is no meaningful WAL LSN for the logical change;
+  capturing a flush-time LSN would tag pre-branch contents with a post-branch LSN
+  and hide data the branch should see. For clog the dirtying LSN is the commit
+  record's LSN (`TransactionIdSetTreeStatus`'s `lsn`, already plumbed to
+  `SlruSharedData.group_lsn` for clog); SLRUs without group-lsn tracking need an
+  equivalent per-page "dirtied at" LSN added. The daemon stores the supplied LSN
+  verbatim (no daemon counter for objects); it is cluster-global, monotonic,
+  globally ordered across backends, and is the branch read cutoff.
 - **Read returns the version.** `obj_read` / `PS_OP_READ_AT` currently return only
   page bytes plus status/result; they must also return the resolved object version
   (LSN) so the read hook can compare it against a cached local page (see cache
@@ -89,14 +113,19 @@ PANIC-safe in a commit critical section, so it is removed from the hot write pat
 ### Deferred mirror queue (shared memory)
 
 - The write hook's only job under the bank lock is to **stage** the dirty page into
-  a **shared-memory** queue: the just-written page image (snapshotted under the
-  lock), `(slru_klass_id, pageno)`, and the **WAL insert LSN captured under the
-  lock** as the version. The queue must be in shared memory, not a per-backend
-  buffer -- PostgreSQL backends are separate processes, so a private queue is
-  invisible to the checkpointer and would never be drained for an idle backend
-  (fixes the "use shared state for checkpoint drains" finding). Staging is
-  allocation-free and cannot fail in a way that breaks the SLRU write, so it is
-  safe in a critical section.
+  a **shared-memory** queue: the page image, `(slru_klass_id, pageno)`, and the
+  page's **dirtied-at LSN** (the per-slot version above) as the object version.
+  - **Snapshot before releasing the lock.** `SlruInternalWritePage()` drops the
+    bank lock while `pg_pwrite()` reads the shared buffer, and a write-OK caller may
+    update the same page meanwhile, so an image copied *after* the physical write
+    can differ from what was written. Copy the buffer into the staged entry **under
+    the bank lock, before local I/O**, and use that frozen copy for the mirror (and,
+    ideally, for the local write too) so the mirrored image matches the local one.
+  - **Shared, not per-backend.** PostgreSQL backends are separate processes, so a
+    private queue is invisible to the checkpointer and would never be drained for an
+    idle backend; the queue lives in shared memory.
+  - Staging is allocation-free and cannot fail in a way that breaks the SLRU write,
+    so it is safe in a critical section.
 - **Global order, last-writer-wins by LSN.** Because the version is the captured
   WAL LSN, two backends staging the same page and draining in either order are
   resolved correctly: the daemon keeps the highest-LSN version and **rejects a
@@ -121,22 +150,41 @@ PANIC-safe in a commit critical section, so it is removed from the hot write pat
   recorded LSN. The store is never left believing it is current when a page was
   dropped.
 
-### Durability handoff
+### Durability vs. cross-compute visibility
 
-- **Default (deferred).** Correctness for branch *reads* needs only: a store read
-  never returns an image older than what a reader on the writing compute would see,
-  and the checkpoint barrier makes all pages dirtied before a checkpoint durable on
-  the store before that checkpoint is complete-on-store. Read-side revalidation
-  (below) covers the in-flight window. This is the mode for branch read-sharing.
-- **Synchronous (opt-in).** Pages dirtied by a transaction are drained and acked
-  **before the commit decision**, so a failure aborts rather than lying about a
-  committed transaction. For computes that must fail over without replaying local
-  WAL.
+Two different guarantees must not be conflated. **Durability** (the mirror is on the
+store) is anchored at the checkpoint barrier. **Visibility** (another compute on the
+branch may treat a commit as committed) is a *separate, stronger* requirement that
+the deferred queue alone does not provide.
 
-| Mode | When mirror ships | Durability on store | Use |
-|------|-------------------|---------------------|-----|
-| deferred (default) | checkpoint / next non-critical access | durable by checkpoint barrier | branch read-sharing |
-| synchronous | before the commit decision | durable-on-commit | failover without local WAL replay |
+- **Deferred is durable-enough but not visible-enough on its own.** A writer can
+  commit (clog dirtied at the commit LSN) and leave that `pg_xact` page merely
+  staged until the next checkpoint. A *different* compute on the same branch, which
+  never had the dirty page, can read the store in that window and see the old
+  status. Local-slot revalidation cannot help a process that never cached the page.
+  So checkpoint-delayed mirroring is fine for crash durability but **wrong for live
+  read-sharing of transaction status**.
+- **Commit-visibility watermark.** Cross-compute visibility is gated, not the local
+  commit. The writer publishes a monotonic **`mirrored_status_lsn`** watermark =
+  the highest commit LSN whose clog/multixact/commit-ts mirrors are durable on the
+  store. A reader compute must **not treat a commit at LSN `L` as visible until the
+  branch's `mirrored_status_lsn >= L`** (it waits, or treats the xid as
+  in-progress). This keeps the local transaction genuinely committed while making
+  its *visibility elsewhere* depend on the mirror -- so there is no "lie about a
+  committed transaction": the local commit is never held back or aborted.
+- **Where the mirror happens for clog.** The committable status image is produced by
+  `TransactionIdCommitTree()` **after** the commit record is flushed, inside the
+  commit critical section -- a daemon failure there cannot abort the transaction. So
+  the mirror cannot gate the *local* commit. It instead advances
+  `mirrored_status_lsn` *after* the page is shipped (from the deferred drain or a
+  status shipper), and readers gate on that watermark. "Synchronous mode" therefore
+  does **not** mean "abort the commit if the mirror fails" for clog; it means
+  "advance the visibility watermark only once durable", retrying on failure.
+
+| Guarantee | Mechanism | Use |
+|-----------|-----------|-----|
+| crash durability | checkpoint barrier drains all pre-checkpoint pages | restart/failover |
+| live read-sharing | `mirrored_status_lsn` watermark gates cross-compute visibility | another compute reads this branch's xact status |
 
 The prototype's `CritSectionCount > 0 -> return` becomes `CritSectionCount > 0 ->
 stage only`; the actual `obj_write` always runs outside critical sections.
@@ -152,6 +200,13 @@ before serving store pages", "Do not resurrect truncated SLRU pages").
   at the truncation's WAL LSN that the daemon honours in `read_resolve` -- a read
   whose cutoff is at/after the tombstone LSN returns "not present" for those pages
   even if an older image exists.
+- **Requires a WAL-logged truncation LSN.** This versioning only works when the
+  truncation has a WAL record to take the LSN from. The M4-scoped SLRUs (clog,
+  multixact, commit-ts) truncate via WAL and qualify. SLRUs that truncate during
+  checkpoint/cleanup without a WAL record (`pg_subtrans`, `pg_notify`,
+  serializable) have no LSN to version the tombstone with -- they are out of scope
+  (see Scope); adding them later needs a defined per-SLRU truncate-version source,
+  not an invented LSN (which would break branch visibility).
 - **Synchronous order-barrier, not deferred.** Unlike page mirrors, the tombstone
   must be **durable on the store before the local segments are deleted**. If it
   rode the deferred queue, there would be a window after `SimpleLruTruncate()`
@@ -181,6 +236,12 @@ declaring pages absent").
     negative cache entries" finding); the store's tombstone is authoritative.
   - **unknown/miss** -- the store has nothing for this page; fall through to the
     local stat.
+  - **failed** -- a daemon error or cancel during the probe. For a store-required
+    compute this must **fail closed** exactly like the read hook (below): collapsing
+    it into unknown/miss would let `SimpleLruDoesPhysicalPageExist()` fall through to
+    the local stat, report the page absent, and the callers (commit-ts activation,
+    multixact offset) would zero-initialize real state. So the probe propagates a
+    safe error rather than reporting absence on error.
 - The probe shares the read path's found-ness contract: a block below fork length
   but never written is a miss (sparse), reported absent so the caller
   zero-initializes -- distinct from a tombstone, which actively forbids the page.
@@ -198,11 +259,23 @@ declaring pages absent").
   (LSN) so the read hook can do cache revalidation below.
 - **Sparse blocks.** A block below the object's fork length but never written reads
   as a miss (sparse), never as a zero-filled "present" page.
-- **Local cache revalidation.** A compute with `slru_read_from_store` on may also
-  hold the page in an SLRU shared buffer. Using the returned version, the read hook
-  serves the store page only when its LSN is at least as new as the cached slot's
-  known version, falls back to the buffered page when that is newer, and
-  invalidates the cached page when the store is newer. A read-only compute (no
+- **Cache hits must be revalidated too.** The physical read hook only runs on a
+  cache *miss*; `SimpleLruReadPage()` returns an already-valid cached slot without
+  reaching it. A compute that cached an older `pg_xact`/multixact page would keep
+  serving stale status indefinitely until eviction. So the cache-*hit* path needs a
+  store-version check or an invalidation signal, not just the miss path. The design
+  uses the branch-shared **`mirrored_status_lsn` watermark** (above) plus a per-slot
+  "validated through LSN": a reader gates xid visibility on the watermark, and a
+  cached SLRU slot whose validated-through LSN is behind the watermark is treated as
+  stale (re-fetched through the hook) before its status is trusted. A coarse epoch
+  bump on the watermark that forces revalidation of SLRU slots is the minimal
+  mechanism; the alternative is invalidating affected slots when the watermark
+  advances. Either way, a cache hit alone is not sufficient proof of currency for a
+  store-reading compute.
+- **Local cache revalidation (miss path).** On a miss, using the returned version,
+  the read hook serves the store page only when its LSN is at least as new as the
+  cached slot's known version, falls back to the buffered page when that is newer,
+  and invalidates the cached page when the store is newer. A read-only compute (no
   local writer) never caches a newer page, so the common case is a plain store read.
 - **Fail closed for store-required pages.** Returning `false` (fall back to local)
   on a store error is only safe when a valid local copy exists. A branch compute
@@ -243,20 +316,24 @@ rethrow while an SLRU read is in progress", "...while an SLRU write holds locks"
 
 ## Sequencing
 
-1. Daemon IPC: `READ_AT` reports found-ness in `ch->result` **and returns the
+1. Scope: enable store-backing only for the WAL-logged, uint32-pageno SLRUs
+   (clog, multixact, commit-ts); refuse the rest.
+2. Daemon IPC: `READ_AT` reports found-ness in `ch->result` **and returns the
    resolved version (LSN)** -- on **both** POSIX and SPDK paths (neither does today).
-2. Daemon: store object versions are writer-supplied LSNs (no daemon `max+1`
+3. Daemon: store object versions are writer-supplied LSNs (no daemon `max+1`
    counter for objects); `read_resolve` caps by the branch LSN using those.
-3. Daemon: SLRU tombstone object + LSN-ordered `read_resolve` honouring it,
-   including a negative result for existence probes.
-4. Core: shared-memory mirror queue; write hook captures the WAL LSN under the
-   bank lock and stages only.
-5. Core: `slru_page_exists_hook` (tri-state) from `SimpleLruDoesPhysicalPageExist()`.
-6. Core: read hook returns `SERVED`/`FALLBACK`/`FAILED`; `slru.c` cleans the slot
-   and fails closed for store-required pages.
-7. Module: drain points (checkpoint + next access), cache revalidation, sparse
+4. Daemon: SLRU tombstone object + LSN-ordered `read_resolve` honouring it,
+   including a negative (tombstoned) result for existence probes.
+5. Core: per-slot **dirtied-at LSN** captured when the buffer is dirtied; image
+   snapshotted under the bank lock; shared-memory mirror queue carries both.
+6. Core: `mirrored_status_lsn` watermark; readers gate xid visibility on it;
+   cache-hit revalidation against it.
+7. Core: `slru_page_exists_hook` and read hook return
+   `SERVED`/`FALLBACK`/`FAILED`; `slru.c` cleans the slot and fails closed for
+   store-required pages (read and existence).
+8. Module: drain points (checkpoint + next access), miss-path revalidation, sparse
    fallback; truncate -> synchronous tombstone barrier before local deletion.
-8. Tests: the acceptance scenarios below.
+9. Tests: the acceptance scenarios below.
 
 ## Acceptance criteria
 
@@ -264,7 +341,13 @@ rethrow while an SLRU read is in progress", "...while an SLRU write holds locks"
   still mirrored (via the shared deferred queue, drained at checkpoint even if the
   writing backend went idle) and readable from the store on another compute.
 - A parent SLRU write *after* a branch is created is **not** visible to the branch
-  (the LSN version compares above the branch cutoff), and a write before it is.
+  (the dirtied-at LSN compares above the branch cutoff), and a write before it is.
+- The version reflects when the page was **dirtied**, not when it was flushed: a
+  pre-branch change flushed by a post-branch checkpoint is still visible to the
+  branch.
+- A second compute on the branch does not observe a commit until the branch's
+  `mirrored_status_lsn` reaches it -- no stale-status window, including for a
+  cached SLRU slot it already held (cache-hit revalidation).
 - Two backends mirroring the same page in either drain order converge to the
   higher-LSN image; a stale lower-LSN drain is rejected.
 - A truncated SLRU range is reported absent by both the read hook and the existence
@@ -276,17 +359,25 @@ rethrow while an SLRU read is in progress", "...while an SLRU write holds locks"
   rather than serving zeros, on both POSIX and SPDK daemons.
 - A store page never overrides a newer locally-cached page, and a stale local
   cache is invalidated when the store is newer (using the returned version).
-- For a store-required page, a daemon error or query cancel during the read **fails
-  closed** (clean slot + error) -- it never turns transaction status into zeros --
-  and never wedges a later reader of that SLRU slot/bank.
+- For a store-required page, a daemon error or query cancel during **either** the
+  read hook or the existence probe **fails closed** (clean slot + error) -- it never
+  turns transaction status into zeros -- and never wedges a later reader of that
+  SLRU slot/bank.
+- The mirror image matches the locally written bytes even when a write-OK caller
+  updates the page during the physical write (snapshot-under-lock).
+- A non-WAL-truncating / int64-pageno SLRU (e.g. `pg_notify`) is refused rather
+  than silently store-backed with an undefined tombstone version or an aliased key.
 
 ## Open questions
 
 - Tombstone granularity: per-page vs per-segment range, and how it interacts with
   M3 layer/manifest persistence.
-- Whether the synchronous (durable-on-commit) mode is needed for the first bootable
-  branch (M4) or can wait until failover work.
-- Per-slot store-version tracking cost vs a coarser epoch-based invalidation.
+- The exact cache-hit revalidation mechanism: a coarse `mirrored_status_lsn`-epoch
+  bump that forces SLRU slot revalidation vs. targeted slot invalidation.
+- Where `mirrored_status_lsn` is advanced (deferred-drain completion vs. a dedicated
+  status shipper) and how a reader waits on it without livelock.
+- A per-SLRU truncate-version source + a 64-bit object key, to admit the non-WAL /
+  int64 SLRUs (`pg_subtrans`, `pg_notify`, serializable) post-M4.
 
 See also: the read-path PR stack plan and the branch-PostgreSQL milestone plan
 (M4: bootable branch compute), and [PGCONTROL_ON_STORE_DESIGN.md] for the sibling

--- a/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
@@ -1,384 +1,195 @@
 # SLRU on the store: lifecycle design (M4)
 
-Status: design. The PR-#49 prototype (`feat/pagestore-slru`) mirrors and serves
-SLRU pages through the `klass` storage seam, but review showed the gaps are not
-local bugs -- they span the whole SLRU object lifecycle. Per the read-path stack
-plan, store-backed SLRU stays frozen until that lifecycle is defined here. This
-document is the gate; implementation resumes against it.
+Status: design. The PR-#49 prototype (`feat/pagestore-slru`) mirrors flushed SLRU
+page images to the store and serves them back through a read hook. Three rounds of
+review showed this model is the wrong primitive for *branch-correct* transaction
+status, so the M4 design pivots to **WAL-based as-of reconstruction** and defers
+live page mirroring. This document is the gate; implementation resumes against it.
+
+## What M4 actually needs
+
+M4 is a bootable branch compute. The milestone goal for SLRU is **"safe inheritance
+of parent transaction status at the fork point"** plus **"branch-local transaction
+status handling"**:
+
+1. A branch is created at a consistent LSN `L` on a parent timeline.
+2. The new branch compute must see the parent's transaction status (clog /
+   multixact / commit-ts) **exactly as of `L`** -- no earlier, no later.
+3. From there the branch writes its **own** status forward on its own timeline,
+   using ordinary local SLRU.
+
+That is the whole M4 requirement. It is a *seed* problem, not a live-sharing
+problem.
+
+## The core correction: page images cannot represent as-of-`L` status
+
+The prototype mirrors the **flushed page image** and versions it by one LSN. Review
+(round 3) showed this is irreparably wrong for branch reads, because an SLRU page
+**coalesces many independent logical updates** between flushes:
+
+- A `pg_xact` page holds the commit/abort bits of thousands of xids. If xid A sets
+  its bit before `L` and xid B sets its bit after `L` on the **same page**, with no
+  checkpoint/eviction between them, the only flushed image that ever exists is the
+  combined A+B page. Versioning it by A's LSN leaks B into the branch; versioning it
+  by B's LSN hides A from the branch. There is no single-LSN page image that equals
+  "the page as of `L`".
+- Overflow/eviction make it worse: a dropped image cannot be reconstructed by
+  re-reading the local segment later (that only yields the newest bytes), so a
+  range-watermark overflow scheme loses the as-of snapshot entirely.
+
+The fix is not a cleverer snapshot. **SLRU status as of an LSN must be reconstructed
+from the per-update WAL records**, exactly as relation pages are reconstructed by
+`redo_page_asof` over shipped WAL (PR #53). The SLRU-changing records --
+`XLOG_XACT_COMMIT`/`ABORT`/`COMMIT_PREPARED`/... for clog, multixact create,
+commit-ts set -- are **per-logical-update and LSN-ordered**, so replaying them up to
+`L` yields the exact status page as of `L` with no coalescing ambiguity.
 
 ## Scope
 
-SLRUs are the small fixed-page logs PostgreSQL keeps under `pg_xact`,
-`pg_multixact/{offsets,members}`, `pg_subtrans`, `pg_commit_ts`, `pg_serial`,
-and `pg_notify`. Putting them on the store lets a branch compute read shared
-transaction-status state (clog, commit-ts, multixact) it has no local copy of,
-and lets a writer's SLRU updates become visible to other computes of the same
-branch.
+In scope (M4): reconstructing clog, multixact (`offsets`+`members`), and commit-ts
+as of the fork LSN to seed a branch, and the branch then running on local SLRU.
 
-**M4 covers only the WAL-logged, branch-relevant SLRUs: `pg_xact` (clog),
-`pg_multixact/{offsets,members}`, and `pg_commit_ts`.** The rest are explicitly
-out of scope for M4, for two concrete reasons surfaced in review:
+These are the WAL-logged, `uint32`-page SLRUs. Out of scope and explicitly excluded:
 
-- **Non-WAL truncation.** `pg_subtrans`, `pg_notify`, and the serializable SLRU
-  (`pg_serial`) truncate during checkpoint/cleanup with **no truncate WAL record**,
-  so there is no LSN to version a tombstone with (see truncation). The in-scope
-  three all truncate via WAL (`XLOG_*_TRUNCATE`-style records), giving a real LSN.
-- **Page-number width.** `SimpleLru` page numbers are `int64`, and `pg_notify`'s
-  queue page is unbounded `int64`, but the pagestore object `block` key is
-  `uint32`. The in-scope three have page numbers bounded by the 32-bit xid /
-  multixact-id space, so they fit `uint32`; `pg_notify` does not. Supporting
-  int64-pageno SLRUs requires widening the object key first (out of scope here).
+- `pg_subtrans`, `pg_notify`, serializable (`pg_serial`): they truncate during
+  checkpoint/cleanup with **no truncate WAL record** (no LSN to reconstruct or
+  tombstone against), and `pg_notify`'s queue page is an unbounded `int64` while the
+  pagestore object `block` key is `uint32`. `pg_subtrans` is rebuilt on its own and
+  is not needed across a fork; `pg_notify`/`pg_serial` are not branch transaction
+  status. Admitting them later needs a per-SLRU version source and a 64-bit key.
+- **Live multi-compute SLRU read-sharing** (several concurrent computes on one
+  branch sharing each other's in-flight status). That is a separate, harder feature
+  with its own section below; it is **not** required to boot a branch and is
+  deferred past M4.
 
-Also out of scope for M4: these are transient/derivable (`pg_subtrans` is rebuilt,
-`pg_notify`/`pg_serial` are not needed to read a branch's transaction status).
+## M4 design: as-of-fork reconstruction
 
-In scope: identity/versioning, the write/mirror protocol, truncation, existence
-probes, the read path and cache coherence, and interrupt/lock safety. Out of
-scope: cross-branch SLRU retention/GC (M5), SLRU-specific compaction, and the
-non-WAL/int64 SLRUs above (need a per-SLRU truncate-version source and a wider
-object key before they can be added).
+At branch creation (or first start of the branch compute):
 
-## Why the prototype is not mergeable
+- Replay the parent's WAL from a base up to `L`, applying only the SLRU-relevant
+  records, to **materialize the branch's local clog / multixact / commit-ts
+  segments** as of `L`. This reuses the shipped-WAL + redo machinery from #53 (the
+  store already serves per-timeline WAL byte ranges and the compute already has an
+  `XLogReader` redo path); the SLRU apply is the existing `xact_redo` /
+  `multixact_redo` / `commit_ts_redo` logic pointed at the branch's segment files.
+- The base to start replay from is the parent's last SLRU checkpoint/truncation
+  point at or before `L` (clog/multixact pages are only kept back to their truncate
+  horizon, which is itself WAL-logged for the in-scope SLRUs).
+- After materialization the branch has ordinary local SLRU and **writes forward
+  itself**; nothing is served from the store on the steady-state path, so none of
+  the live-mirror hazards (critical-section mirroring, read-hook interrupt safety,
+  cache coherence) arise for M4.
 
-The prototype installs two hooks in `slru.c` -- a write hook after
-`SlruPhysicalWritePage()` and a read hook in `SlruPhysicalReadPage()` -- and
-mirrors/serves each page as a `PS_KLASS_SLRU` object keyed by
-`(slru_klass_id(Dir), pageno)`. The hooks run **with the SLRU bank lock held**,
-and the write hook can fire **inside a transaction commit/abort critical
-section** (an eviction via `SlruSelectLRUPage`). From there it does fallible
-shared-memory I/O against the daemon. The review findings (15 P1 / 11 P2) reduce
-to seven lifecycle questions the prototype answers unsafely or not at all:
+Why this dissolves the round-1/2/3 findings:
 
-1. **Critical-section writes.** The hook returns early when `CritSectionCount > 0`
-   so it never PANICs -- but then the page is silently *not* mirrored, and there
-   is no guarantee a later non-critical write ever re-mirrors it. The store goes
-   permanently stale for that page (e.g. an evicted `pg_xact` page during commit).
-2. **Mirror fidelity.** The hook must mirror exactly the image that was written
-   to the local segment, snapshotted under the bank lock -- not whatever the
-   shared buffer holds when the (possibly deferred) mirror later runs.
-3. **Version ordering.** SLRU pages have no `pd_lsn`; their first bytes are
-   payload. Versions must come from a real monotonic order, not page bytes, or an
-   overwrite can compare lower than the prior version and be lost.
-4. **Truncation / tombstones.** `SimpleLruTruncate()` drops segments. Without a
-   durable tombstone on the store, a store read can resurrect a truncated page.
-5. **Existence probes.** `SimpleLruDoesPhysicalPageExist()` is consulted *before*
-   the read hook by commit-ts activation and multixact offset reads
-   (`commit_ts.c`, `multixact.c`). With local segments absent it reports "missing"
-   and the caller zero-initializes -- the store is never consulted.
-6. **Read cache coherence.** A compute may hold a cached local SLRU page in a
-   shared buffer; serving an *older* store page, or trusting a stale local page
-   over a newer store version, both corrupt transaction state.
-7. **Interrupt / lock safety.** The read hook runs after the slot is marked
-   `SLRU_PAGE_READ_IN_PROGRESS` and the bank lock is released; a `PG_RE_THROW()`
-   of a query-cancel exits before `slru.c` marks the slot valid/empty, wedging
-   every later reader of that slot. The write hook rethrows while the bank lock is
-   still held.
+- No flushed-page snapshot, so no coalescing (round-3 finding) and no
+  overflow-snapshot problem.
+- The "version" of a reconstructed page is intrinsic -- it is whatever the WAL says
+  at `L` -- so there is no daemon-counter-vs-branch-LSN mismatch and no need for a
+  per-object version IPC for the seed path.
+- Truncation as of `L` is just the truncate records up to `L`; no store tombstone is
+  needed to seed a branch.
 
-## SLRU object model on the store
+### Reconstruction correctness
+
+- The replay must stop at exactly `L` (record-aligned): a record that *starts* at or
+  before `L` but ends after it is not part of the as-of-`L` state (same rule
+  `redo_page_asof` already applies for relation pages).
+- multixact needs both `offsets` and `members` replayed together to a consistent
+  point; commit-ts only if `track_commit_timestamp` was on in the parent.
+- Fail closed: if the parent WAL needed to reach `L` is not available on the store
+  (not shipped / truncated away), branch creation fails rather than seeding partial
+  status -- a half-known clog must never boot.
+
+## Identity and versioning (for any persisted SLRU object)
+
+The seed path needs no SLRU store objects. *If* SLRU pages are ever persisted as
+store objects -- as a reconstruction cache, or for the deferred live-sharing path --
+they use:
 
 - **Identity.** `PsKey{ klass = PS_KLASS_SLRU, relNumber = slru_klass_id(Dir),
-  block = pageno }`, `spcOid = dbOid = forkNum = 0`. `slru_klass_id(Dir)` maps a
-  stable small integer per SLRU directory (`pg_xact` = 1, `pg_multixact/offsets`
-  = 2, ...). The mapping is fixed and versioned; adding an SLRU appends an id.
-- **Version order (branch-aware), captured at dirty time.** The store resolves
-  branch reads by walking timeline ancestry and capping parent versions at the
-  branch-creation LSN (`read_through`). An SLRU object version must be comparable to
-  that cap, so the daemon-local `max+1` counter the relation prototype uses is
-  **wrong for objects**: a parent SLRU write after a branch is created still gets a
-  small counter value, compares below the branch LSN, and leaks post-branch parent
-  status into the branch. The version is therefore the **WAL LSN of the change that
-  dirtied the page** -- recorded **per slot when the buffer is dirtied**, not the
-  LSN read at physical-write time. Physical writes happen later at
-  checkpoint/eviction, where there is no meaningful WAL LSN for the logical change;
-  capturing a flush-time LSN would tag pre-branch contents with a post-branch LSN
-  and hide data the branch should see. For clog the dirtying LSN is the commit
-  record's LSN (`TransactionIdSetTreeStatus`'s `lsn`, already plumbed to
-  `SlruSharedData.group_lsn` for clog); SLRUs without group-lsn tracking need an
-  equivalent per-page "dirtied at" LSN added. The daemon stores the supplied LSN
-  verbatim (no daemon counter for objects); it is cluster-global, monotonic,
-  globally ordered across backends, and is the branch read cutoff.
-- **Read returns the version.** `obj_read` / `PS_OP_READ_AT` currently return only
-  page bytes plus status/result; they must also return the resolved object version
-  (LSN) so the read hook can compare it against a cached local page (see cache
-  coherence). This is a required IPC addition, not optional.
-- **Granularity.** One object block per SLRU page (`BLCKSZ`). A segment's worth of
-  pages is many objects; there is no segment-level object.
+  block = pageno }` (`pageno` fits `uint32` for the in-scope SLRUs).
+- **Version = the dirtying WAL LSN**, supplied by the writer and stored verbatim
+  (never a daemon `max+1` counter -- not comparable to a branch cutoff), captured
+  when the page is **logically dirtied** (clog: the commit record LSN), not at
+  physical-write time. This keeps versions comparable to branch cutoffs. (Even so,
+  per round 3, a single image per page cannot be branch-correct on its own; WAL
+  reconstruction remains the source of truth.)
 
-## Write / mirror protocol
+## Deferred: live multi-compute SLRU read-sharing (post-M4)
 
-The core decision: **mirroring is deferred, never synchronous from inside a
-critical section.** A synchronous mirror cannot be made both crash-safe and
-PANIC-safe in a commit critical section, so it is removed from the hot write path.
+Letting several **concurrently running** computes on one branch observe each other's
+in-flight transaction status is a distinct feature, not needed to boot a branch.
+When it is built, the three review rounds established the requirements it must meet
+-- recorded here so they are not lost:
 
-### Deferred mirror queue (shared memory)
+- **Per-update capture, not flushed-page snapshots.** Because pages coalesce
+  updates, live sharing must ship the per-update status changes (or reconstruct via
+  WAL on the reader), not single-LSN page images.
+- **No-drop overflow.** A staging queue may not drop an image and "reread later"
+  (the as-of bytes are gone); it must block/backpressure or spill durably.
+- **Snapshot under the bank lock.** Any page image staged must be copied under the
+  bank lock before `SlruInternalWritePage()` releases it for `pg_pwrite`, or a
+  concurrent write-OK caller changes the bytes.
+- **Contiguous-durable-prefix visibility watermark.** A reader gates xid visibility
+  on a `mirrored_status_lsn` watermark that advances only over a **contiguous
+  durable prefix** -- not "highest mirrored", since out-of-order/failed drains mean
+  a high LSN being durable does not imply lower ones are. The local commit is never
+  held back; only its visibility to *other* computes waits.
+- **Cache-hit revalidation, including tombstones.** `SimpleLruReadPage()` returns a
+  valid cached slot without hitting the physical-read hook, so cached slots must be
+  revalidated against both the status watermark **and** truncation tombstones
+  (tombstones are a separate versioned negative result with their own
+  epoch/invalidation).
+- **Tombstones with a defined version + synchronous truncate barrier.** A store
+  tombstone must be durable before local segment deletion, versioned by the
+  truncation LSN -- which only the WAL-logged SLRUs have.
+- **Fail-closed, interrupt-safe hooks.** Read and existence hooks return
+  `SERVED`/`FALLBACK`/`FAILED`; `slru.c` cleans the slot before any error; a
+  store-required page fails closed (never a zero page); no `PG_RE_THROW()` across the
+  `SLRU_PAGE_READ_IN_PROGRESS` window.
+- **Daemon IPC.** `READ_AT` must report found-ness in `ch->result` and return the
+  resolved version on **both** POSIX and SPDK paths (neither does today).
+- **Critical-section-safe write path.** Mirroring must never do fallible store I/O
+  in a commit/abort critical section; it stages into shared memory and drains
+  outside.
 
-- The write hook's only job under the bank lock is to **stage** the dirty page into
-  a **shared-memory** queue: the page image, `(slru_klass_id, pageno)`, and the
-  page's **dirtied-at LSN** (the per-slot version above) as the object version.
-  - **Snapshot before releasing the lock.** `SlruInternalWritePage()` drops the
-    bank lock while `pg_pwrite()` reads the shared buffer, and a write-OK caller may
-    update the same page meanwhile, so an image copied *after* the physical write
-    can differ from what was written. Copy the buffer into the staged entry **under
-    the bank lock, before local I/O**, and use that frozen copy for the mirror (and,
-    ideally, for the local write too) so the mirrored image matches the local one.
-  - **Shared, not per-backend.** PostgreSQL backends are separate processes, so a
-    private queue is invisible to the checkpointer and would never be drained for an
-    idle backend; the queue lives in shared memory.
-  - Staging is allocation-free and cannot fail in a way that breaks the SLRU write,
-    so it is safe in a critical section.
-- **Global order, last-writer-wins by LSN.** Because the version is the captured
-  WAL LSN, two backends staging the same page and draining in either order are
-  resolved correctly: the daemon keeps the highest-LSN version and **rejects a
-  drained entry whose LSN is below the page's current stored version**. Ordering is
-  by LSN, never by drain wall-clock or a per-process stamp (fixes the
-  "keep mirrors ordered across deferred drains" finding).
-- **Drain points.** Any backend or the checkpointer ships queued images via
-  `obj_write` from outside any critical section: at (a) the next non-critical SLRU
-  access and (b) `SimpleLruWriteAll()` / checkpoint. Because the queue is shared
-  and entries carry their LSN, the checkpointer drains entries staged by an
-  idle backend, bounding staleness regardless of which process flushes.
-- **No fallible post-commit drain.** There is deliberately *no* "drain before the
-  commit returns to the client" point: a page dirtied inside the commit critical
-  section can only be drained after the transaction is already durable locally, so
-  an `obj_write` failure there is too late to abort and must not throw. The
-  durability contract is instead anchored at the checkpoint barrier (below); a
-  backend that needs durable-on-commit uses `synchronous` mode, which drains
-  **before** the commit decision, where an error can still abort.
-- **Overflow.** If the queue fills (a long critical section dirtying many pages),
-  staging records a "dirty SLRU range" watermark instead of dropping pages; the
-  drain re-reads those pages from the local segment and re-stages them with their
-  recorded LSN. The store is never left believing it is current when a page was
-  dropped.
+This list is the spec for that feature; none of it blocks M4.
 
-### Durability vs. cross-compute visibility
+## Sequencing (M4)
 
-Two different guarantees must not be conflated. **Durability** (the mirror is on the
-store) is anchored at the checkpoint barrier. **Visibility** (another compute on the
-branch may treat a commit as committed) is a *separate, stronger* requirement that
-the deferred queue alone does not provide.
+1. Reuse #53's shipped-WAL + `XLogReader` redo to replay SLRU records to `L`.
+2. Branch-create: materialize clog / multixact / commit-ts segments as of `L` from
+   the parent's WAL; fail closed if that WAL is unavailable.
+3. Verify the branch boots on its reconstructed status and writes forward locally.
+4. Tests: the acceptance scenarios below.
 
-- **Deferred is durable-enough but not visible-enough on its own.** A writer can
-  commit (clog dirtied at the commit LSN) and leave that `pg_xact` page merely
-  staged until the next checkpoint. A *different* compute on the same branch, which
-  never had the dirty page, can read the store in that window and see the old
-  status. Local-slot revalidation cannot help a process that never cached the page.
-  So checkpoint-delayed mirroring is fine for crash durability but **wrong for live
-  read-sharing of transaction status**.
-- **Commit-visibility watermark.** Cross-compute visibility is gated, not the local
-  commit. The writer publishes a monotonic **`mirrored_status_lsn`** watermark =
-  the highest commit LSN whose clog/multixact/commit-ts mirrors are durable on the
-  store. A reader compute must **not treat a commit at LSN `L` as visible until the
-  branch's `mirrored_status_lsn >= L`** (it waits, or treats the xid as
-  in-progress). This keeps the local transaction genuinely committed while making
-  its *visibility elsewhere* depend on the mirror -- so there is no "lie about a
-  committed transaction": the local commit is never held back or aborted.
-- **Where the mirror happens for clog.** The committable status image is produced by
-  `TransactionIdCommitTree()` **after** the commit record is flushed, inside the
-  commit critical section -- a daemon failure there cannot abort the transaction. So
-  the mirror cannot gate the *local* commit. It instead advances
-  `mirrored_status_lsn` *after* the page is shipped (from the deferred drain or a
-  status shipper), and readers gate on that watermark. "Synchronous mode" therefore
-  does **not** mean "abort the commit if the mirror fails" for clog; it means
-  "advance the visibility watermark only once durable", retrying on failure.
+(The deferred live-sharing items above are sequenced separately, after M4.)
 
-| Guarantee | Mechanism | Use |
-|-----------|-----------|-----|
-| crash durability | checkpoint barrier drains all pre-checkpoint pages | restart/failover |
-| live read-sharing | `mirrored_status_lsn` watermark gates cross-compute visibility | another compute reads this branch's xact status |
+## Acceptance criteria (M4)
 
-The prototype's `CritSectionCount > 0 -> return` becomes `CritSectionCount > 0 ->
-stage only`; the actual `obj_write` always runs outside critical sections.
-
-## Truncation / tombstone semantics
-
-`SimpleLruTruncate()` and segment deletion must be represented on the store so a
-store read cannot resurrect a truncated page (findings: "Mirror SLRU truncations
-before serving store pages", "Do not resurrect truncated SLRU pages").
-
-- A truncate installs a durable **tombstone** object for the truncated page range
-  on the relevant timeline: a versioned record `(klass, pageno-range, truncated)`
-  at the truncation's WAL LSN that the daemon honours in `read_resolve` -- a read
-  whose cutoff is at/after the tombstone LSN returns "not present" for those pages
-  even if an older image exists.
-- **Requires a WAL-logged truncation LSN.** This versioning only works when the
-  truncation has a WAL record to take the LSN from. The M4-scoped SLRUs (clog,
-  multixact, commit-ts) truncate via WAL and qualify. SLRUs that truncate during
-  checkpoint/cleanup without a WAL record (`pg_subtrans`, `pg_notify`,
-  serializable) have no LSN to version the tombstone with -- they are out of scope
-  (see Scope); adding them later needs a defined per-SLRU truncate-version source,
-  not an invented LSN (which would break branch visibility).
-- **Synchronous order-barrier, not deferred.** Unlike page mirrors, the tombstone
-  must be **durable on the store before the local segments are deleted**. If it
-  rode the deferred queue, there would be a window after `SimpleLruTruncate()`
-  removes the local segment but before the tombstone is durable where another
-  compute still reads the older store image -- exactly the resurrection this
-  prevents. So truncation drains any pending mirrors for the range, writes the
-  tombstone, waits for the daemon ack, and only then proceeds with local deletion.
-- Ordering is by LSN: the tombstone carries the truncation LSN, so a re-extension
-  (a new page write in a previously truncated range) at a higher LSN wins over the
-  tombstone, and a stale page write at a lower LSN stays hidden. The daemon must
-  apply tombstone and page versions in LSN order regardless of drain arrival order.
-
-## Existence semantics
-
-`SimpleLruDoesPhysicalPageExist()` must consult the same source of truth as reads
-(findings: "Add an existence hook for SLRU probes", "Check the SLRU store before
-declaring pages absent").
-
-- Add a `slru_page_exists_hook` symmetric to the read hook, called from
-  `SimpleLruDoesPhysicalPageExist()` *before* the local-segment stat. With
-  `slru_read_from_store` on, it asks the daemon about the object block and returns
-  a **tri-state**, not a bool:
-  - **present** -- a live version exists; report exists, skip the local stat.
-  - **tombstoned (negative)** -- the store has truncated this range; report
-    **absent and suppress the local fallback**. A compute that still has an old
-    local segment must not report the page present (fixes the "treat tombstones as
-    negative cache entries" finding); the store's tombstone is authoritative.
-  - **unknown/miss** -- the store has nothing for this page; fall through to the
-    local stat.
-  - **failed** -- a daemon error or cancel during the probe. For a store-required
-    compute this must **fail closed** exactly like the read hook (below): collapsing
-    it into unknown/miss would let `SimpleLruDoesPhysicalPageExist()` fall through to
-    the local stat, report the page absent, and the callers (commit-ts activation,
-    multixact offset) would zero-initialize real state. So the probe propagates a
-    safe error rather than reporting absence on error.
-- The probe shares the read path's found-ness contract: a block below fork length
-  but never written is a miss (sparse), reported absent so the caller
-  zero-initializes -- distinct from a tombstone, which actively forbids the page.
-
-## Read path and cache coherence
-
-- **Found-ness (both daemons).** `obj_read` uses `PS_OP_READ_AT` and must report
-  presence in `ch->result`. **Neither merged daemon does this yet**: the POSIX
-  `PS_OP_READ_AT` path initializes `ch->result = 0` and never sets it on a
-  successful `read_resolve()`, and the SPDK path likewise leaves it 0. Both must be
-  fixed before this contract holds (the POSIX fix is the first sequencing item, not
-  a precondition assumed done), or every store read looks like a miss and SLRU
-  falls back to local/zeros.
-- **Version return.** The same `READ_AT` reply must carry the resolved version
-  (LSN) so the read hook can do cache revalidation below.
-- **Sparse blocks.** A block below the object's fork length but never written reads
-  as a miss (sparse), never as a zero-filled "present" page.
-- **Cache hits must be revalidated too.** The physical read hook only runs on a
-  cache *miss*; `SimpleLruReadPage()` returns an already-valid cached slot without
-  reaching it. A compute that cached an older `pg_xact`/multixact page would keep
-  serving stale status indefinitely until eviction. So the cache-*hit* path needs a
-  store-version check or an invalidation signal, not just the miss path. The design
-  uses the branch-shared **`mirrored_status_lsn` watermark** (above) plus a per-slot
-  "validated through LSN": a reader gates xid visibility on the watermark, and a
-  cached SLRU slot whose validated-through LSN is behind the watermark is treated as
-  stale (re-fetched through the hook) before its status is trusted. A coarse epoch
-  bump on the watermark that forces revalidation of SLRU slots is the minimal
-  mechanism; the alternative is invalidating affected slots when the watermark
-  advances. Either way, a cache hit alone is not sufficient proof of currency for a
-  store-reading compute.
-- **Local cache revalidation (miss path).** On a miss, using the returned version,
-  the read hook serves the store page only when its LSN is at least as new as the
-  cached slot's known version, falls back to the buffered page when that is newer,
-  and invalidates the cached page when the store is newer. A read-only compute (no
-  local writer) never caches a newer page, so the common case is a plain store read.
-- **Fail closed for store-required pages.** Returning `false` (fall back to local)
-  on a store error is only safe when a valid local copy exists. A branch compute
-  booted with no local SLRU has none, and PostgreSQL treats a missing local SLRU
-  page during recovery as a **zero page** -- so a transient daemon error or cancel
-  while reading `pg_xact`/multixact would silently turn real transaction status
-  into zeros. When the page is store-required (no local segment / store-only mode),
-  the hook must instead **fail closed**: clean up the slot and propagate a safe
-  error, never let the core zero-fill. Distinguish the two modes explicitly:
-  - **store-optional** (local copy present): error -> fall back to local read.
-  - **store-required** (no local copy): error -> slot cleanup + error, never zero.
-
-## Interrupt and lock safety
-
-The hooks run inside `slru.c` with transitional lock/slot state held; they must
-not let an interrupt escape before the core restores that state (findings: "Do not
-rethrow while an SLRU read is in progress", "...while an SLRU write holds locks").
-
-- **Read hook.** Invoked after the slot is `SLRU_PAGE_READ_IN_PROGRESS` and the
-  bank lock is dropped. The hook must **never `PG_RE_THROW()`** out of this window
-  directly -- a raw throw exits before `slru.c` resets the slot and wedges later
-  readers. Instead the hook returns a small status to the core: `SERVED`,
-  `FALLBACK` (store-optional miss/error -> read local), or `FAILED` (store-required
-  error). `slru.c` is taught to restore the slot to a clean state (mark it
-  empty/error and release the in-progress marker) for both `FALLBACK` and `FAILED`,
-  and *then*, for `FAILED`, raise the error -- so the store-required fail-closed
-  path (above) propagates a real error without ever leaving the slot transitional.
-  This replaces the prototype's "swallow-but-rethrow-cancel" dance, which threw
-  across the in-progress window.
-- **Write hook.** With deferral, the hook only stages into the shared-memory queue
-  and does no fallible daemon I/O under the bank lock, so it has nothing to throw.
-  The actual `obj_write` happens at a drain point where normal error handling
-  applies and no SLRU lock is held.
-- **No swallowing of cancel/shutdown at unsafe points.** Because the fallible work
-  moved out of the locked/critical window, the prototype's
-  "swallow-but-rethrow-cancel" `PG_TRY/PG_CATCH` dance in the hooks is gone; there
-  is no interrupt to mishandle while a lock is held.
-
-## Sequencing
-
-1. Scope: enable store-backing only for the WAL-logged, uint32-pageno SLRUs
-   (clog, multixact, commit-ts); refuse the rest.
-2. Daemon IPC: `READ_AT` reports found-ness in `ch->result` **and returns the
-   resolved version (LSN)** -- on **both** POSIX and SPDK paths (neither does today).
-3. Daemon: store object versions are writer-supplied LSNs (no daemon `max+1`
-   counter for objects); `read_resolve` caps by the branch LSN using those.
-4. Daemon: SLRU tombstone object + LSN-ordered `read_resolve` honouring it,
-   including a negative (tombstoned) result for existence probes.
-5. Core: per-slot **dirtied-at LSN** captured when the buffer is dirtied; image
-   snapshotted under the bank lock; shared-memory mirror queue carries both.
-6. Core: `mirrored_status_lsn` watermark; readers gate xid visibility on it;
-   cache-hit revalidation against it.
-7. Core: `slru_page_exists_hook` and read hook return
-   `SERVED`/`FALLBACK`/`FAILED`; `slru.c` cleans the slot and fails closed for
-   store-required pages (read and existence).
-8. Module: drain points (checkpoint + next access), miss-path revalidation, sparse
-   fallback; truncate -> synchronous tombstone barrier before local deletion.
-9. Tests: the acceptance scenarios below.
-
-## Acceptance criteria
-
-- A committed xid's `pg_xact` page evicted *inside* the commit critical section is
-  still mirrored (via the shared deferred queue, drained at checkpoint even if the
-  writing backend went idle) and readable from the store on another compute.
-- A parent SLRU write *after* a branch is created is **not** visible to the branch
-  (the dirtied-at LSN compares above the branch cutoff), and a write before it is.
-- The version reflects when the page was **dirtied**, not when it was flushed: a
-  pre-branch change flushed by a post-branch checkpoint is still visible to the
-  branch.
-- A second compute on the branch does not observe a commit until the branch's
-  `mirrored_status_lsn` reaches it -- no stale-status window, including for a
-  cached SLRU slot it already held (cache-hit revalidation).
-- Two backends mirroring the same page in either drain order converge to the
-  higher-LSN image; a stale lower-LSN drain is rejected.
-- A truncated SLRU range is reported absent by both the read hook and the existence
-  hook, suppressing local fallback even when an old local segment is still present;
-  a re-extension at a higher LSN supersedes the tombstone.
-- `SimpleLruDoesPhysicalPageExist()`-first callers (commit-ts activation,
-  multixact offset) see store-backed pages on a compute with no local segments.
-- A sparse/unwritten page below fork length falls back to local (or reports absent)
-  rather than serving zeros, on both POSIX and SPDK daemons.
-- A store page never overrides a newer locally-cached page, and a stale local
-  cache is invalidated when the store is newer (using the returned version).
-- For a store-required page, a daemon error or query cancel during **either** the
-  read hook or the existence probe **fails closed** (clean slot + error) -- it never
-  turns transaction status into zeros -- and never wedges a later reader of that
-  SLRU slot/bank.
-- The mirror image matches the locally written bytes even when a write-OK caller
-  updates the page during the physical write (snapshot-under-lock).
-- A non-WAL-truncating / int64-pageno SLRU (e.g. `pg_notify`) is refused rather
-  than silently store-backed with an undefined tombstone version or an aliased key.
+- A branch created at `L` sees a committed xid iff its commit record is at/below `L`;
+  an xid committed on the parent after `L` is **not** committed on the branch, even
+  when it shares a `pg_xact` page with a pre-`L` commit.
+- multixact and commit-ts as of `L` match what the parent saw at `L`.
+- The branch boots from its reconstructed SLRU and then writes its own status
+  forward with no store involvement on the steady-state path.
+- If the parent WAL through `L` is not available on the store, branch creation fails
+  closed rather than seeding partial/zeroed status.
+- A non-WAL/`int64` SLRU (`pg_subtrans`, `pg_notify`, serializable) is excluded, not
+  silently store-backed.
 
 ## Open questions
 
-- Tombstone granularity: per-page vs per-segment range, and how it interacts with
-  M3 layer/manifest persistence.
-- The exact cache-hit revalidation mechanism: a coarse `mirrored_status_lsn`-epoch
-  bump that forces SLRU slot revalidation vs. targeted slot invalidation.
-- Where `mirrored_status_lsn` is advanced (deferred-drain completion vs. a dedicated
-  status shipper) and how a reader waits on it without livelock.
-- A per-SLRU truncate-version source + a 64-bit object key, to admit the non-WAL /
-  int64 SLRUs (`pg_subtrans`, `pg_notify`, serializable) post-M4.
+- Materialize-at-create (simple; a one-time replay cost) vs. serve SLRU pages
+  on-demand via as-of redo (lazier; needs the read hooks and their safety). M4
+  leans materialize-at-create.
+- How far back the replay base must sit for each in-scope SLRU, and how that
+  interacts with parent WAL retention (see PGCONTROL_ON_STORE_DESIGN.md's
+  retention-gating point).
+- Whether commit-ts should be reconstructed eagerly or only when
+  `track_commit_timestamp` is on.
 
-See also: the read-path PR stack plan and the branch-PostgreSQL milestone plan
-(M4: bootable branch compute), and [PGCONTROL_ON_STORE_DESIGN.md] for the sibling
-pg_control protocol.
+See also: the read-path PR stack plan, the branch-PostgreSQL milestone plan (M4:
+bootable branch compute), the store-backed WAL reader (#53) this reuses, and
+[PGCONTROL_ON_STORE_DESIGN.md] for the sibling pg_control protocol.

--- a/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
@@ -64,17 +64,34 @@ These are the WAL-logged, `uint32`-page SLRUs. Out of scope and explicitly exclu
 
 ## M4 design: as-of-fork reconstruction
 
-At branch creation (or first start of the branch compute):
+The seed is a **base snapshot + forward replay** (the same base-image-plus-redo
+pattern relation pages use), not replay into empty segments. At branch creation (or
+first start of the branch compute):
 
-- Replay the parent's WAL from a base up to `L`, applying only the SLRU-relevant
-  records, to **materialize the branch's local clog / multixact / commit-ts
-  segments** as of `L`. This reuses the shipped-WAL + redo machinery from #53 (the
-  store already serves per-timeline WAL byte ranges and the compute already has an
-  `XLogReader` redo path); the SLRU apply is the existing `xact_redo` /
-  `multixact_redo` / `commit_ts_redo` logic pointed at the branch's segment files.
-- The base to start replay from is the parent's last SLRU checkpoint/truncation
-  point at or before `L` (clog/multixact pages are only kept back to their truncate
-  horizon, which is itself WAL-logged for the in-scope SLRUs).
+- **Base snapshot.** Start from a **consistent SLRU segment snapshot at a checkpoint
+  `C <= L`** -- the parent's actual `pg_xact` / `pg_multixact` / commit-ts segment
+  contents as of `C`. WAL alone is not enough: an xid committed *before* `C` but
+  still within the retained clog/multixact range has **no** record in `(C, L]`
+  (`CheckPointCLOG()` / `SimpleLruWriteAll()` only flush pages, `CLOG_TRUNCATE` only
+  removes them), so replaying into empty segments would leave its status unset and
+  change visibility. The base must carry those already-set statuses.
+  - The base is a **consistent point-in-time image at a checkpoint**, so it has no
+    coalescing problem: everything up to `C` is in the snapshot, everything after
+    `C` is in per-update WAL. This is *not* the per-write flushed-page mirror round 3
+    ruled out -- that tried to answer an as-of query from one coalesced image; here
+    the image answers as-of-`C` exactly and `(C, L]` is WAL.
+  - Source: the parent ships a whole-segment SLRU snapshot to the store at its
+    checkpoints (coarse, periodic, keyed by the checkpoint redo LSN), or its current
+    segments are copied as the base when the parent is reachable at branch time. The
+    base must cover at least the retained status range as of `C`.
+- **Forward replay `(C, L]`.** Apply only the SLRU status effects of the records in
+  `(C, L]` onto the base to bring it to exactly `L`, reusing #53's shipped-WAL +
+  `XLogReader` path. Use a **narrowly scoped SLRU-status applier**, not full
+  `xact_redo`: commit/abort redo also drops relation files, updates stats, and
+  issues invalidations, none of which may run during branch seeding (they would
+  mutate unrelated branch-local state). The applier extracts only the
+  xid->status / multixact offset+member / commit-ts effects and writes them to the
+  branch's segments.
 - After materialization the branch has ordinary local SLRU and **writes forward
   itself**; nothing is served from the store on the steady-state path, so none of
   the live-mirror hazards (critical-section mirroring, read-hook interrupt safety,
@@ -82,13 +99,14 @@ At branch creation (or first start of the branch compute):
 
 Why this dissolves the round-1/2/3 findings:
 
-- No flushed-page snapshot, so no coalescing (round-3 finding) and no
-  overflow-snapshot problem.
-- The "version" of a reconstructed page is intrinsic -- it is whatever the WAL says
-  at `L` -- so there is no daemon-counter-vs-branch-LSN mismatch and no need for a
-  per-object version IPC for the seed path.
-- Truncation as of `L` is just the truncate records up to `L`; no store tombstone is
-  needed to seed a branch.
+- The base is a consistent checkpoint image and everything after it is per-update
+  WAL, so there is no flushed-page coalescing and no single-image-answers-as-of-`L`
+  problem.
+- The result's "version" is intrinsic -- base at `C` plus exactly the WAL through
+  `L` -- so there is no daemon-counter-vs-branch-LSN mismatch and no per-object
+  version IPC for the seed path.
+- Truncation as of `L` is the base's truncate horizon plus the truncate records in
+  `(C, L]`; no store tombstone is needed to seed a branch.
 
 ### Reconstruction correctness
 
@@ -97,9 +115,9 @@ Why this dissolves the round-1/2/3 findings:
   `redo_page_asof` already applies for relation pages).
 - multixact needs both `offsets` and `members` replayed together to a consistent
   point; commit-ts only if `track_commit_timestamp` was on in the parent.
-- Fail closed: if the parent WAL needed to reach `L` is not available on the store
-  (not shipped / truncated away), branch creation fails rather than seeding partial
-  status -- a half-known clog must never boot.
+- Fail closed: if either the base snapshot at `C` or the parent WAL across `(C, L]`
+  is unavailable on the store, branch creation fails rather than seeding partial or
+  zeroed status -- a half-known clog must never boot.
 
 ## Identity and versioning (for any persisted SLRU object)
 
@@ -158,11 +176,15 @@ This list is the spec for that feature; none of it blocks M4.
 
 ## Sequencing (M4)
 
-1. Reuse #53's shipped-WAL + `XLogReader` redo to replay SLRU records to `L`.
-2. Branch-create: materialize clog / multixact / commit-ts segments as of `L` from
-   the parent's WAL; fail closed if that WAL is unavailable.
-3. Verify the branch boots on its reconstructed status and writes forward locally.
-4. Tests: the acceptance scenarios below.
+1. Parent: ship a consistent whole-segment SLRU snapshot (clog/multixact/commit-ts)
+   to the store at checkpoints, keyed by the checkpoint redo LSN.
+2. A narrowly scoped **SLRU-status applier** that applies only the status effects of
+   xact/multixact/commit-ts records (no relation drops, stats, or invalidations).
+3. Branch-create: load the base snapshot at `C <= L`, replay `(C, L]` through the
+   applier into the branch's segments; fail closed if the base or that WAL is
+   unavailable.
+4. Verify the branch boots on its reconstructed status and writes forward locally.
+5. Tests: the acceptance scenarios below.
 
 (The deferred live-sharing items above are sequenced separately, after M4.)
 
@@ -171,11 +193,16 @@ This list is the spec for that feature; none of it blocks M4.
 - A branch created at `L` sees a committed xid iff its commit record is at/below `L`;
   an xid committed on the parent after `L` is **not** committed on the branch, even
   when it shares a `pg_xact` page with a pre-`L` commit.
+- An xid committed **before the base `C`** but still in the retained clog range is
+  committed on the branch -- its status comes from the base snapshot, not from
+  `(C, L]` WAL (which does not contain it).
+- Branch seeding does not drop relation files, touch stats, or fire invalidations
+  (narrow applier, not full `xact_redo`).
 - multixact and commit-ts as of `L` match what the parent saw at `L`.
 - The branch boots from its reconstructed SLRU and then writes its own status
   forward with no store involvement on the steady-state path.
-- If the parent WAL through `L` is not available on the store, branch creation fails
-  closed rather than seeding partial/zeroed status.
+- If the base snapshot or the parent WAL through `L` is not available on the store,
+  branch creation fails closed rather than seeding partial/zeroed status.
 - A non-WAL/`int64` SLRU (`pg_subtrans`, `pg_notify`, serializable) is excluded, not
   silently store-backed.
 

--- a/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
@@ -61,10 +61,22 @@ to seven lifecycle questions the prototype answers unsafely or not at all:
   block = pageno }`, `spcOid = dbOid = forkNum = 0`. `slru_klass_id(Dir)` maps a
   stable small integer per SLRU directory (`pg_xact` = 1, `pg_multixact/offsets`
   = 2, ...). The mapping is fixed and versioned; adding an SLRU appends an id.
-- **Version order.** Each object write carries a monotonic version assigned by the
-  daemon as `max(existing versions across ancestry) + 1` (the existing
-  non-relation path in `append_page`). The compute never derives an SLRU version
-  from page bytes. This already satisfies finding (3); the design keeps it.
+- **Version order (branch-aware).** The store resolves branch reads by walking
+  timeline ancestry and capping parent versions at the branch-creation LSN
+  (`read_through`). An SLRU object version must therefore be comparable to that
+  cap, so the daemon-local `max+1` counter the relation prototype uses is **wrong
+  for objects**: a parent SLRU write that happens *after* a branch is created still
+  gets a small counter value, compares below the branch LSN, and leaks post-branch
+  parent transaction status into the branch. Instead the **writer supplies the
+  version = the WAL insert LSN captured under the SLRU bank lock at write time**,
+  and the daemon stores that value verbatim (no daemon-assigned counter for
+  objects). The LSN is cluster-global, so versions are monotonic, globally ordered
+  across backends, and directly comparable to the branch cutoff -- branch ancestry
+  visibility is then correct, and the read cutoff for objects is this LSN.
+- **Read returns the version.** `obj_read` / `PS_OP_READ_AT` currently return only
+  page bytes plus status/result; they must also return the resolved object version
+  (LSN) so the read hook can compare it against a cached local page (see cache
+  coherence). This is a required IPC addition, not optional.
 - **Granularity.** One object block per SLRU page (`BLCKSZ`). A segment's worth of
   pages is many objects; there is no segment-level object.
 
@@ -74,37 +86,57 @@ The core decision: **mirroring is deferred, never synchronous from inside a
 critical section.** A synchronous mirror cannot be made both crash-safe and
 PANIC-safe in a commit critical section, so it is removed from the hot write path.
 
-### Deferred mirror queue
+### Deferred mirror queue (shared memory)
 
-- The write hook's only job under the bank lock is to **stage** the dirty page: it
-  copies the just-written page image (finding 2: snapshot under the lock) plus
-  `(slru_klass_id, pageno)` and a monotonically increasing local stamp into a
-  bounded in-process queue. Staging is allocation-free and lock-free against the
-  daemon; it cannot fail in a way that breaks the SLRU write, and it is safe in a
-  critical section.
-- A **drain point** outside any critical section ships the queued images via
-  `obj_write`. Drain runs at: (a) the next non-critical SLRU access, (b)
-  `SimpleLruWriteAll()` / checkpoint, and (c) before transaction commit returns to
-  the client. Whichever comes first flushes the page; (b) bounds staleness even
-  for an idle backend, because the checkpointer's `SimpleLruWriteAll` drains.
-- **Durability handoff.** A commit is not acknowledged as durable-on-store until
-  the queue entries for SLRU pages it dirtied have been shipped and the daemon has
-  acked. For correctness of branch *reads* the weaker contract is enough: a store
-  read must never return an image older than what a reader on the writing compute
-  would see locally; the drain-at-checkpoint plus read-side revalidation (below)
-  provides that. Strict durable-on-commit is an opt-in (`synchronous` mode) for
-  computes that must fail over without replaying local WAL.
+- The write hook's only job under the bank lock is to **stage** the dirty page into
+  a **shared-memory** queue: the just-written page image (snapshotted under the
+  lock), `(slru_klass_id, pageno)`, and the **WAL insert LSN captured under the
+  lock** as the version. The queue must be in shared memory, not a per-backend
+  buffer -- PostgreSQL backends are separate processes, so a private queue is
+  invisible to the checkpointer and would never be drained for an idle backend
+  (fixes the "use shared state for checkpoint drains" finding). Staging is
+  allocation-free and cannot fail in a way that breaks the SLRU write, so it is
+  safe in a critical section.
+- **Global order, last-writer-wins by LSN.** Because the version is the captured
+  WAL LSN, two backends staging the same page and draining in either order are
+  resolved correctly: the daemon keeps the highest-LSN version and **rejects a
+  drained entry whose LSN is below the page's current stored version**. Ordering is
+  by LSN, never by drain wall-clock or a per-process stamp (fixes the
+  "keep mirrors ordered across deferred drains" finding).
+- **Drain points.** Any backend or the checkpointer ships queued images via
+  `obj_write` from outside any critical section: at (a) the next non-critical SLRU
+  access and (b) `SimpleLruWriteAll()` / checkpoint. Because the queue is shared
+  and entries carry their LSN, the checkpointer drains entries staged by an
+  idle backend, bounding staleness regardless of which process flushes.
+- **No fallible post-commit drain.** There is deliberately *no* "drain before the
+  commit returns to the client" point: a page dirtied inside the commit critical
+  section can only be drained after the transaction is already durable locally, so
+  an `obj_write` failure there is too late to abort and must not throw. The
+  durability contract is instead anchored at the checkpoint barrier (below); a
+  backend that needs durable-on-commit uses `synchronous` mode, which drains
+  **before** the commit decision, where an error can still abort.
 - **Overflow.** If the queue fills (a long critical section dirtying many pages),
   staging records a "dirty SLRU range" watermark instead of dropping pages; the
-  drain re-reads those pages from the local segment and ships them. The store is
-  never left believing it is current when a page was dropped (fixes finding 1).
+  drain re-reads those pages from the local segment and re-stages them with their
+  recorded LSN. The store is never left believing it is current when a page was
+  dropped.
 
-### Mode summary
+### Durability handoff
+
+- **Default (deferred).** Correctness for branch *reads* needs only: a store read
+  never returns an image older than what a reader on the writing compute would see,
+  and the checkpoint barrier makes all pages dirtied before a checkpoint durable on
+  the store before that checkpoint is complete-on-store. Read-side revalidation
+  (below) covers the in-flight window. This is the mode for branch read-sharing.
+- **Synchronous (opt-in).** Pages dirtied by a transaction are drained and acked
+  **before the commit decision**, so a failure aborts rather than lying about a
+  committed transaction. For computes that must fail over without replaying local
+  WAL.
 
 | Mode | When mirror ships | Durability on store | Use |
 |------|-------------------|---------------------|-----|
-| deferred (default) | checkpoint / next access / pre-commit | bounded staleness | branch read-sharing |
-| synchronous | before commit ack | durable-on-commit | failover without local WAL replay |
+| deferred (default) | checkpoint / next non-critical access | durable by checkpoint barrier | branch read-sharing |
+| synchronous | before the commit decision | durable-on-commit | failover without local WAL replay |
 
 The prototype's `CritSectionCount > 0 -> return` becomes `CritSectionCount > 0 ->
 stage only`; the actual `obj_write` always runs outside critical sections.
@@ -117,13 +149,20 @@ before serving store pages", "Do not resurrect truncated SLRU pages").
 
 - A truncate installs a durable **tombstone** object for the truncated page range
   on the relevant timeline: a versioned record `(klass, pageno-range, truncated)`
-  that the daemon honours in `read_resolve` -- a read at/after the tombstone's
-  version returns "not present" for those pages even if an older image exists.
-- Truncation is logged (it follows WAL) so the tombstone write can be deferred to
-  the same drain mechanism, ordered after the page writes it supersedes by the
-  monotonic version. Ordering is by version, not wall-clock.
-- A re-extension (new page in a previously truncated range) is just a newer
-  version above the tombstone and wins normally.
+  at the truncation's WAL LSN that the daemon honours in `read_resolve` -- a read
+  whose cutoff is at/after the tombstone LSN returns "not present" for those pages
+  even if an older image exists.
+- **Synchronous order-barrier, not deferred.** Unlike page mirrors, the tombstone
+  must be **durable on the store before the local segments are deleted**. If it
+  rode the deferred queue, there would be a window after `SimpleLruTruncate()`
+  removes the local segment but before the tombstone is durable where another
+  compute still reads the older store image -- exactly the resurrection this
+  prevents. So truncation drains any pending mirrors for the range, writes the
+  tombstone, waits for the daemon ack, and only then proceeds with local deletion.
+- Ordering is by LSN: the tombstone carries the truncation LSN, so a re-extension
+  (a new page write in a previously truncated range) at a higher LSN wins over the
+  tombstone, and a stale page write at a lower LSN stays hidden. The daemon must
+  apply tombstone and page versions in LSN order regardless of drain arrival order.
 
 ## Existence semantics
 
@@ -133,30 +172,48 @@ declaring pages absent").
 
 - Add a `slru_page_exists_hook` symmetric to the read hook, called from
   `SimpleLruDoesPhysicalPageExist()` *before* the local-segment stat. With
-  `slru_read_from_store` on, it asks the daemon whether the object block has a
-  live (non-tombstoned) version and returns existence accordingly; on a miss it
-  falls through to the local check.
-- The probe shares the read path's found-ness contract: it must distinguish "has a
-  stored version" from "below fork length but never written" so a sparse page is
-  reported absent (so the caller zero-initializes) rather than present-as-zeros.
+  `slru_read_from_store` on, it asks the daemon about the object block and returns
+  a **tri-state**, not a bool:
+  - **present** -- a live version exists; report exists, skip the local stat.
+  - **tombstoned (negative)** -- the store has truncated this range; report
+    **absent and suppress the local fallback**. A compute that still has an old
+    local segment must not report the page present (fixes the "treat tombstones as
+    negative cache entries" finding); the store's tombstone is authoritative.
+  - **unknown/miss** -- the store has nothing for this page; fall through to the
+    local stat.
+- The probe shares the read path's found-ness contract: a block below fork length
+  but never written is a miss (sparse), reported absent so the caller
+  zero-initializes -- distinct from a tombstone, which actively forbids the page.
 
 ## Read path and cache coherence
 
-- **Found-ness.** `obj_read` uses `PS_OP_READ_AT` and reports presence in
-  `ch->result` (already fixed for the POSIX daemon). The **SPDK daemon must set the
-  same `ch->result` on its `READ_AT` path** before this is relied on (P2 finding),
-  or store-backed SLRU silently misses on SPDK. This is a precondition for serving
-  SLRU from an SPDK-backed store.
-- **Sparse blocks.** A block below the object's fork length but never written must
-  read as a miss (fall back to local), never as a zero-filled "present" page.
+- **Found-ness (both daemons).** `obj_read` uses `PS_OP_READ_AT` and must report
+  presence in `ch->result`. **Neither merged daemon does this yet**: the POSIX
+  `PS_OP_READ_AT` path initializes `ch->result = 0` and never sets it on a
+  successful `read_resolve()`, and the SPDK path likewise leaves it 0. Both must be
+  fixed before this contract holds (the POSIX fix is the first sequencing item, not
+  a precondition assumed done), or every store read looks like a miss and SLRU
+  falls back to local/zeros.
+- **Version return.** The same `READ_AT` reply must carry the resolved version
+  (LSN) so the read hook can do cache revalidation below.
+- **Sparse blocks.** A block below the object's fork length but never written reads
+  as a miss (sparse), never as a zero-filled "present" page.
 - **Local cache revalidation.** A compute with `slru_read_from_store` on may also
-  hold the page in an SLRU shared buffer. The design serves the store version only
-  when it is at least as new as any cached local copy: the read hook compares the
-  store version against the buffered page's known version (tracked per slot) and
-  falls back to the local/buffered page when it is newer, and invalidates the
-  cached page when the store is newer. A compute that only reads from the store
-  (no local writer) never caches a newer page, so the common case is a plain
-  store read.
+  hold the page in an SLRU shared buffer. Using the returned version, the read hook
+  serves the store page only when its LSN is at least as new as the cached slot's
+  known version, falls back to the buffered page when that is newer, and
+  invalidates the cached page when the store is newer. A read-only compute (no
+  local writer) never caches a newer page, so the common case is a plain store read.
+- **Fail closed for store-required pages.** Returning `false` (fall back to local)
+  on a store error is only safe when a valid local copy exists. A branch compute
+  booted with no local SLRU has none, and PostgreSQL treats a missing local SLRU
+  page during recovery as a **zero page** -- so a transient daemon error or cancel
+  while reading `pg_xact`/multixact would silently turn real transaction status
+  into zeros. When the page is store-required (no local segment / store-only mode),
+  the hook must instead **fail closed**: clean up the slot and propagate a safe
+  error, never let the core zero-fill. Distinguish the two modes explicitly:
+  - **store-optional** (local copy present): error -> fall back to local read.
+  - **store-required** (no local copy): error -> slot cleanup + error, never zero.
 
 ## Interrupt and lock safety
 
@@ -165,14 +222,17 @@ not let an interrupt escape before the core restores that state (findings: "Do n
 rethrow while an SLRU read is in progress", "...while an SLRU write holds locks").
 
 - **Read hook.** Invoked after the slot is `SLRU_PAGE_READ_IN_PROGRESS` and the
-  bank lock is dropped. The hook must **never `PG_RE_THROW()`** out of this window.
-  On any error -- including query-cancel -- it returns `false` (fall back to local
-  read) and lets `slru.c` finish the slot transition; the pending interrupt is
-  serviced at the next `CHECK_FOR_INTERRUPTS()` after the slot is consistent.
-  Equivalently, `slru.c` can be taught to run the hook before marking the slot and
-  to clean up the slot if the hook signals failure -- but the simpler rule is
-  "hook never throws across the in-progress window".
-- **Write hook.** With deferral, the hook only stages into the in-process queue
+  bank lock is dropped. The hook must **never `PG_RE_THROW()`** out of this window
+  directly -- a raw throw exits before `slru.c` resets the slot and wedges later
+  readers. Instead the hook returns a small status to the core: `SERVED`,
+  `FALLBACK` (store-optional miss/error -> read local), or `FAILED` (store-required
+  error). `slru.c` is taught to restore the slot to a clean state (mark it
+  empty/error and release the in-progress marker) for both `FALLBACK` and `FAILED`,
+  and *then*, for `FAILED`, raise the error -- so the store-required fail-closed
+  path (above) propagates a real error without ever leaving the slot transitional.
+  This replaces the prototype's "swallow-but-rethrow-cancel" dance, which threw
+  across the in-progress window.
+- **Write hook.** With deferral, the hook only stages into the shared-memory queue
   and does no fallible daemon I/O under the bank lock, so it has nothing to throw.
   The actual `obj_write` happens at a drain point where normal error handling
   applies and no SLRU lock is held.
@@ -183,28 +243,42 @@ rethrow while an SLRU read is in progress", "...while an SLRU write holds locks"
 
 ## Sequencing
 
-1. Daemon: SLRU tombstone object + version-ordered `read_resolve` honouring it.
-2. Daemon: SPDK `READ_AT` found-ness parity (precondition for serving SLRU on SPDK).
-3. Core: `slru_page_exists_hook` from `SimpleLruDoesPhysicalPageExist()`.
-4. Core/module: deferred mirror queue + drain points; write hook stages only.
-5. Module: read-hook cache revalidation + sparse-block fallback.
-6. Module: truncate -> tombstone wiring through the drain.
-7. Tests: the acceptance scenarios below.
+1. Daemon IPC: `READ_AT` reports found-ness in `ch->result` **and returns the
+   resolved version (LSN)** -- on **both** POSIX and SPDK paths (neither does today).
+2. Daemon: store object versions are writer-supplied LSNs (no daemon `max+1`
+   counter for objects); `read_resolve` caps by the branch LSN using those.
+3. Daemon: SLRU tombstone object + LSN-ordered `read_resolve` honouring it,
+   including a negative result for existence probes.
+4. Core: shared-memory mirror queue; write hook captures the WAL LSN under the
+   bank lock and stages only.
+5. Core: `slru_page_exists_hook` (tri-state) from `SimpleLruDoesPhysicalPageExist()`.
+6. Core: read hook returns `SERVED`/`FALLBACK`/`FAILED`; `slru.c` cleans the slot
+   and fails closed for store-required pages.
+7. Module: drain points (checkpoint + next access), cache revalidation, sparse
+   fallback; truncate -> synchronous tombstone barrier before local deletion.
+8. Tests: the acceptance scenarios below.
 
 ## Acceptance criteria
 
 - A committed xid's `pg_xact` page evicted *inside* the commit critical section is
-  still mirrored (via deferral) and readable from the store on another compute.
-- A truncated SLRU page is reported absent by both the read hook and the existence
-  hook; it is not resurfaced from an older store image.
+  still mirrored (via the shared deferred queue, drained at checkpoint even if the
+  writing backend went idle) and readable from the store on another compute.
+- A parent SLRU write *after* a branch is created is **not** visible to the branch
+  (the LSN version compares above the branch cutoff), and a write before it is.
+- Two backends mirroring the same page in either drain order converge to the
+  higher-LSN image; a stale lower-LSN drain is rejected.
+- A truncated SLRU range is reported absent by both the read hook and the existence
+  hook, suppressing local fallback even when an old local segment is still present;
+  a re-extension at a higher LSN supersedes the tombstone.
 - `SimpleLruDoesPhysicalPageExist()`-first callers (commit-ts activation,
   multixact offset) see store-backed pages on a compute with no local segments.
-- A sparse/unwritten page below fork length falls back to local rather than
-  serving zeros, on both POSIX and SPDK daemons.
+- A sparse/unwritten page below fork length falls back to local (or reports absent)
+  rather than serving zeros, on both POSIX and SPDK daemons.
 - A store page never overrides a newer locally-cached page, and a stale local
-  cache is invalidated when the store is newer.
-- A query cancel during a store-backed SLRU read or a mirror write never wedges a
-  later reader of that SLRU slot/bank.
+  cache is invalidated when the store is newer (using the returned version).
+- For a store-required page, a daemon error or query cancel during the read **fails
+  closed** (clean slot + error) -- it never turns transaction status into zeros --
+  and never wedges a later reader of that SLRU slot/bank.
 
 ## Open questions
 

--- a/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
@@ -75,15 +75,23 @@ first start of the branch compute):
   (`CheckPointCLOG()` / `SimpleLruWriteAll()` only flush pages, `CLOG_TRUNCATE` only
   removes them), so replaying into empty segments would leave its status unset and
   change visibility. The base must carry those already-set statuses.
-  - The base is a **consistent point-in-time image at a checkpoint**, so it has no
-    coalescing problem: everything up to `C` is in the snapshot, everything after
-    `C` is in per-update WAL. This is *not* the per-write flushed-page mirror round 3
-    ruled out -- that tried to answer an as-of query from one coalesced image; here
-    the image answers as-of-`C` exactly and `(C, L]` is WAL.
-  - Source: the parent ships a whole-segment SLRU snapshot to the store at its
-    checkpoints (coarse, periodic, keyed by the checkpoint redo LSN), or its current
-    segments are copied as the base when the parent is reachable at branch time. The
-    base must cover at least the retained status range as of `C`.
+  - The base must be a **clean as-of-`C` image**: all status with LSN `<= C`, none
+    after. Then everything after `C` comes from per-update WAL and there is no
+    coalescing. This is *not* the per-write flushed-page mirror round 3 ruled out.
+  - **`C` is not the checkpoint redo LSN.** An online checkpoint fixes `redo`,
+    releases the WAL insertion locks, and only later flushes SLRUs in
+    `CheckPointGuts()`; `SimpleLruWriteAll(.., allow_redirtied=true)` lets a commit
+    *after* `redo` land in that flush. So the flushed image contains status past
+    `redo`, and keying it by `redo` would let a branch whose `L` falls between
+    `redo` and such a commit seed with post-branch status. `C` must instead be an
+    LSN that truly upper-bounds the snapshot's contents (at or after the checkpoint
+    **completion record**), and the snapshot must provably contain nothing past `C`
+    -- captured at a quiesce/restartpoint, or under a brief SLRU write barrier that
+    stamps the current insert LSN as `C`. A base may seed only branches with
+    `L >= C`; a branch below the nearest snapshot uses an earlier one.
+  - Source: the parent ships such a clean whole-segment SLRU snapshot to the store
+    (coarse, periodic, keyed by its proven cutoff `C`), or its current segments are
+    copied as the base when the parent is reachable at branch time.
 - **Forward replay `(C, L]`.** Apply only the SLRU status effects of the records in
   `(C, L]` onto the base to bring it to exactly `L`, reusing #53's shipped-WAL +
   `XLogReader` path. Use a **narrowly scoped SLRU-status applier**, not full
@@ -91,7 +99,11 @@ first start of the branch compute):
   issues invalidations, none of which may run during branch seeding (they would
   mutate unrelated branch-local state). The applier extracts only the
   xid->status / multixact offset+member / commit-ts effects and writes them to the
-  branch's segments.
+  branch's segments. It must **also** process `XLOG_PARAMETER_CHANGE`
+  (`RM_XLOG_ID`), whose redo (`CommitTsParameterChange()`) activates/deactivates
+  commit-ts and creates/resets its segment state: a parent that toggles
+  `track_commit_timestamp` between `C` and `L` would otherwise seed commit-ts active
+  over the wrong interval or miss the activation page.
 - After materialization the branch has ordinary local SLRU and **writes forward
   itself**; nothing is served from the store on the steady-state path, so none of
   the live-mirror hazards (critical-section mirroring, read-hook interrupt safety,
@@ -176,10 +188,12 @@ This list is the spec for that feature; none of it blocks M4.
 
 ## Sequencing (M4)
 
-1. Parent: ship a consistent whole-segment SLRU snapshot (clog/multixact/commit-ts)
-   to the store at checkpoints, keyed by the checkpoint redo LSN.
+1. Parent: ship a clean whole-segment SLRU snapshot (clog/multixact/commit-ts) to
+   the store, keyed by a **proven cutoff `C`** (at/after the checkpoint completion
+   record, or a barrier-stamped insert LSN) -- never the redo LSN.
 2. A narrowly scoped **SLRU-status applier** that applies only the status effects of
-   xact/multixact/commit-ts records (no relation drops, stats, or invalidations).
+   xact/multixact/commit-ts **and `XLOG_PARAMETER_CHANGE`** records (no relation
+   drops, stats, or invalidations).
 3. Branch-create: load the base snapshot at `C <= L`, replay `(C, L]` through the
    applier into the branch's segments; fail closed if the base or that WAL is
    unavailable.
@@ -196,9 +210,14 @@ This list is the spec for that feature; none of it blocks M4.
 - An xid committed **before the base `C`** but still in the retained clog range is
   committed on the branch -- its status comes from the base snapshot, not from
   `(C, L]` WAL (which does not contain it).
+- A base snapshot is keyed by a cutoff `C` that provably bounds its contents (no
+  status past `C`), so a branch at `L >= C` never inherits a commit that landed in
+  an online checkpoint's flush after `redo` but after `L`.
 - Branch seeding does not drop relation files, touch stats, or fire invalidations
   (narrow applier, not full `xact_redo`).
-- multixact and commit-ts as of `L` match what the parent saw at `L`.
+- multixact and commit-ts as of `L` match what the parent saw at `L`, including when
+  the parent toggled `track_commit_timestamp` in `(C, L]` (the applier replays
+  `XLOG_PARAMETER_CHANGE`).
 - The branch boots from its reconstructed SLRU and then writes its own status
   forward with no store involvement on the steady-state path.
 - If the base snapshot or the parent WAL through `L` is not available on the store,

--- a/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
+++ b/contrib/pagestore/SLRU_ON_STORE_DESIGN.md
@@ -1,0 +1,219 @@
+# SLRU on the store: lifecycle design (M4)
+
+Status: design. The PR-#49 prototype (`feat/pagestore-slru`) mirrors and serves
+SLRU pages through the `klass` storage seam, but review showed the gaps are not
+local bugs -- they span the whole SLRU object lifecycle. Per the read-path stack
+plan, store-backed SLRU stays frozen until that lifecycle is defined here. This
+document is the gate; implementation resumes against it.
+
+## Scope
+
+SLRUs are the small fixed-page logs PostgreSQL keeps under `pg_xact`,
+`pg_multixact/{offsets,members}`, `pg_subtrans`, `pg_commit_ts`, `pg_serial`,
+and `pg_notify`. Putting them on the store lets a branch compute read shared
+transaction-status state (clog, commit-ts, multixact) it has no local copy of,
+and lets a writer's SLRU updates become visible to other computes of the same
+branch.
+
+In scope: identity/versioning, the write/mirror protocol, truncation, existence
+probes, the read path and cache coherence, and interrupt/lock safety. Out of
+scope: cross-branch SLRU retention/GC (M5) and any SLRU-specific compaction.
+
+## Why the prototype is not mergeable
+
+The prototype installs two hooks in `slru.c` -- a write hook after
+`SlruPhysicalWritePage()` and a read hook in `SlruPhysicalReadPage()` -- and
+mirrors/serves each page as a `PS_KLASS_SLRU` object keyed by
+`(slru_klass_id(Dir), pageno)`. The hooks run **with the SLRU bank lock held**,
+and the write hook can fire **inside a transaction commit/abort critical
+section** (an eviction via `SlruSelectLRUPage`). From there it does fallible
+shared-memory I/O against the daemon. The review findings (15 P1 / 11 P2) reduce
+to seven lifecycle questions the prototype answers unsafely or not at all:
+
+1. **Critical-section writes.** The hook returns early when `CritSectionCount > 0`
+   so it never PANICs -- but then the page is silently *not* mirrored, and there
+   is no guarantee a later non-critical write ever re-mirrors it. The store goes
+   permanently stale for that page (e.g. an evicted `pg_xact` page during commit).
+2. **Mirror fidelity.** The hook must mirror exactly the image that was written
+   to the local segment, snapshotted under the bank lock -- not whatever the
+   shared buffer holds when the (possibly deferred) mirror later runs.
+3. **Version ordering.** SLRU pages have no `pd_lsn`; their first bytes are
+   payload. Versions must come from a real monotonic order, not page bytes, or an
+   overwrite can compare lower than the prior version and be lost.
+4. **Truncation / tombstones.** `SimpleLruTruncate()` drops segments. Without a
+   durable tombstone on the store, a store read can resurrect a truncated page.
+5. **Existence probes.** `SimpleLruDoesPhysicalPageExist()` is consulted *before*
+   the read hook by commit-ts activation and multixact offset reads
+   (`commit_ts.c`, `multixact.c`). With local segments absent it reports "missing"
+   and the caller zero-initializes -- the store is never consulted.
+6. **Read cache coherence.** A compute may hold a cached local SLRU page in a
+   shared buffer; serving an *older* store page, or trusting a stale local page
+   over a newer store version, both corrupt transaction state.
+7. **Interrupt / lock safety.** The read hook runs after the slot is marked
+   `SLRU_PAGE_READ_IN_PROGRESS` and the bank lock is released; a `PG_RE_THROW()`
+   of a query-cancel exits before `slru.c` marks the slot valid/empty, wedging
+   every later reader of that slot. The write hook rethrows while the bank lock is
+   still held.
+
+## SLRU object model on the store
+
+- **Identity.** `PsKey{ klass = PS_KLASS_SLRU, relNumber = slru_klass_id(Dir),
+  block = pageno }`, `spcOid = dbOid = forkNum = 0`. `slru_klass_id(Dir)` maps a
+  stable small integer per SLRU directory (`pg_xact` = 1, `pg_multixact/offsets`
+  = 2, ...). The mapping is fixed and versioned; adding an SLRU appends an id.
+- **Version order.** Each object write carries a monotonic version assigned by the
+  daemon as `max(existing versions across ancestry) + 1` (the existing
+  non-relation path in `append_page`). The compute never derives an SLRU version
+  from page bytes. This already satisfies finding (3); the design keeps it.
+- **Granularity.** One object block per SLRU page (`BLCKSZ`). A segment's worth of
+  pages is many objects; there is no segment-level object.
+
+## Write / mirror protocol
+
+The core decision: **mirroring is deferred, never synchronous from inside a
+critical section.** A synchronous mirror cannot be made both crash-safe and
+PANIC-safe in a commit critical section, so it is removed from the hot write path.
+
+### Deferred mirror queue
+
+- The write hook's only job under the bank lock is to **stage** the dirty page: it
+  copies the just-written page image (finding 2: snapshot under the lock) plus
+  `(slru_klass_id, pageno)` and a monotonically increasing local stamp into a
+  bounded in-process queue. Staging is allocation-free and lock-free against the
+  daemon; it cannot fail in a way that breaks the SLRU write, and it is safe in a
+  critical section.
+- A **drain point** outside any critical section ships the queued images via
+  `obj_write`. Drain runs at: (a) the next non-critical SLRU access, (b)
+  `SimpleLruWriteAll()` / checkpoint, and (c) before transaction commit returns to
+  the client. Whichever comes first flushes the page; (b) bounds staleness even
+  for an idle backend, because the checkpointer's `SimpleLruWriteAll` drains.
+- **Durability handoff.** A commit is not acknowledged as durable-on-store until
+  the queue entries for SLRU pages it dirtied have been shipped and the daemon has
+  acked. For correctness of branch *reads* the weaker contract is enough: a store
+  read must never return an image older than what a reader on the writing compute
+  would see locally; the drain-at-checkpoint plus read-side revalidation (below)
+  provides that. Strict durable-on-commit is an opt-in (`synchronous` mode) for
+  computes that must fail over without replaying local WAL.
+- **Overflow.** If the queue fills (a long critical section dirtying many pages),
+  staging records a "dirty SLRU range" watermark instead of dropping pages; the
+  drain re-reads those pages from the local segment and ships them. The store is
+  never left believing it is current when a page was dropped (fixes finding 1).
+
+### Mode summary
+
+| Mode | When mirror ships | Durability on store | Use |
+|------|-------------------|---------------------|-----|
+| deferred (default) | checkpoint / next access / pre-commit | bounded staleness | branch read-sharing |
+| synchronous | before commit ack | durable-on-commit | failover without local WAL replay |
+
+The prototype's `CritSectionCount > 0 -> return` becomes `CritSectionCount > 0 ->
+stage only`; the actual `obj_write` always runs outside critical sections.
+
+## Truncation / tombstone semantics
+
+`SimpleLruTruncate()` and segment deletion must be represented on the store so a
+store read cannot resurrect a truncated page (findings: "Mirror SLRU truncations
+before serving store pages", "Do not resurrect truncated SLRU pages").
+
+- A truncate installs a durable **tombstone** object for the truncated page range
+  on the relevant timeline: a versioned record `(klass, pageno-range, truncated)`
+  that the daemon honours in `read_resolve` -- a read at/after the tombstone's
+  version returns "not present" for those pages even if an older image exists.
+- Truncation is logged (it follows WAL) so the tombstone write can be deferred to
+  the same drain mechanism, ordered after the page writes it supersedes by the
+  monotonic version. Ordering is by version, not wall-clock.
+- A re-extension (new page in a previously truncated range) is just a newer
+  version above the tombstone and wins normally.
+
+## Existence semantics
+
+`SimpleLruDoesPhysicalPageExist()` must consult the same source of truth as reads
+(findings: "Add an existence hook for SLRU probes", "Check the SLRU store before
+declaring pages absent").
+
+- Add a `slru_page_exists_hook` symmetric to the read hook, called from
+  `SimpleLruDoesPhysicalPageExist()` *before* the local-segment stat. With
+  `slru_read_from_store` on, it asks the daemon whether the object block has a
+  live (non-tombstoned) version and returns existence accordingly; on a miss it
+  falls through to the local check.
+- The probe shares the read path's found-ness contract: it must distinguish "has a
+  stored version" from "below fork length but never written" so a sparse page is
+  reported absent (so the caller zero-initializes) rather than present-as-zeros.
+
+## Read path and cache coherence
+
+- **Found-ness.** `obj_read` uses `PS_OP_READ_AT` and reports presence in
+  `ch->result` (already fixed for the POSIX daemon). The **SPDK daemon must set the
+  same `ch->result` on its `READ_AT` path** before this is relied on (P2 finding),
+  or store-backed SLRU silently misses on SPDK. This is a precondition for serving
+  SLRU from an SPDK-backed store.
+- **Sparse blocks.** A block below the object's fork length but never written must
+  read as a miss (fall back to local), never as a zero-filled "present" page.
+- **Local cache revalidation.** A compute with `slru_read_from_store` on may also
+  hold the page in an SLRU shared buffer. The design serves the store version only
+  when it is at least as new as any cached local copy: the read hook compares the
+  store version against the buffered page's known version (tracked per slot) and
+  falls back to the local/buffered page when it is newer, and invalidates the
+  cached page when the store is newer. A compute that only reads from the store
+  (no local writer) never caches a newer page, so the common case is a plain
+  store read.
+
+## Interrupt and lock safety
+
+The hooks run inside `slru.c` with transitional lock/slot state held; they must
+not let an interrupt escape before the core restores that state (findings: "Do not
+rethrow while an SLRU read is in progress", "...while an SLRU write holds locks").
+
+- **Read hook.** Invoked after the slot is `SLRU_PAGE_READ_IN_PROGRESS` and the
+  bank lock is dropped. The hook must **never `PG_RE_THROW()`** out of this window.
+  On any error -- including query-cancel -- it returns `false` (fall back to local
+  read) and lets `slru.c` finish the slot transition; the pending interrupt is
+  serviced at the next `CHECK_FOR_INTERRUPTS()` after the slot is consistent.
+  Equivalently, `slru.c` can be taught to run the hook before marking the slot and
+  to clean up the slot if the hook signals failure -- but the simpler rule is
+  "hook never throws across the in-progress window".
+- **Write hook.** With deferral, the hook only stages into the in-process queue
+  and does no fallible daemon I/O under the bank lock, so it has nothing to throw.
+  The actual `obj_write` happens at a drain point where normal error handling
+  applies and no SLRU lock is held.
+- **No swallowing of cancel/shutdown at unsafe points.** Because the fallible work
+  moved out of the locked/critical window, the prototype's
+  "swallow-but-rethrow-cancel" `PG_TRY/PG_CATCH` dance in the hooks is gone; there
+  is no interrupt to mishandle while a lock is held.
+
+## Sequencing
+
+1. Daemon: SLRU tombstone object + version-ordered `read_resolve` honouring it.
+2. Daemon: SPDK `READ_AT` found-ness parity (precondition for serving SLRU on SPDK).
+3. Core: `slru_page_exists_hook` from `SimpleLruDoesPhysicalPageExist()`.
+4. Core/module: deferred mirror queue + drain points; write hook stages only.
+5. Module: read-hook cache revalidation + sparse-block fallback.
+6. Module: truncate -> tombstone wiring through the drain.
+7. Tests: the acceptance scenarios below.
+
+## Acceptance criteria
+
+- A committed xid's `pg_xact` page evicted *inside* the commit critical section is
+  still mirrored (via deferral) and readable from the store on another compute.
+- A truncated SLRU page is reported absent by both the read hook and the existence
+  hook; it is not resurfaced from an older store image.
+- `SimpleLruDoesPhysicalPageExist()`-first callers (commit-ts activation,
+  multixact offset) see store-backed pages on a compute with no local segments.
+- A sparse/unwritten page below fork length falls back to local rather than
+  serving zeros, on both POSIX and SPDK daemons.
+- A store page never overrides a newer locally-cached page, and a stale local
+  cache is invalidated when the store is newer.
+- A query cancel during a store-backed SLRU read or a mirror write never wedges a
+  later reader of that SLRU slot/bank.
+
+## Open questions
+
+- Tombstone granularity: per-page vs per-segment range, and how it interacts with
+  M3 layer/manifest persistence.
+- Whether the synchronous (durable-on-commit) mode is needed for the first bootable
+  branch (M4) or can wait until failover work.
+- Per-slot store-version tracking cost vs a coarser epoch-based invalidation.
+
+See also: the read-path PR stack plan and the branch-PostgreSQL milestone plan
+(M4: bootable branch compute), and [PGCONTROL_ON_STORE_DESIGN.md] for the sibling
+pg_control protocol.


### PR DESCRIPTION
## Summary

Adds the two M4 design docs that gate reviving the frozen SLRU (#49) and pg_control (#50) PRs. Review showed both prototypes have whole-lifecycle gaps (SLRU 15 P1 / 11 P2; pg_control 5 P1 / 11 P2) and run fallible store I/O inside critical sections. Per `READ_PATH_PR_STACK_PLAN.md`, design comes before more implementation.

- **`SLRU_ON_STORE_DESIGN.md`** — object identity/versioning; a **deferred** mirror queue (stage under the bank lock, ship at a checkpoint/pre-commit drain — never fallible I/O in a critical section); durable truncate **tombstones**; a `SimpleLruDoesPhysicalPageExist` store hook; read-side found-ness + local-cache revalidation; interrupt/lock-safe hooks (never rethrow across the SLRU in-progress window).
- **`PGCONTROL_ON_STORE_DESIGN.md`** — monotonic control version; a **critical-section-safe** mirror via a checkpoint-completion handoff with a store-durability contract and hook chaining; an **atomic restore** (temp+rename, directory fsync, timeline-correct, channel-release, fail-closed).

Each doc maps the open review findings to required behavior with acceptance criteria. #49/#50 stay draft and resume against these.

## Validation

Documentation-only.