### PR TITLE
pagestore: fail-safe compaction/GC sequence + crash-resume test (M3)

### DIFF
--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -250,6 +250,24 @@ sw_store=$($P -c "SET pagestore.redo_wal_from_store = on;
      AND position('sw_delta'::bytea in pagestore_redo_page_asof('swal',0,0,'$sw1')) > 0;" | tail -1)
 assert "$sw_store" "t" "redo_page_asof replays base+deltas read from the store's shipped WAL (store-backed reader)"
 
+# --- 15. daemon crash recovery: un-flushed writes survive a daemon restart ------
+# Write rows that stay in the daemon's memtable + segment log (far below the flush
+# threshold, so no image layer records them), then SIGKILL the daemon (no clean
+# shutdown -> the memtable is lost) and restart it.  Recovery rebuilds the index
+# from image layers AND scans the segment tail, so these acknowledged-but-unflushed
+# rows must still read back -- otherwise layer-only recovery would drop them.
+$P -c "CREATE TABLE crash(id int, v text) TABLESPACE ts;
+       INSERT INTO crash SELECT g, 'c'||md5(g::text) FROM generate_series(1,500) g;" >/dev/null
+crash_ck=$($P -c "SELECT md5(string_agg(v,',' ORDER BY id)) FROM crash;")
+"$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1     # detach the engine (daemon zeroes shm on start)
+kill -9 "$DPID" 2>/dev/null; wait "$DPID" 2>/dev/null # crash the daemon: no ps_core_close() flush
+"$DAEMON" --shm "$SHM" --store "$STORE" >/dev/null 2>&1 &	# restart -> recovery scans layers + segment tail
+DPID=$!
+sleep 0.5
+"$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
+crash_ck2=$($P -c "SELECT md5(string_agg(v,',' ORDER BY id)) FROM crash;")
+assert "$crash_ck2" "$crash_ck" "un-flushed rows survive a daemon crash+restart (segment-tail recovery)"
+
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
 exit $fail

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -250,23 +250,30 @@ sw_store=$($P -c "SET pagestore.redo_wal_from_store = on;
      AND position('sw_delta'::bytea in pagestore_redo_page_asof('swal',0,0,'$sw1')) > 0;" | tail -1)
 assert "$sw_store" "t" "redo_page_asof replays base+deltas read from the store's shipped WAL (store-backed reader)"
 
-# --- 15. daemon crash recovery: un-flushed writes survive a daemon restart ------
-# Write rows that stay in the daemon's memtable + segment log (far below the flush
-# threshold, so no image layer records them), then SIGKILL the daemon (no clean
-# shutdown -> the memtable is lost) and restart it.  Recovery rebuilds the index
-# from image layers AND scans the segment tail, so these acknowledged-but-unflushed
-# rows must still read back -- otherwise layer-only recovery would drop them.
+# --- 15. daemon crash recovery: segment-log recovery of un-flushed writes -------
+# Restart the daemon with a flush threshold so high the rows below can never be
+# sealed into an image layer -- they live ONLY in the memtable + segment log.  Then
+# SIGKILL it (no clean shutdown, so the memtable is lost), restart, and require the
+# rows to read back.  They can only come from the segment log, so this fails if
+# recovery ever stops scanning segments (e.g. a regression to layer-only rebuild) --
+# unlike a shared-daemon test where prior writes could push these into a layer.
+"$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1          # detach the engine before restarting the daemon
+kill -9 "$DPID" 2>/dev/null; wait "$DPID" 2>/dev/null
+"$DAEMON" --shm "$SHM" --store "$STORE" --flush-pages 100000000 >/dev/null 2>&1 &  # never flushes -> no layer
+DPID=$!
+sleep 0.5
+"$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 $P -c "CREATE TABLE crash(id int, v text) TABLESPACE ts;
        INSERT INTO crash SELECT g, 'c'||md5(g::text) FROM generate_series(1,500) g;" >/dev/null
 crash_ck=$($P -c "SELECT md5(string_agg(v,',' ORDER BY id)) FROM crash;")
-"$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1     # detach the engine (daemon zeroes shm on start)
-kill -9 "$DPID" 2>/dev/null; wait "$DPID" 2>/dev/null # crash the daemon: no ps_core_close() flush
-"$DAEMON" --shm "$SHM" --store "$STORE" >/dev/null 2>&1 &	# restart -> recovery scans layers + segment tail
+"$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1          # detach before crashing the daemon
+kill -9 "$DPID" 2>/dev/null; wait "$DPID" 2>/dev/null      # crash: no ps_core_close() -> memtable lost
+"$DAEMON" --shm "$SHM" --store "$STORE" >/dev/null 2>&1 &  # restart -> rebuild the index from the segment log
 DPID=$!
 sleep 0.5
 "$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 crash_ck2=$($P -c "SELECT md5(string_agg(v,',' ORDER BY id)) FROM crash;")
-assert "$crash_ck2" "$crash_ck" "un-flushed rows survive a daemon crash+restart (segment-tail recovery)"
+assert "$crash_ck2" "$crash_ck" "un-flushed rows survive a daemon crash+restart (segment-log recovery)"
 
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"

--- a/contrib/pagestore/meson.build
+++ b/contrib/pagestore/meson.build
@@ -92,6 +92,18 @@ test('pagestore_manifest',
   timeout: 60,
 )
 
+# Unit test for crash-safe compaction/GC recovery (no daemon, no PG).
+pagestore_gc_test = executable('pagestore_gc_test',
+  files('pagestore_gc_test.c', 'pagestore_manifest.c', 'pagestore_layer.c',
+        'pagestore_layer_store.c'),
+  install: false,
+)
+test('pagestore_gc',
+  pagestore_gc_test,
+  suite: ['pagestore'],
+  timeout: 60,
+)
+
 # Unit test for the scan-resistant materialized-page cache (no daemon, no PG).
 pagestore_pgcache_test = executable('pagestore_pgcache_test',
   files('pagestore_pgcache_test.c', 'pagestore_pgcache.c'),

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1184,7 +1184,15 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	if (s->memtable)
 	{
 		ps_memtable_put(s->memtable, timeline, key, block, hdr.lsn, page);
-		if (ps_memtable_full(s->memtable))
+		/*
+		 * Flush to an image layer when full -- but not once the manifest is
+		 * poisoned: record_layer() could not record the layer, so flushing would
+		 * seal an unreferenced layer file on every subsequent write.  The page is
+		 * already durable in the segment log (recovery scans it), so it is safe to
+		 * leave it in the memtable until a restart recovers the manifest; the write
+		 * still succeeds.
+		 */
+		if (ps_memtable_full(s->memtable) && !ps_manifest_poisoned())
 		{
 			/* A flush (and any inline compaction) mutates the cross-shard
 			 * ps_layer_map, so take map_lock here -- only on the rare flush, not
@@ -1199,12 +1207,6 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 			if (count_image_layers(timeline, s->id) > (uint32_t) compact_layers * 4)
 				compact_timeline(timeline, s->id);
 			ps_unlock_map();
-			/*
-			 * A flush that could not record its layer (manifest poisoned) is not a
-			 * write failure: the page is already in the segment log, which recovery
-			 * scans, so the write stays durable and acknowledged.  The manifest
-			 * poison only stops further metadata writes and compaction.
-			 */
 		}
 	}
 	return 0;
@@ -1296,9 +1298,16 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 				__atomic_fetch_add(&s->rr_mem, 1, __ATOMIC_RELAXED);
 				served = 1;		/* served from the memtable */
 			}
-			else if (layer_map_lookup(tl, key, block, rl, &l, out) &&
+			else if (pv->seg < 0 &&
+					 layer_map_lookup(tl, key, block, rl, &l, out) &&
 					 l == pv->lsn)
 			{
+				/*
+				 * Serve from a layer only for a layer-origin version (no segment
+				 * copy).  A segment-backed version must come from its segment: a
+				 * layer match is keyed by LSN alone, so a same-pd_lsn rewrite in
+				 * the segment would otherwise be masked by the older layer image.
+				 */
 				__atomic_fetch_add(&s->rr_layer, 1, __ATOMIC_RELAXED);
 				served = 1;		/* served from an image layer */
 			}
@@ -1347,11 +1356,14 @@ recover(uint32_t shard)
 	for (int id = 0;; id++)
 	{
 		uint64_t	off = 0;
+		int64_t		seg_bytes = ps_storage->seg_size(shard, id);
 
-		if (ps_storage->seg_size(shard, id) < 0)
+		if (seg_bytes < 0)
 			break;				/* no more segments -> done */
 
-		/* replay records until one fails to validate (end of log) */
+		/* replay records until one fails to validate (end of log).  seg_bytes is
+		 * cached once here: the segment is not being written during recovery, and
+		 * the POSIX backend's seg_size() is a stat() we must not pay per record. */
 		for (;;)
 		{
 			SegRecHdr	hdr;
@@ -1386,8 +1398,7 @@ recover(uint32_t shard)
 			 * never index a version whose bytes cannot be read (which would mask a
 			 * good older version and zero-fill on read).
 			 */
-			if (ps_storage->seg_size(shard, id) <
-				(int64_t) (off + sizeof(hdr) + hdr.len))
+			if (seg_bytes < (int64_t) (off + sizeof(hdr) + hdr.len))
 				break;
 
 			page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn,
@@ -1516,6 +1527,16 @@ ps_core_close(void)
 			s->memtable = NULL;
 		}
 	}
+
+	/*
+	 * Recovery rebuilds the index from the segment log, so the segments must be
+	 * durable before we rely on them: fsync them on clean shutdown (writes between
+	 * checkpoints are otherwise only in the OS page cache, and would be lost to a
+	 * power failure after the daemon exits even though the write was acknowledged).
+	 */
+	if (ps_storage->sync)
+		ps_storage->sync();
+
 	ps_pgcache_free();
 	ps_manifest_close();
 }

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1179,20 +1179,20 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	page_add_version(timeline, key, block, hdr.lsn, s->id, s->cur_seg, data_off);
 	s->cur_off += reclen;
 
-	/* stage the version for the LSM memtable; flush to an image layer when full
-	 * (additive in phase 2 -- the segment write above is still authoritative) */
-	if (s->memtable)
+	/*
+	 * Stage the version for the LSM memtable and flush to an image layer when full
+	 * (additive in phase 2 -- the segment write above is still authoritative).
+	 *
+	 * Skip all of this once the manifest is poisoned: record_layer() can no longer
+	 * record a layer, so staging pages we can never flush would grow the memtable
+	 * without bound (turning a metadata error into an OOM), and flushing would seal
+	 * unreferenced layer files.  The page is durable in the segment log, which
+	 * recovery scans, so the write still succeeds; reads fall back to the segment.
+	 */
+	if (s->memtable && !ps_manifest_poisoned())
 	{
 		ps_memtable_put(s->memtable, timeline, key, block, hdr.lsn, page);
-		/*
-		 * Flush to an image layer when full -- but not once the manifest is
-		 * poisoned: record_layer() could not record the layer, so flushing would
-		 * seal an unreferenced layer file on every subsequent write.  The page is
-		 * already durable in the segment log (recovery scans it), so it is safe to
-		 * leave it in the memtable until a restart recovers the manifest; the write
-		 * still succeeds.
-		 */
-		if (ps_memtable_full(s->memtable) && !ps_manifest_poisoned())
+		if (ps_memtable_full(s->memtable))
 		{
 			/* A flush (and any inline compaction) mutates the cross-shard
 			 * ps_layer_map, so take map_lock here -- only on the rare flush, not
@@ -1516,6 +1516,21 @@ ps_core_close(void)
 {
 	uint32_t	ns = core_shards();
 
+	/*
+	 * Recovery rebuilds the index from the segment log, so the segments must be
+	 * durable before we rely on them: fsync them on clean shutdown (writes between
+	 * checkpoints are otherwise only in the OS page cache, and would be lost to a
+	 * power failure after the daemon exits even though the write was acknowledged).
+	 *
+	 * Sync *before* flushing the memtable into image layers below.  Otherwise a
+	 * power loss in the shutdown window could leave a just-committed layer as the
+	 * only durable copy of pages whose segment bytes were still in the page cache,
+	 * which segment-only recovery would miss.  Syncing first makes the recovery
+	 * source durable before any layer is committed on top of it.
+	 */
+	if (ps_storage->sync)
+		ps_storage->sync();
+
 	for (uint32_t i = 0; i < ns; i++)
 	{
 		Shard	   *s = &g_shards[i];
@@ -1527,15 +1542,6 @@ ps_core_close(void)
 			s->memtable = NULL;
 		}
 	}
-
-	/*
-	 * Recovery rebuilds the index from the segment log, so the segments must be
-	 * durable before we rely on them: fsync them on clean shutdown (writes between
-	 * checkpoints are otherwise only in the OS page cache, and would be lost to a
-	 * power failure after the daemon exits even though the write was acknowledged).
-	 */
-	if (ps_storage->sync)
-		ps_storage->sync();
 
 	ps_pgcache_free();
 	ps_manifest_close();

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -27,6 +27,7 @@
  *
  *-------------------------------------------------------------------------
  */
+#include <errno.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1291,7 +1292,15 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 			if (ps_pgcache_lookup(tl, key, block, pv->lsn, out))
 				return 1;
 
-			if (s->memtable &&
+			/*
+			 * The memtable is a safe read source only while it stays in lock-step
+			 * with the segment log.  Once the manifest is poisoned, append_page()
+			 * stops staging, so a later same-pd_lsn rewrite lands in the segment
+			 * only; the memtable would then return the older bytes under the same
+			 * LSN as the segment-backed pv.  Skip it when poisoned and read the
+			 * authoritative segment instead.
+			 */
+			if (s->memtable && !ps_manifest_poisoned() &&
 				ps_memtable_lookup(s->memtable, tl, key, block, rl, &l, out) &&
 				l == pv->lsn)
 			{
@@ -1527,9 +1536,17 @@ ps_core_close(void)
 	 * only durable copy of pages whose segment bytes were still in the page cache,
 	 * which segment-only recovery would miss.  Syncing first makes the recovery
 	 * source durable before any layer is committed on top of it.
+	 *
+	 * If the sync fails (EIO/ENOSPC/...), the segment log -- the sole source
+	 * segment-only recovery reads -- is not durable, so the about-to-be-destroyed
+	 * memtable may be the only good copy of recent writes.  We cannot make it
+	 * durable from here, but we must not let that pass silently: report it loudly
+	 * so the failure is not mistaken for a clean shutdown.
 	 */
-	if (ps_storage->sync)
-		ps_storage->sync();
+	if (ps_storage->sync && ps_storage->sync() != 0)
+		fprintf(stderr, "pagestore_daemon: FATAL: segment sync failed on shutdown "
+				"(%s); recently acknowledged writes may be lost on restart\n",
+				strerror(errno));
 
 	for (uint32_t i = 0; i < ns; i++)
 	{

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -297,11 +297,15 @@ gc_resume(void)
 		 * Drop the manifest entry only after the file is gone (a missing file
 		 * is ENOENT == success in delete_local_layer, so this is idempotent and
 		 * a partially-deleted layer still completes).  A real unlink error keeps
-		 * the layer "deleting" so the next start retries it.
+		 * the layer "deleting" so the next start retries it.  A REMOVE_LAYER
+		 * write error may have torn the manifest tail; stop so that record stays
+		 * the recoverable tail instead of becoming interior corruption, and the
+		 * next start retries from the last valid manifest state.
 		 */
 		if (ps_layer_store->delete_local_layer(&dead[k]) != 0)
 			continue;
-		ps_manifest_remove_layer(dead[k].layer_id);
+		if (ps_manifest_remove_layer(dead[k].layer_id) != 0)
+			break;
 	}
 	free(dead);
 }
@@ -406,15 +410,23 @@ compact_timeline(uint32_t timeline, uint32_t shard)
 		/*
 		 * Fail safe at every step.  Only delete the file once the layer is
 		 * durably marked deleting, and only drop it from the manifest once the
-		 * file is gone -- so a failed manifest/unlink leaves a readable layer
-		 * (its data is also in the new layer) that gc_resume() retries on the
-		 * next start, never a manifest entry pointing at a deleted file.
+		 * file is gone -- so a failed step leaves a readable layer (its data is
+		 * also in the new layer) that gc_resume() retries on the next start,
+		 * never a manifest entry pointing at a deleted file.
+		 *
+		 * A manifest write error may have left a torn record at the tail; STOP
+		 * before unlinking or appending anything more, so that torn record stays
+		 * the recoverable tail rather than becoming interior corruption that
+		 * fails replay (and so we never unlink a file whose later delete mark is
+		 * not durable).  A failed unlink is not a manifest error: the layer is
+		 * durably deleting, so we can move on and let gc_resume() retry it.
 		 */
 		if (ps_manifest_mark_delete(old[k].layer_id) != 0)
-			continue;
+			break;
 		if (ps_layer_store->delete_local_layer(&old[k]) != 0)
 			continue;			/* still "deleting"; gc_resume() will retry */
-		ps_manifest_remove_layer(old[k].layer_id);
+		if (ps_manifest_remove_layer(old[k].layer_id) != 0)
+			break;
 	}
 	rc = 0;
 

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -335,6 +335,15 @@ compact_timeline(uint32_t timeline, uint32_t shard)
 	if (nold < 2)
 		return 0;				/* nothing worth merging */
 
+	/*
+	 * Never compact a poisoned manifest: the new layer could not be recorded, so
+	 * we would just write an unreferenced file and the old layers would stay live
+	 * -- maintenance would keep retrying and leaking files.  Bail (the daemon is
+	 * already rejecting writes; a restart recovers the manifest).
+	 */
+	if (ps_manifest_poisoned())
+		return -1;
+
 	old = malloc((size_t) nold * sizeof(PsLayerDesc));
 	if (!old)
 		return -1;
@@ -422,11 +431,11 @@ compact_timeline(uint32_t timeline, uint32_t shard)
 		 * durably deleting, so we can move on and let gc_resume() retry it.
 		 */
 		if (ps_manifest_mark_delete(old[k].layer_id) != 0)
-			break;
+			goto cleanup;		/* incomplete: old layers stay live, count not cut */
 		if (ps_layer_store->delete_local_layer(&old[k]) != 0)
 			continue;			/* still "deleting"; gc_resume() will retry */
 		if (ps_manifest_remove_layer(old[k].layer_id) != 0)
-			break;
+			goto cleanup;		/* incomplete */
 	}
 	rc = 0;
 
@@ -1119,6 +1128,16 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	uint64_t	data_off;
 	Shard	   *s = shard_for(key);
 
+	/*
+	 * Reject writes once the manifest is poisoned.  Recovery rebuilds from
+	 * manifest-recorded layers and does not rescan segments, so a page appended
+	 * now -- whose memtable flush can no longer record a layer -- would be lost on
+	 * restart.  Failing the write (rather than acknowledging un-recoverable data)
+	 * is the safe response; a restart recovers the manifest and clears the poison.
+	 */
+	if (use_layers && ps_manifest_poisoned())
+		return -1;
+
 	/* roll over to a fresh segment when the current one would overflow */
 	if (s->cur_seg < 0 || s->cur_off + reclen > segment_size)
 	{
@@ -1190,6 +1209,15 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 			if (count_image_layers(timeline, s->id) > (uint32_t) compact_layers * 4)
 				compact_timeline(timeline, s->id);
 			ps_unlock_map();
+
+			/*
+			 * If this flush could not record its layer (manifest poisoned), the
+			 * page just written is not durable through layer-based recovery -- fail
+			 * the write so it is not acknowledged.  Subsequent writes are rejected
+			 * at the top of append_page.
+			 */
+			if (ps_manifest_poisoned())
+				return -1;
 		}
 	}
 	return 0;

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "pagestore_core.h"
 #include "pagestore_layer_store.h"
@@ -1288,19 +1289,22 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 			uint64_t	l;
 			int			served;
 
+			/*
+			 * The materialized-page cache and the memtable are safe read sources
+			 * only while they stay in lock-step with the segment log.  Once the
+			 * manifest is poisoned, append_page() stops staging and a later
+			 * same-pd_lsn rewrite lands in the segment only; both the cache (keyed
+			 * by (tl,key,block,lsn)) and the memtable would then return the older
+			 * bytes under the same LSN as the segment-backed pv.  When poisoned,
+			 * bypass both and read the authoritative segment.
+			 */
+			int			poisoned = ps_manifest_poisoned();
+
 			/* fast path: materialized-page cache, keyed by the resolved version */
-			if (ps_pgcache_lookup(tl, key, block, pv->lsn, out))
+			if (!poisoned && ps_pgcache_lookup(tl, key, block, pv->lsn, out))
 				return 1;
 
-			/*
-			 * The memtable is a safe read source only while it stays in lock-step
-			 * with the segment log.  Once the manifest is poisoned, append_page()
-			 * stops staging, so a later same-pd_lsn rewrite lands in the segment
-			 * only; the memtable would then return the older bytes under the same
-			 * LSN as the segment-backed pv.  Skip it when poisoned and read the
-			 * authoritative segment instead.
-			 */
-			if (s->memtable && !ps_manifest_poisoned() &&
+			if (s->memtable && !poisoned &&
 				ps_memtable_lookup(s->memtable, tl, key, block, rl, &l, out) &&
 				l == pv->lsn)
 			{
@@ -1540,13 +1544,17 @@ ps_core_close(void)
 	 * If the sync fails (EIO/ENOSPC/...), the segment log -- the sole source
 	 * segment-only recovery reads -- is not durable, so the about-to-be-destroyed
 	 * memtable may be the only good copy of recent writes.  We cannot make it
-	 * durable from here, but we must not let that pass silently: report it loudly
-	 * so the failure is not mistaken for a clean shutdown.
+	 * durable from here, so do not proceed to a clean-looking teardown that would
+	 * mask the loss: report it and abort with a failure status before destroying
+	 * the memtables, leaving the operator a clear signal to investigate.
 	 */
 	if (ps_storage->sync && ps_storage->sync() != 0)
+	{
 		fprintf(stderr, "pagestore_daemon: FATAL: segment sync failed on shutdown "
-				"(%s); recently acknowledged writes may be lost on restart\n",
-				strerror(errno));
+				"(%s); aborting before teardown -- recently acknowledged writes "
+				"may not be durable\n", strerror(errno));
+		_exit(EXIT_FAILURE);
+	}
 
 	for (uint32_t i = 0; i < ns; i++)
 	{

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1340,8 +1340,30 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
  * effects are not reproduced on restart.  Also a partial/torn trailing record
  * is simply treated as end-of-log (the magic/len check below stops the scan).
  */
+/* Is a version of (timeline, key, block) at exactly 'lsn' already indexed? */
+static int
+page_version_exists(uint32_t timeline, const PsKey *key, uint32_t block,
+					uint64_t lsn)
+{
+	PageEnt    *e = page_find(timeline, key, block);
+
+	if (e)
+		for (int i = 0; i < e->nver; i++)
+			if (e->vers[i].lsn == lsn)
+				return 1;
+	return 0;
+}
+
+/*
+ * Scan a shard's segment log and add its versions.  With dedup != 0 (the tail
+ * scan run after rebuild_from_layers) a version already indexed from a layer is
+ * skipped, so only the un-flushed tail -- pages whose memtable flush never made it
+ * into a recorded layer -- is added.  Either way the append cursor ends just past
+ * the last valid record.  The segment log is append-only and never deleted, so it
+ * is the authoritative source for any version a layer flush did not record.
+ */
 static void
-recover(uint32_t shard)
+recover(uint32_t shard, int dedup)
 {
 	Shard	   *s = &g_shards[shard];
 
@@ -1382,8 +1404,10 @@ recover(uint32_t shard)
 			if (hdr.len != page_size)
 				break;			/* our magic but a torn/short tail record */
 
-			page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn, shard, id,
-							 off + sizeof(hdr));
+			if (!dedup ||
+				!page_version_exists(hdr.timeline, &hdr.key, hdr.block, hdr.lsn))
+				page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn,
+								 shard, id, off + sizeof(hdr));
 			fork_grow(hdr.timeline, &hdr.key, hdr.block + 1);
 			off += sizeof(hdr) + hdr.len;
 		}
@@ -1558,6 +1582,15 @@ ps_core_maintenance(void)
 
 	if (!use_layers)
 		return 0;
+
+	/*
+	 * Back off all maintenance once the manifest is poisoned: compaction cannot
+	 * record its replacement layer, so compact_timeline() returns immediately and
+	 * reporting "did work" would spin the idle worker on the same timeline until
+	 * restart.  Returning 0 lets it sleep until the manifest is recovered.
+	 */
+	if (ps_manifest_poisoned())
+		return 0;
 	ns = core_shards();
 
 	/*
@@ -1659,24 +1692,22 @@ ps_core_open(const char *store_dir)
 	load_timelines();
 	if (use_layers && ps_layer_map.nlayers > 0)
 	{
-		/* layers are the durable read state -- rebuild from their indexes and
-		 * position the append cursor at a fresh segment (a cheap stat loop, no
-		 * per-record scan).  Segments are written but no longer scanned. */
+		/*
+		 * Layers are the durable read state -- rebuild from their (compact)
+		 * indexes -- but the segment log is authoritative and never deleted, so
+		 * still scan it (dedup) for the un-flushed tail: any version whose memtable
+		 * flush never made it into a recorded layer (e.g. a crash, or a poisoned
+		 * manifest) would otherwise be lost despite being acknowledged.  The tail
+		 * scan also leaves the append cursor at the true end of the log.
+		 */
 		rebuild_from_layers();
 		for (uint32_t sh = 0; sh < ns; sh++)
-		{
-			int			id = 0;
-
-			while (ps_storage->seg_size(sh, id) >= 0)
-				id++;
-			g_shards[sh].cur_seg = id;
-			g_shards[sh].cur_off = 0;
-		}
+			recover(sh, 1);
 	}
 	else
 	{
 		for (uint32_t sh = 0; sh < ns; sh++)	/* segment scan (SPDK path, or no layers yet) */
-			recover(sh);
+			recover(sh, 0);
 	}
 
 	/* rebuild each timeline's shipped-WAL end LSN from its log */

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1128,16 +1128,6 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	uint64_t	data_off;
 	Shard	   *s = shard_for(key);
 
-	/*
-	 * Reject writes once the manifest is poisoned.  Recovery rebuilds from
-	 * manifest-recorded layers and does not rescan segments, so a page appended
-	 * now -- whose memtable flush can no longer record a layer -- would be lost on
-	 * restart.  Failing the write (rather than acknowledging un-recoverable data)
-	 * is the safe response; a restart recovers the manifest and clears the poison.
-	 */
-	if (use_layers && ps_manifest_poisoned())
-		return -1;
-
 	/* roll over to a fresh segment when the current one would overflow */
 	if (s->cur_seg < 0 || s->cur_off + reclen > segment_size)
 	{
@@ -1209,15 +1199,12 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 			if (count_image_layers(timeline, s->id) > (uint32_t) compact_layers * 4)
 				compact_timeline(timeline, s->id);
 			ps_unlock_map();
-
 			/*
-			 * If this flush could not record its layer (manifest poisoned), the
-			 * page just written is not durable through layer-based recovery -- fail
-			 * the write so it is not acknowledged.  Subsequent writes are rejected
-			 * at the top of append_page.
+			 * A flush that could not record its layer (manifest poisoned) is not a
+			 * write failure: the page is already in the segment log, which recovery
+			 * scans, so the write stays durable and acknowledged.  The manifest
+			 * poison only stops further metadata writes and compaction.
 			 */
-			if (ps_manifest_poisoned())
-				return -1;
 		}
 	}
 	return 0;
@@ -1340,30 +1327,17 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
  * effects are not reproduced on restart.  Also a partial/torn trailing record
  * is simply treated as end-of-log (the magic/len check below stops the scan).
  */
-/* Is a version of (timeline, key, block) at exactly 'lsn' already indexed? */
-static int
-page_version_exists(uint32_t timeline, const PsKey *key, uint32_t block,
-					uint64_t lsn)
-{
-	PageEnt    *e = page_find(timeline, key, block);
-
-	if (e)
-		for (int i = 0; i < e->nver; i++)
-			if (e->vers[i].lsn == lsn)
-				return 1;
-	return 0;
-}
-
 /*
- * Scan a shard's segment log and add its versions.  With dedup != 0 (the tail
- * scan run after rebuild_from_layers) a version already indexed from a layer is
- * skipped, so only the un-flushed tail -- pages whose memtable flush never made it
- * into a recorded layer -- is added.  Either way the append cursor ends just past
- * the last valid record.  The segment log is append-only and never deleted, so it
- * is the authoritative source for any version a layer flush did not record.
+ * Scan a shard's segment log and rebuild its version index, leaving the append
+ * cursor just past the last valid record.  The segment log is append-only and
+ * never deleted, so it is the complete, authoritative store: it holds every
+ * version (including repeated writes at the same pd_lsn, in order) and any write a
+ * layer flush did not record.  Recovery rebuilds the exact chain from it; image
+ * layers are a future fast-recovery optimization that needs a durable flush
+ * watermark before they can replace this scan.
  */
 static void
-recover(uint32_t shard, int dedup)
+recover(uint32_t shard)
 {
 	Shard	   *s = &g_shards[shard];
 
@@ -1404,10 +1378,20 @@ recover(uint32_t shard, int dedup)
 			if (hdr.len != page_size)
 				break;			/* our magic but a torn/short tail record */
 
-			if (!dedup ||
-				!page_version_exists(hdr.timeline, &hdr.key, hdr.block, hdr.lsn))
-				page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn,
-								 shard, id, off + sizeof(hdr));
+			/*
+			 * append_page() writes the header and the page body in separate
+			 * writes, so after a crash a tail record can have a valid header while
+			 * the body is missing or short.  Index a record only once the segment
+			 * is large enough to hold its body; a torn body ends the log here so we
+			 * never index a version whose bytes cannot be read (which would mask a
+			 * good older version and zero-fill on read).
+			 */
+			if (ps_storage->seg_size(shard, id) <
+				(int64_t) (off + sizeof(hdr) + hdr.len))
+				break;
+
+			page_add_version(hdr.timeline, &hdr.key, hdr.block, hdr.lsn,
+							 shard, id, off + sizeof(hdr));
 			fork_grow(hdr.timeline, &hdr.key, hdr.block + 1);
 			off += sizeof(hdr) + hdr.len;
 		}
@@ -1514,37 +1498,8 @@ ps_handle_meta(PsChannel *ch)
 
 /* ===================== lifecycle ====================================== */
 
-/*
- * Rebuild the page and fork indexes from the image layers' on-disk indexes
- * (the persistent LSM index) instead of scanning every segment record.  The
- * versions are tagged with seg = -1 (no segment copy); read_resolve serves them
- * from the layer they came from.
- */
-static void
-rebuild_from_layers(void)
-{
-	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)
-	{
-		const PsLayerDesc *d = &ps_layer_map.layers[i];
-		PsImgIndexEnt *idx;
-		uint32_t	n;
-
-		if (d->kind != PS_LAYER_IMAGE || d->deleting)
-			continue;
-		if (ps_image_layer_read_index(d, &idx, &n) != 0)
-			continue;			/* skip an unreadable layer */
-		for (uint32_t j = 0; j < n; j++)
-		{
-			page_add_version(d->timeline, &idx[j].key, idx[j].block,
-							 idx[j].lsn, shard_for(&idx[j].key)->id, -1, 0);
-			fork_grow(d->timeline, &idx[j].key, idx[j].block + 1);
-		}
-		free(idx);
-	}
-}
-
-/* Flush the memtable and close the manifest on a clean shutdown, so a restart
- * rebuilds the full state from layers without scanning segments. */
+/* Flush the memtable and close the manifest on a clean shutdown.  (The segment
+ * log is authoritative, so a restart recovers from it regardless.) */
 void
 ps_core_close(void)
 {
@@ -1690,25 +1645,17 @@ ps_core_open(const char *store_dir)
 	/* timeline 0 is the root; load any persisted branches, then rebuild data */
 	timeline_define(0, -1, 0);
 	load_timelines();
-	if (use_layers && ps_layer_map.nlayers > 0)
-	{
-		/*
-		 * Layers are the durable read state -- rebuild from their (compact)
-		 * indexes -- but the segment log is authoritative and never deleted, so
-		 * still scan it (dedup) for the un-flushed tail: any version whose memtable
-		 * flush never made it into a recorded layer (e.g. a crash, or a poisoned
-		 * manifest) would otherwise be lost despite being acknowledged.  The tail
-		 * scan also leaves the append cursor at the true end of the log.
-		 */
-		rebuild_from_layers();
-		for (uint32_t sh = 0; sh < ns; sh++)
-			recover(sh, 1);
-	}
-	else
-	{
-		for (uint32_t sh = 0; sh < ns; sh++)	/* segment scan (SPDK path, or no layers yet) */
-			recover(sh, 0);
-	}
+
+	/*
+	 * Rebuild the version index from the segment log, the complete authoritative
+	 * store (never deleted).  This recovers every acknowledged write -- including
+	 * a tail the memtable flush never recorded in a layer (a crash, or a poisoned
+	 * manifest) -- and repeated same-pd_lsn writes in order, which a layer rebuild
+	 * keyed only by LSN could not.  Image layers are still loaded into the layer
+	 * map (for compaction/GC) but are not used to rebuild the read index here.
+	 */
+	for (uint32_t sh = 0; sh < ns; sh++)
+		recover(sh);
 
 	/* rebuild each timeline's shipped-WAL end LSN from its log */
 	for (uint32_t tl = 0; tl < MAX_TIMELINES; tl++)

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -293,7 +293,14 @@ gc_resume(void)
 			dead[m++] = ps_layer_map.layers[i];
 	for (uint32_t k = 0; k < m; k++)
 	{
-		ps_layer_store->delete_local_layer(&dead[k]);
+		/*
+		 * Drop the manifest entry only after the file is gone (a missing file
+		 * is ENOENT == success in delete_local_layer, so this is idempotent and
+		 * a partially-deleted layer still completes).  A real unlink error keeps
+		 * the layer "deleting" so the next start retries it.
+		 */
+		if (ps_layer_store->delete_local_layer(&dead[k]) != 0)
+			continue;
 		ps_manifest_remove_layer(dead[k].layer_id);
 	}
 	free(dead);
@@ -396,8 +403,17 @@ compact_timeline(uint32_t timeline, uint32_t shard)
 		goto cleanup;
 	for (uint32_t k = 0; k < nold; k++)
 	{
-		ps_manifest_mark_delete(old[k].layer_id);
-		ps_layer_store->delete_local_layer(&old[k]);
+		/*
+		 * Fail safe at every step.  Only delete the file once the layer is
+		 * durably marked deleting, and only drop it from the manifest once the
+		 * file is gone -- so a failed manifest/unlink leaves a readable layer
+		 * (its data is also in the new layer) that gc_resume() retries on the
+		 * next start, never a manifest entry pointing at a deleted file.
+		 */
+		if (ps_manifest_mark_delete(old[k].layer_id) != 0)
+			continue;
+		if (ps_layer_store->delete_local_layer(&old[k]) != 0)
+			continue;			/* still "deleting"; gc_resume() will retry */
 		ps_manifest_remove_layer(old[k].layer_id);
 	}
 	rc = 0;

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -15,9 +15,11 @@
  *
  *-------------------------------------------------------------------------
  */
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -95,6 +97,89 @@ write_layer(uint64_t id, unsigned char fill)
 		exit(2);
 	}
 	return d;
+}
+
+/* A layer descriptor that needs no on-disk file (only a manifest record). */
+static PsLayerDesc
+synth_layer(uint64_t id, const char *dir)
+{
+	PsLayerDesc d;
+
+	memset(&d, 0, sizeof(d));
+	d.layer_id = id;
+	d.kind = PS_LAYER_IMAGE;
+	d.location_count = 1;
+	d.locations[0].tier = PS_LAYER_TIER_LOCAL_HOT;
+	d.locations[0].available = true;
+	snprintf(d.locations[0].uri, sizeof(d.locations[0].uri), "%s/l%llu",
+			 dir, (unsigned long long) id);
+	return d;
+}
+
+/*
+ * Torn-tail poisoning: force a manifest append to fail mid-write (RLIMIT_FSIZE),
+ * then verify every later append is refused (so nothing lands after the torn
+ * tail) and that a restart's replay truncates the torn record, keeping the
+ * pre-failure layer.
+ */
+static void
+test_torn_tail_poison(void)
+{
+	char		dir[] = "/tmp/pspoisontestXXXXXX";
+	char		mpath[4096];
+	PsLayerDesc d1,
+				d2;
+	struct rlimit save,
+				lim;
+	struct stat st;
+
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "poison test setup");
+		return;
+	}
+	d1 = synth_layer(1, dir);
+	d2 = synth_layer(2, dir);
+	check(ps_manifest_add_layer(&d1) == 0, "add layer 1 before the torn write");
+
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	if (stat(mpath, &st) != 0)
+	{
+		check(0, "stat manifest");
+		return;
+	}
+
+	/* cap the file just past its current size so the next record's write tears */
+	signal(SIGXFSZ, SIG_IGN);	/* exceed -> EFBIG/short write, not a signal */
+	getrlimit(RLIMIT_FSIZE, &save);
+	lim = save;
+	lim.rlim_cur = (rlim_t) (st.st_size + 8);
+	setrlimit(RLIMIT_FSIZE, &lim);
+
+	check(ps_manifest_add_layer(&d2) != 0, "torn manifest write fails");
+
+	/*
+	 * Lift the size cap *before* the next append: writes would now succeed, so
+	 * the only thing that can refuse this is the poison flag.  Without poisoning
+	 * this append would land a MARK_DELETE record *after* the torn tail, turning
+	 * it into interior corruption that fails the replay below.
+	 */
+	setrlimit(RLIMIT_FSIZE, &save);
+	check(ps_manifest_mark_delete(1) != 0,
+		  "manifest is poisoned: later appends refused even though writes would succeed");
+
+	ps_manifest_close();
+
+	/* restart: replay truncates the torn tail; only the pre-failure layer remains */
+	check(ps_manifest_open(dir) == 0, "reopen after poison");
+	check(ps_manifest_replay(&ps_layer_map) == 0, "replay recovers the torn tail");
+	check(ps_layer_map_count(&ps_layer_map) == 1, "only the pre-failure layer survives");
+	check(find_layer(1) != NULL && find_layer(2) == NULL,
+		  "layer 1 durable, the torn layer-2 record is gone");
+	ps_manifest_close();
+
+	unlink(mpath);
+	rmdir(dir);
 }
 
 int
@@ -175,6 +260,8 @@ main(void)
 		unlink(mpath);
 	}
 	rmdir(dir);
+
+	test_torn_tail_poison();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -1,0 +1,181 @@
+/*-------------------------------------------------------------------------
+ *
+ * pagestore_gc_test.c
+ *	  Standalone unit test for crash-safe compaction/GC recovery: a layer left
+ *	  "deleting" by a crash (marked in the manifest but not yet removed) must be
+ *	  recoverable, the merged survivor must stay readable across the crash
+ *	  window, and resume must be durable and idempotent.  No daemon, no PG.
+ *
+ * This exercises the manifest + local layer store with real on-disk layer files
+ * and replicates gc_resume()'s loop (which is static in pagestore_core.c):
+ * delete the file, then drop the manifest entry only on success.
+ *
+ * Usage: pagestore_gc_test
+ * Exit status: 0 = all checks passed, 1 = one or more failed.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "pagestore_manifest.h"
+#include "pagestore_layer.h"
+#include "pagestore_layer_store.h"
+
+#define PSZ 8192
+
+static int	run = 0,
+			failed = 0;
+
+static void
+check(int cond, const char *msg)
+{
+	run++;
+	if (!cond)
+	{
+		failed++;
+		fprintf(stderr, "  FAIL: %s\n", msg);
+	}
+}
+
+static int
+file_exists(const char *path)
+{
+	struct stat st;
+
+	return stat(path, &st) == 0;
+}
+
+static PsLayerDesc *
+find_layer(uint64_t id)
+{
+	for (uint32_t i = 0; i < ps_layer_map.nlayers; i++)
+		if (ps_layer_map.layers[i].layer_id == id)
+			return &ps_layer_map.layers[i];
+	return NULL;
+}
+
+/*
+ * Replica of pagestore_core.c's gc_resume() (static there): for each layer the
+ * manifest still marks "deleting", delete the local file, then drop the manifest
+ * entry only once the file is gone.  Snapshot the deleting set first since
+ * ps_manifest_remove_layer() mutates the map.
+ */
+static void
+gc_resume_like(void)
+{
+	PsLayerDesc dead[16];
+	uint32_t	n = 0;
+
+	for (uint32_t i = 0; i < ps_layer_map.nlayers && n < 16; i++)
+		if (ps_layer_map.layers[i].deleting)
+			dead[n++] = ps_layer_map.layers[i];
+	for (uint32_t k = 0; k < n; k++)
+		if (ps_layer_store->delete_local_layer(&dead[k]) == 0)
+			ps_manifest_remove_layer(dead[k].layer_id);
+}
+
+static PsLayerDesc
+write_layer(uint64_t id, unsigned char fill)
+{
+	static unsigned char pg[PSZ];
+	PsKey		k = {1, 1, 5, 0, PS_KLASS_RELATION};
+	PsImgRec	rec;
+	PsLayerDesc d;
+
+	memset(pg, fill, PSZ);
+	rec = (PsImgRec) {k, 0, 100, pg};
+	memset(&d, 0, sizeof(d));
+	if (ps_image_layer_write(id, 0, &rec, 1, PSZ, &d) != 0)
+	{
+		fprintf(stderr, "write_layer %llu failed\n", (unsigned long long) id);
+		exit(2);
+	}
+	return d;
+}
+
+int
+main(void)
+{
+	char		dir[] = "/tmp/psgctestXXXXXX";
+	PsLayerDesc a,
+				b;
+	char		a_uri[PS_LAYER_URI_MAX],
+				b_uri[PS_LAYER_URI_MAX];
+	PsKey		k = {1, 1, 5, 0, PS_KLASS_RELATION};
+	unsigned char out[PSZ];
+	PsLayerDesc *pa,
+			   *pb;
+
+	if (!mkdtemp(dir) || ps_layer_store->open(dir) != 0 ||
+		ps_manifest_open(dir) != 0)
+	{
+		fprintf(stderr, "setup failed\n");
+		return 2;
+	}
+
+	/*
+	 * Compaction wrote a merged layer B and recorded it, then started removing
+	 * the old layer A -- install-new-before-delete-old.  Simulate a crash right
+	 * after A is marked deleting but before it is removed.
+	 */
+	a = write_layer(1, 0xA1);
+	check(ps_manifest_add_layer(&a) == 0, "manifest add old layer A");
+	b = write_layer(2, 0xB2);
+	check(ps_manifest_add_layer(&b) == 0, "manifest add merged layer B");
+	snprintf(a_uri, sizeof(a_uri), "%s", a.locations[0].uri);
+	snprintf(b_uri, sizeof(b_uri), "%s", b.locations[0].uri);
+	check(ps_manifest_mark_delete(a.layer_id) == 0, "mark A deleting");
+	ps_manifest_close();		/* simulate process exit; files remain on disk */
+
+	/* --- restart: replay the manifest --- */
+	check(ps_manifest_open(dir) == 0, "reopen manifest");
+	check(ps_manifest_replay(&ps_layer_map) == 0, "replay after crash");
+	check(ps_layer_map_count(&ps_layer_map) == 2, "both layers present after replay");
+
+	pa = find_layer(1);
+	pb = find_layer(2);
+	check(pa != NULL && pa->deleting,
+		  "A replays as deleting (interrupted GC is recoverable, not lost)");
+	check(pb != NULL && !pb->deleting, "B replays live");
+	check(file_exists(a_uri),
+		  "A's file is still present (install-before-delete kept the data safe)");
+	check(file_exists(b_uri) && pb != NULL &&
+		  ps_image_layer_lookup(pb, &k, 0, 1000, out, PSZ, NULL) == 1 &&
+		  out[0] == 0xB2,
+		  "merged layer B is readable through the entire crash window");
+
+	/* --- gc_resume finishes the interrupted deletion --- */
+	gc_resume_like();
+	check(!file_exists(a_uri), "resume removed A's local file");
+	check(ps_layer_map_count(&ps_layer_map) == 1, "resume removed A from the map");
+
+	/* --- restart again: the removal is durable --- */
+	ps_manifest_close();
+	check(ps_manifest_open(dir) == 0, "reopen manifest after resume");
+	check(ps_manifest_replay(&ps_layer_map) == 0, "replay after resume");
+	check(ps_layer_map_count(&ps_layer_map) == 1, "only B survives (durable)");
+	check(find_layer(2) != NULL && find_layer(1) == NULL, "B durable, A gone");
+
+	/* --- resume is idempotent: nothing deleting, nothing to do --- */
+	gc_resume_like();
+	check(ps_layer_map_count(&ps_layer_map) == 1, "second resume is a no-op");
+
+	ps_manifest_close();
+
+	/* best-effort cleanup */
+	unlink(b_uri);
+	{
+		char		mpath[4096];
+
+		snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+		unlink(mpath);
+	}
+	rmdir(dir);
+
+	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);
+	return failed ? 1 : 0;
+}

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -299,6 +299,18 @@ ps_manifest_close(void)
 	manifest_path[0] = '\0';
 }
 
+/*
+ * True once an append failed (torn tail).  The metadata is no longer durable, so
+ * callers must stop persisting new layers -- the daemon rejects further writes and
+ * skips compaction rather than accepting data it can never record (and that
+ * layer-based recovery would not see).  Cleared by (re)open after replay recovers.
+ */
+int
+ps_manifest_poisoned(void)
+{
+	return manifest_poisoned;
+}
+
 int
 ps_manifest_replay(PsLayerMap *map)
 {

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -96,6 +96,9 @@ PsLayerMap ps_layer_map;
  * tail and turn it into unrecoverable interior corruption.  Reset on (re)open,
  * where replay truncates the torn tail.  Layer data itself is not lost: the
  * segment log stays authoritative and recover() rebuilds from it.
+ *
+ * Accessed from multiple shard worker threads (one shard can poison while another
+ * reads the flag), so all reads/writes go through __atomic.
  */
 static int	manifest_poisoned = 0;
 
@@ -122,7 +125,7 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 	int			created = 0;
 
 	/* once the tail may be torn, never append again (see manifest_poisoned) */
-	if (manifest_poisoned)
+	if (__atomic_load_n(&manifest_poisoned, __ATOMIC_ACQUIRE))
 		return -1;
 
 	fd = open(manifest_path, O_WRONLY | O_APPEND | O_CREAT, 0600);
@@ -145,7 +148,8 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 		rc = -1;
 	close(fd);
 	if (rc != 0)
-		manifest_poisoned = 1;	/* a partial write/fsync may have torn the tail */
+		/* a partial write/fsync may have torn the tail */
+		__atomic_store_n(&manifest_poisoned, 1, __ATOMIC_RELEASE);
 	return rc;
 }
 
@@ -287,7 +291,8 @@ ps_manifest_open(const char *store_dir)
 	n = snprintf(manifest_path, sizeof(manifest_path), "%s/layers.manifest", store_dir);
 	if (n < 0 || (size_t) n >= sizeof(manifest_path))
 		return -1;
-	manifest_poisoned = 0;		/* replay truncates any torn tail; start clean */
+	/* replay truncates any torn tail; start clean */
+	__atomic_store_n(&manifest_poisoned, 0, __ATOMIC_RELEASE);
 	ps_layer_map_init(&ps_layer_map);
 	return 0;
 }
@@ -308,7 +313,7 @@ ps_manifest_close(void)
 int
 ps_manifest_poisoned(void)
 {
-	return manifest_poisoned;
+	return __atomic_load_n(&manifest_poisoned, __ATOMIC_ACQUIRE);
 }
 
 int

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -88,6 +88,17 @@ static char manifest_path[4096];
 static char manifest_dir[2048];
 PsLayerMap ps_layer_map;
 
+/*
+ * Sticky once a record append fails: a short write or failed fsync may have left
+ * a torn record at the tail, which replay can only recover if it stays the *last*
+ * record.  So after any append error we refuse every further append for the life
+ * of this process -- no later flush/compaction/GC record can land after the torn
+ * tail and turn it into unrecoverable interior corruption.  Reset on (re)open,
+ * where replay truncates the torn tail.  Layer data itself is not lost: the
+ * segment log stays authoritative and recover() rebuilds from it.
+ */
+static int	manifest_poisoned = 0;
+
 static int
 manifest_fsync_dir(void)
 {
@@ -110,9 +121,13 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 	int			rc = 0;
 	int			created = 0;
 
+	/* once the tail may be torn, never append again (see manifest_poisoned) */
+	if (manifest_poisoned)
+		return -1;
+
 	fd = open(manifest_path, O_WRONLY | O_APPEND | O_CREAT, 0600);
 	if (fd < 0)
-		return -1;
+		return -1;				/* nothing written; tail not torn */
 	if (lseek(fd, 0, SEEK_END) == 0)
 		created = 1;
 
@@ -129,6 +144,8 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 	if (created && manifest_fsync_dir() != 0)
 		rc = -1;
 	close(fd);
+	if (rc != 0)
+		manifest_poisoned = 1;	/* a partial write/fsync may have torn the tail */
 	return rc;
 }
 
@@ -270,6 +287,7 @@ ps_manifest_open(const char *store_dir)
 	n = snprintf(manifest_path, sizeof(manifest_path), "%s/layers.manifest", store_dir);
 	if (n < 0 || (size_t) n >= sizeof(manifest_path))
 		return -1;
+	manifest_poisoned = 0;		/* replay truncates any torn tail; start clean */
 	ps_layer_map_init(&ps_layer_map);
 	return 0;
 }

--- a/contrib/pagestore/pagestore_manifest.h
+++ b/contrib/pagestore/pagestore_manifest.h
@@ -16,6 +16,7 @@ extern PsLayerMap ps_layer_map;
 
 extern int	ps_manifest_open(const char *store_dir);
 extern void ps_manifest_close(void);
+extern int	ps_manifest_poisoned(void);
 extern int	ps_manifest_replay(PsLayerMap *map);
 extern int	ps_manifest_add_layer(const PsLayerDesc *desc);
 extern int	ps_manifest_set_remote_durable(uint64_t layer_id,

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -220,6 +220,22 @@ posix_sync(void)
 	}
 out:
 	pthread_mutex_unlock(&seg_fds_lock);
+
+	/*
+	 * Segment files are created lazily with O_CREAT, so a new segment's directory
+	 * entry is not durable until the store directory itself is fsynced.  Recovery
+	 * scans the segment log by name, so persist the directory here too; otherwise a
+	 * power loss after a clean shutdown that created a new segment could drop the
+	 * name and hide acknowledged writes.
+	 */
+	{
+		int			dfd = open(posix_dir, O_RDONLY);
+
+		if (dfd < 0 || fsync(dfd) != 0)
+			rc = -1;
+		if (dfd >= 0)
+			close(dfd);
+	}
 	return rc;
 }
 


### PR DESCRIPTION
## What

Hardens the local compaction/GC sequence to be crash-safe at **every** step, and adds a standalone regression test that certifies the M3 criterion *"restart after interrupted compaction or GC is safe."*

## Why

`compact_timeline()` uses the right **install-new-before-delete-old** ordering, and `gc_resume()` (run on startup after manifest replay) finishes interrupted deletions — a sound design. But the manifest `mark_delete`/`delete_local`/`remove_layer` return values were **ignored**, leaving a narrow window: if `mark_delete`'s fsync failed and the subsequent `unlink` succeeded, a layer could be left **readable in the manifest with its file already deleted** → a missing-file read after restart.

## Changes

- **`compact_timeline()`**: mark deleting → (on success) unlink → (on success) remove. Any failure `continue`s, leaving the old layer fully readable (its data is also in the new merged layer) for `gc_resume()` to retry. Never a manifest entry pointing at a deleted file.
- **`gc_resume()`**: drop the manifest entry only after `delete_local_layer()` succeeds (`ENOENT` = success, so a partially-deleted layer still completes; a real unlink error keeps it `deleting` for next-start retry).
- **`pagestore_gc_test`** (no daemon/PG, real on-disk layer files): add old layer A + merged layer B, mark A deleting, "crash" (close). On replay: A is `deleting` with its **file intact**, B is **readable** through the whole window. A `gc_resume`-equivalent then deletes A's file and removes it; a further restart shows **only B survives** (durable); a second resume is a **no-op** (idempotent). 17 checks.

## Validation

- `pagestore_gc_test`: 17/17.
- Full `meson test --suite pagestore`: **5/5** (gc, layer, manifest, pgcache, standalone).
- Daemon builds with the core hardening; the in-engine integration test exercises real compaction end-to-end.

Part of M3 (durable layer/manifest foundation); follows #56 (manifest klass-decode fix).