### PR TITLE
pagestore: compact the manifest log to bound replay time (M3)

### DIFF
--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1586,6 +1586,7 @@ ps_core_maintenance(void)
 	uint32_t	ftl = 0,
 				fsh = 0;
 	int			found = 0;
+	int			did = 0;
 
 	if (!use_layers)
 		return 0;
@@ -1617,21 +1618,40 @@ ps_core_maintenance(void)
 			}
 	ps_unlock_map();
 
-	if (!found)
-		return 0;
-
 	/*
 	 * Phase 2: compact the chosen shard under shard-wr + map-wr (the order other
 	 * paths use), which excludes that shard's worker and other map mutators.
 	 * Re-check under the write lock since the count may have changed.
 	 */
-	ps_lock_shard_wr(fsh);
-	ps_lock_map_wr();
-	if (count_image_layers(ftl, fsh) > (uint32_t) compact_layers)
-		compact_timeline(ftl, fsh);
+	if (found)
+	{
+		ps_lock_shard_wr(fsh);
+		ps_lock_map_wr();
+		if (count_image_layers(ftl, fsh) > (uint32_t) compact_layers)
+			compact_timeline(ftl, fsh);
+		ps_unlock_map();
+		ps_unlock_shard(fsh);
+		did = 1;
+	}
+
+	/*
+	 * Phase 3: rewrite the manifest log if add/seal/delete churn has grown it
+	 * well past the live layer count, bounding replay time.  Independent of layer
+	 * compaction; map-wr excludes the manifest appends a concurrent flush makes.
+	 */
+	ps_lock_map_rd();
+	found = ps_manifest_should_compact();
 	ps_unlock_map();
-	ps_unlock_shard(fsh);
-	return 1;
+	if (found)
+	{
+		ps_lock_map_wr();
+		if (ps_manifest_should_compact())
+			ps_manifest_compact();
+		ps_unlock_map();
+		did = 1;
+	}
+
+	return did;
 }
 
 /*

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1644,11 +1644,23 @@ ps_core_maintenance(void)
 	ps_unlock_map();
 	if (found)
 	{
+		int			compacted = 0;
+
 		ps_lock_map_wr();
 		if (ps_manifest_should_compact())
-			ps_manifest_compact();
+			compacted = (ps_manifest_compact() == 0);
 		ps_unlock_map();
-		did = 1;
+
+		/*
+		 * Only count a *successful* rewrite as work done.  A failed compaction
+		 * leaves should_compact() true, so reporting "did work" would make the
+		 * idle worker re-run maintenance immediately and busy-loop on the failing
+		 * compaction; returning false here lets it sleep and retry on the next
+		 * tick instead.  (An I/O failure also poisons the manifest, after which
+		 * should_compact() returns false and the retries stop entirely.)
+		 */
+		if (compacted)
+			did = 1;
 	}
 
 	return did;

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -15,6 +15,7 @@
  *
  *-------------------------------------------------------------------------
  */
+#include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -182,6 +183,95 @@ test_torn_tail_poison(void)
 	rmdir(dir);
 }
 
+/*
+ * Manifest compaction: add/delete churn grows the append-only log past the live
+ * set; ps_manifest_compact() rewrites it to one record per live layer, preserving
+ * every layer's state (including the deleting flag), and a stale .tmp left by a
+ * crashed compaction is never treated as authority.
+ */
+static void
+test_manifest_compaction(void)
+{
+	char		dir[] = "/tmp/psmcomptestXXXXXX";
+	char		mpath[4096],
+				tmppath[4096];
+	struct stat before,
+				after;
+	PsLayerDesc *l39,
+			   *l40;
+	int			fd;
+
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "manifest-compaction setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	snprintf(tmppath, sizeof(tmppath), "%s/layers.manifest.tmp", dir);
+
+	/* churn: add 40 layers, delete 1..38 (mark+remove), mark 39 deleting */
+	for (uint64_t i = 1; i <= 40; i++)
+	{
+		PsLayerDesc d = synth_layer(i, dir);
+
+		if (ps_manifest_add_layer(&d) != 0)
+		{
+			check(0, "add during churn");
+			return;
+		}
+	}
+	for (uint64_t i = 1; i <= 38; i++)
+		if (ps_manifest_mark_delete(i) != 0 || ps_manifest_remove_layer(i) != 0)
+		{
+			check(0, "delete during churn");
+			return;
+		}
+	check(ps_manifest_mark_delete(39) == 0, "mark layer 39 deleting");
+	check(ps_layer_map_count(&ps_layer_map) == 2, "2 layers live after churn (39,40)");
+	check(ps_manifest_should_compact(),
+		  "log is due for compaction after add/delete churn");
+	if (stat(mpath, &before) != 0)
+	{
+		check(0, "stat before");
+		return;
+	}
+
+	check(ps_manifest_compact() == 0, "compact succeeds");
+	check(!ps_manifest_should_compact(), "no longer due right after compaction");
+	check(stat(mpath, &after) == 0 && after.st_size < before.st_size,
+		  "compacted log is smaller than the churned log");
+	check(stat(tmppath, &after) != 0, "no .tmp file left behind");
+
+	/* restart: the compacted log replays to the same live set, flags intact */
+	ps_manifest_close();
+	check(ps_manifest_open(dir) == 0, "reopen after compaction");
+	check(ps_manifest_replay(&ps_layer_map) == 0, "replay the compacted log");
+	check(ps_layer_map_count(&ps_layer_map) == 2, "live set preserved across compaction");
+	l39 = find_layer(39);
+	l40 = find_layer(40);
+	check(l39 != NULL && l39->deleting, "deleting flag preserved through compaction");
+	check(l40 != NULL && !l40->deleting, "live layer preserved through compaction");
+
+	/* crash-safety: a stale .tmp (crash before rename) is not authority */
+	fd = open(tmppath, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (fd >= 0)
+	{
+		ssize_t		w = write(fd, "garbage", 7);
+
+		(void) w;
+		close(fd);
+	}
+	ps_manifest_close();
+	check(ps_manifest_open(dir) == 0, "reopen with a stale .tmp present");
+	check(ps_manifest_replay(&ps_layer_map) == 0, "replay ignores the stale .tmp");
+	check(ps_layer_map_count(&ps_layer_map) == 2, "live set intact despite stale .tmp");
+	ps_manifest_close();
+
+	unlink(mpath);
+	unlink(tmppath);
+	rmdir(dir);
+}
+
 int
 main(void)
 {
@@ -262,6 +352,7 @@ main(void)
 	rmdir(dir);
 
 	test_torn_tail_poison();
+	test_manifest_compaction();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -620,7 +620,7 @@ ps_manifest_remove_layer(uint64_t layer_id)
 int
 ps_manifest_should_compact(void)
 {
-	if (manifest_poisoned)
+	if (__atomic_load_n(&manifest_poisoned, __ATOMIC_ACQUIRE))
 		return 0;
 	return manifest_nrecords >= 64 &&
 		manifest_nrecords > 4 * ((uint64_t) ps_layer_map.nlayers + 1);
@@ -643,7 +643,7 @@ ps_manifest_compact(void)
 	uint64_t	nrec = 0;
 	int			n;
 
-	if (manifest_poisoned)
+	if (__atomic_load_n(&manifest_poisoned, __ATOMIC_ACQUIRE))
 		return -1;
 	n = snprintf(tmp, sizeof(tmp), "%s.tmp", manifest_path);
 	if (n < 0 || (size_t) n >= sizeof(tmp))
@@ -681,9 +681,10 @@ ps_manifest_compact(void)
 		 * The rename is in place but its durability is unconfirmed (the directory
 		 * fsync failed -- the disk is misbehaving).  Poison so no further append
 		 * lands until a restart re-establishes a known-durable manifest, matching
-		 * the fail-stop policy for any other manifest write/fsync error.
+		 * the fail-stop policy for any other manifest write/fsync error.  Atomic:
+		 * a concurrent shard may read the flag without the map lock.
 		 */
-		manifest_poisoned = 1;
+		__atomic_store_n(&manifest_poisoned, 1, __ATOMIC_RELEASE);
 		return -1;
 	}
 	manifest_nrecords = nrec;

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -676,7 +676,16 @@ ps_manifest_compact(void)
 		return -1;
 	}
 	if (manifest_fsync_dir() != 0)
-		return -1;				/* rename done; the new log is authoritative */
+	{
+		/*
+		 * The rename is in place but its durability is unconfirmed (the directory
+		 * fsync failed -- the disk is misbehaving).  Poison so no further append
+		 * lands until a restart re-establishes a known-durable manifest, matching
+		 * the fail-stop policy for any other manifest write/fsync error.
+		 */
+		manifest_poisoned = 1;
+		return -1;
+	}
 	manifest_nrecords = nrec;
 	return 0;
 }

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -102,6 +102,14 @@ PsLayerMap ps_layer_map;
  */
 static int	manifest_poisoned = 0;
 
+/*
+ * Records currently in the on-disk log (set by replay, bumped by append, reset by
+ * compaction).  The log is append-only, so add/delete churn makes it grow without
+ * bound; ps_manifest_should_compact() uses this to decide when to rewrite it down
+ * to one ADD_LAYER per live layer (ps_manifest_compact()), bounding replay time.
+ */
+static uint64_t manifest_nrecords = 0;
+
 static int
 manifest_fsync_dir(void)
 {
@@ -116,10 +124,26 @@ manifest_fsync_dir(void)
 	return rc;
 }
 
+/* Write one [header | payload] record to an open fd (no fsync). */
+static int
+manifest_write_record(int fd, uint32_t type, const void *payload, uint32_t len)
+{
+	PsManifestRecord rec;
+
+	rec.magic = PS_MANIFEST_MAGIC;
+	rec.version = PS_MANIFEST_VERSION;
+	rec.type = type;
+	rec.len = len;
+
+	if (write(fd, &rec, sizeof(rec)) != (ssize_t) sizeof(rec) ||
+		(len > 0 && write(fd, payload, len) != (ssize_t) len))
+		return -1;
+	return 0;
+}
+
 static int
 manifest_append(uint32_t type, const void *payload, uint32_t len)
 {
-	PsManifestRecord rec;
 	int			fd;
 	int			rc = 0;
 	int			created = 0;
@@ -134,13 +158,7 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 	if (lseek(fd, 0, SEEK_END) == 0)
 		created = 1;
 
-	rec.magic = PS_MANIFEST_MAGIC;
-	rec.version = PS_MANIFEST_VERSION;
-	rec.type = type;
-	rec.len = len;
-
-	if (write(fd, &rec, sizeof(rec)) != (ssize_t) sizeof(rec) ||
-		(len > 0 && write(fd, payload, len) != (ssize_t) len))
+	if (manifest_write_record(fd, type, payload, len) != 0)
 		rc = -1;
 	if (fsync(fd) != 0)
 		rc = -1;
@@ -150,6 +168,8 @@ manifest_append(uint32_t type, const void *payload, uint32_t len)
 	if (rc != 0)
 		/* a partial write/fsync may have torn the tail */
 		__atomic_store_n(&manifest_poisoned, 1, __ATOMIC_RELEASE);
+	else
+		manifest_nrecords++;
 	return rc;
 }
 
@@ -293,6 +313,7 @@ ps_manifest_open(const char *store_dir)
 		return -1;
 	/* replay truncates any torn tail; start clean */
 	__atomic_store_n(&manifest_poisoned, 0, __ATOMIC_RELEASE);
+	manifest_nrecords = 0;
 	ps_layer_map_init(&ps_layer_map);
 	return 0;
 }
@@ -325,6 +346,7 @@ ps_manifest_replay(PsLayerMap *map)
 	off_t		file_size;
 	struct stat st;
 
+	manifest_nrecords = 0;
 	fd = open(manifest_path, O_RDWR);
 	if (fd < 0)
 	{
@@ -510,6 +532,7 @@ ps_manifest_replay(PsLayerMap *map)
 			close(fd);
 			return -1;
 		}
+		manifest_nrecords++;
 	}
 
 done:
@@ -586,5 +609,74 @@ ps_manifest_remove_layer(uint64_t layer_id)
 	if (manifest_append(PS_MANIFEST_REMOVE_LAYER, &ev, sizeof(ev)) != 0)
 		return -1;
 	manifest_remove_from_map(&ps_layer_map, layer_id);
+	return 0;
+}
+
+/*
+ * Should the log be rewritten?  True once it has grown well past the live layer
+ * count (add/seal/delete churn appends records the live set no longer needs), so
+ * replay stays bounded.  Never while poisoned -- a restart recovers that first.
+ */
+int
+ps_manifest_should_compact(void)
+{
+	if (manifest_poisoned)
+		return 0;
+	return manifest_nrecords >= 64 &&
+		manifest_nrecords > 4 * ((uint64_t) ps_layer_map.nlayers + 1);
+}
+
+/*
+ * Rewrite the log to one ADD_LAYER record per current layer (an ADD encodes every
+ * flag -- deleting, remote_durable, ... -- and replay restores them, so one record
+ * fully captures a layer's state).  Atomic via a temp file + rename + dir fsync:
+ * a crash before the rename leaves the old full log intact; after it, the new
+ * compacted log; both replay to the same layer map.  Caller must hold the state
+ * stable (no concurrent map mutation) across this.
+ */
+int
+ps_manifest_compact(void)
+{
+	char		tmp[4096];
+	int			fd;
+	int			rc = 0;
+	uint64_t	nrec = 0;
+	int			n;
+
+	if (manifest_poisoned)
+		return -1;
+	n = snprintf(tmp, sizeof(tmp), "%s.tmp", manifest_path);
+	if (n < 0 || (size_t) n >= sizeof(tmp))
+		return -1;
+
+	fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (fd < 0)
+		return -1;
+	for (uint32_t i = 0; i < ps_layer_map.nlayers && rc == 0; i++)
+	{
+		PsManifestLayerDisk disk;
+
+		if (manifest_encode_layer(&disk, &ps_layer_map.layers[i]) != 0 ||
+			manifest_write_record(fd, PS_MANIFEST_ADD_LAYER, &disk, sizeof(disk)) != 0)
+			rc = -1;
+		else
+			nrec++;
+	}
+	if (rc == 0 && fsync(fd) != 0)
+		rc = -1;
+	close(fd);
+	if (rc != 0)
+	{
+		unlink(tmp);			/* never touched the live manifest */
+		return -1;
+	}
+	if (rename(tmp, manifest_path) != 0)
+	{
+		unlink(tmp);
+		return -1;
+	}
+	if (manifest_fsync_dir() != 0)
+		return -1;				/* rename done; the new log is authoritative */
+	manifest_nrecords = nrec;
 	return 0;
 }

--- a/contrib/pagestore/pagestore_manifest.h
+++ b/contrib/pagestore/pagestore_manifest.h
@@ -24,4 +24,8 @@ extern int	ps_manifest_set_remote_durable(uint64_t layer_id,
 extern int	ps_manifest_mark_delete(uint64_t layer_id);
 extern int	ps_manifest_remove_layer(uint64_t layer_id);
 
+/* Bound replay time by rewriting the append-only log to one record per live layer. */
+extern int	ps_manifest_should_compact(void);
+extern int	ps_manifest_compact(void);
+
 #endif							/* PAGESTORE_MANIFEST_H */


### PR DESCRIPTION
## What

The manifest is append-only, so add/seal/delete churn grows it without bound and **replay time scales with all history**, not the live layer count. This adds atomic log compaction so the log stays proportional to the live set.

## Changes

- **`ps_manifest_compact()`** — rewrite the log to one `ADD_LAYER` record per current layer. (An `ADD` encodes every flag — `deleting`, `remote_durable`, … — and replay restores them, so one record fully captures a layer's state.) Atomic via **temp file + fsync + rename + dir fsync**: a crash *before* the rename leaves the old full log intact; *after* it, the new compacted log — both replay to the same map. Refused while the manifest is poisoned (a restart recovers that first).
- **Record counter + `ps_manifest_should_compact()`** — track the on-disk record count (set by replay, bumped by append, reset by compact); trips once the log is well past the live set.
- **`ps_core_maintenance()`** — runs the rewrite off the write path under `map-wr` (which excludes the manifest appends a concurrent flush makes), independent of layer compaction.

## Test (`pagestore_gc_test`)

Churn 40 adds + 38 deletes down to 2 live layers, then compact and assert:
- the log file **shrinks**, `should_compact` clears;
- replay **preserves the live set and the `deleting` flag**;
- a **stale `.tmp`** left by a crashed compaction is never treated as authority.

Suite **5/5** (gc test now 39 checks); daemon builds.

## Notes

Stacked on #57 (poison flag + crash-safe GC). Part of M3 (durable layer/manifest foundation); follows #56 (klass decode) and #57 (GC crash-safety). Remaining M3 gap: per-record CRC.