### PR TITLE
pagestore: per-record CRC in the manifest (M3 integrity)

### DIFF
--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -421,6 +421,82 @@ test_manifest_replay_robustness(void)
 }
 
 /*
+ * A legacy v2 manifest (16-byte header, no CRC) must still replay -- and be upgraded
+ * to v3 in place -- rather than be rejected and truncated to empty.  We can't write
+ * a v2 record through the public API (it only writes v3), so synthesize one by
+ * byte-editing a v3 ADD: drop the 4-byte CRC and set the version word to 2.
+ */
+static void
+test_manifest_v2_migration(void)
+{
+	char		dir[] = "/tmp/psv2XXXXXX";
+	char		mpath[4096];
+	PsLayerDesc d1;
+	struct stat st;
+	unsigned char v3[4096],
+				v2[4096];
+	int			fd;
+	ssize_t		sz;
+	unsigned char ver;
+
+	/* 1. write a normal v3 manifest with one ADD(7) */
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "v2: setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	d1 = synth_layer(7, dir);
+	check(ps_manifest_add_layer(&d1) == 0 && stat(mpath, &st) == 0 &&
+		  st.st_size > 20 && st.st_size <= (off_t) sizeof(v3),
+		  "v2: built a v3 ADD record");
+	ps_manifest_close();
+
+	/* 2. read the v3 record and rebuild it as a v2 record on disk:
+	 *    v3 = magic[0..3] version[4..7] type[8..11] len[12..15] crc[16..19] payload
+	 *    v2 = magic version type len payload  (no crc; 16-byte header) */
+	fd = open(mpath, O_RDONLY);
+	sz = (fd >= 0) ? read(fd, v3, sizeof(v3)) : -1;
+	if (fd >= 0)
+		close(fd);
+	check(sz > 20, "v2: read v3 bytes");
+	memcpy(v2, v3, 16);				/* magic, version, type, len */
+	v2[4] = 2;						/* version 3 -> 2 (LE low byte; rest already 0) */
+	memcpy(v2 + 16, v3 + 20, (size_t) (sz - 20));	/* payload, sans the 4-byte crc */
+	fd = open(mpath, O_WRONLY | O_TRUNC, 0600);
+	check(fd >= 0 && write(fd, v2, (size_t) (sz - 4)) == (ssize_t) (sz - 4),
+		  "v2: wrote a synthetic v2 manifest");
+	if (fd >= 0)
+		close(fd);
+
+	/* 3. replay must recover the layer (not reject/empty the manifest) */
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) == 0,
+		  "v2 manifest replays instead of being truncated to empty");
+	check(ps_layer_map_count(&ps_layer_map) == 1 && find_layer(7),
+		  "  ... the v2 layer is recovered");
+
+	/* 4. and the on-disk file is upgraded to v3 (version word == 3) */
+	fd = open(mpath, O_RDONLY);
+	ver = 0xFF;
+	if (fd >= 0)
+	{
+		(void) pread(fd, &ver, 1, 4);
+		close(fd);
+	}
+	check(ver == 3, "  ... the manifest is migrated to v3 on disk");
+	ps_manifest_close();
+
+	/* 5. the migrated v3 file re-replays cleanly */
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) == 0 && find_layer(7),
+		  "the migrated v3 manifest re-replays");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+}
+
+/*
  * Per-record CRC: a bit-flip inside a record (not the tail) is detected and fails
  * replay rather than loading a wrong layer; the same flip in the last record is a
  * torn tail and is recovered.
@@ -635,6 +711,7 @@ main(void)
 	test_manifest_crc();
 	test_manifest_len_corruption();
 	test_manifest_replay_robustness();
+	test_manifest_v2_migration();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -349,6 +349,78 @@ test_manifest_crc(void)
 	rmdir(dir2);
 }
 
+/*
+ * The len field is not trusted: a corrupted length on an interior record is
+ * detected as corruption (it is not used to size the read, so it cannot consume
+ * the following record), while a corrupted length on the physically last record
+ * is a recoverable torn tail.
+ */
+static void
+test_manifest_len_corruption(void)
+{
+	char		dir[] = "/tmp/pslenintXXXXXX";
+	char		dir2[] = "/tmp/pslentailXXXXXX";
+	char		mpath[4096];
+	PsLayerDesc d1;
+	struct stat st;
+	off_t		add_size;
+	PsLayerDesc *l1;
+
+	/*
+	 * Interior small record whose len is flipped upward: a length-trusting reader
+	 * would consume the following REMOVE record and hit EOF, mis-recovering the
+	 * MARK_DELETE as a torn tail and resurrecting the removed layer.  Sizing from
+	 * the type instead, this is detected as interior corruption and fails replay.
+	 * Build [ADD, MARK_DELETE, REMOVE]; measure the ADD's size to locate the
+	 * MARK_DELETE header that follows it.
+	 */
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "len test setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	d1 = synth_layer(1, dir);
+	check(ps_manifest_add_layer(&d1) == 0, "ADD written");
+	check(stat(mpath, &st) == 0, "measure ADD size");
+	add_size = st.st_size;
+	check(ps_manifest_mark_delete(1) == 0 && ps_manifest_remove_layer(1) == 0,
+		  "MARK_DELETE + REMOVE written");
+	ps_manifest_close();
+	corrupt_byte(mpath, add_size + 12); /* the MARK_DELETE header's len field */
+	check(ps_manifest_open(dir) == 0, "reopen (interior len)");
+	check(ps_manifest_replay(&ps_layer_map) != 0,
+		  "interior len corruption fails replay (not a misread torn tail)");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+
+	/* --- last record's len corrupted -> recoverable torn tail --- */
+	if (!mkdtemp(dir2) || ps_manifest_open(dir2) != 0)
+	{
+		check(0, "len tail setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir2);
+	d1 = synth_layer(1, dir2);
+	check(ps_manifest_add_layer(&d1) == 0, "ADD written");
+	check(ps_manifest_mark_delete(1) == 0, "MARK_DELETE written (last record)");
+	ps_manifest_close();
+	/* the trailing MARK_DELETE is 20-byte header + 16-byte event = 36 bytes; its
+	 * len field sits at file_size - 36 + 12 = file_size - 24 */
+	if (stat(mpath, &st) == 0)
+		corrupt_byte(mpath, st.st_size - 24);
+	check(ps_manifest_open(dir2) == 0, "reopen (last-record len)");
+	check(ps_manifest_replay(&ps_layer_map) == 0,
+		  "last-record len corruption is a recoverable torn tail");
+	l1 = find_layer(1);
+	check(ps_layer_map_count(&ps_layer_map) == 1 && l1 != NULL && !l1->deleting,
+		  "the ADD survives and the truncated MARK_DELETE did not apply");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir2);
+}
+
 int
 main(void)
 {
@@ -431,6 +503,7 @@ main(void)
 	test_torn_tail_poison();
 	test_manifest_compaction();
 	test_manifest_crc();
+	test_manifest_len_corruption();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -272,6 +272,83 @@ test_manifest_compaction(void)
 	rmdir(dir);
 }
 
+/* Flip every bit of one byte at 'off' in a file. */
+static void
+corrupt_byte(const char *path, off_t off)
+{
+	int			fd = open(path, O_RDWR);
+	unsigned char b;
+
+	if (fd < 0)
+		return;
+	if (pread(fd, &b, 1, off) == 1)
+	{
+		b ^= 0xFF;
+		if (pwrite(fd, &b, 1, off) != 1)
+			perror("pwrite");
+	}
+	close(fd);
+}
+
+/*
+ * Per-record CRC: a bit-flip inside a record (not the tail) is detected and fails
+ * replay rather than loading a wrong layer; the same flip in the last record is a
+ * torn tail and is recovered.
+ */
+static void
+test_manifest_crc(void)
+{
+	char		dir[] = "/tmp/pscrcintXXXXXX";
+	char		dir2[] = "/tmp/pscrctailXXXXXX";
+	char		mpath[4096];
+	PsLayerDesc d1,
+				d2;
+	struct stat st;
+
+	/* --- interior corruption must fail replay --- */
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "crc test setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	d1 = synth_layer(1, dir);
+	d2 = synth_layer(2, dir);
+	check(ps_manifest_add_layer(&d1) == 0 && ps_manifest_add_layer(&d2) == 0,
+		  "two records written");
+	ps_manifest_close();
+	corrupt_byte(mpath, 24);		/* inside record 1's payload (header is 20 bytes) */
+	check(ps_manifest_open(dir) == 0, "reopen (interior corruption)");
+	check(ps_manifest_replay(&ps_layer_map) != 0,
+		  "interior CRC corruption fails replay (not loaded as a wrong layer)");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+
+	/* --- corruption of the last record is a recoverable torn tail --- */
+	if (!mkdtemp(dir2) || ps_manifest_open(dir2) != 0)
+	{
+		check(0, "crc tail setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir2);
+	d1 = synth_layer(1, dir);
+	d2 = synth_layer(2, dir);
+	check(ps_manifest_add_layer(&d1) == 0 && ps_manifest_add_layer(&d2) == 0,
+		  "two records written (tail case)");
+	ps_manifest_close();
+	if (stat(mpath, &st) == 0)
+		corrupt_byte(mpath, st.st_size - 1);	/* last byte = record 2's payload */
+	check(ps_manifest_open(dir2) == 0, "reopen (tail corruption)");
+	check(ps_manifest_replay(&ps_layer_map) == 0,
+		  "tail CRC corruption is recovered (torn-tail truncate)");
+	check(ps_layer_map_count(&ps_layer_map) == 1,
+		  "record 1 survives, the corrupt last record is dropped");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir2);
+}
+
 int
 main(void)
 {
@@ -353,6 +430,7 @@ main(void)
 
 	test_torn_tail_poison();
 	test_manifest_compaction();
+	test_manifest_crc();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -503,8 +503,8 @@ test_manifest_v2_migration(void)
 /*
  * A v3 first record whose version word is flipped to 2 is an ambiguous file (a v2
  * record can't be told from a corrupted v3 record without a CRC).  Replay must NOT
- * read it as v2 and install a shifted bogus layer, and must NOT truncate the file;
- * it fails the replay and leaves the manifest untouched for an operator to recover.
+ * read it as v2 and install a shifted bogus layer; since no record passes the v3 CRC
+ * check, it is dropped and the (single, unrecoverable) record truncates to empty.
  */
 static void
 test_manifest_v3_first_downgrade(void)
@@ -512,8 +512,7 @@ test_manifest_v3_first_downgrade(void)
 	char		dir[] = "/tmp/psv3dgXXXXXX";
 	char		mpath[4096];
 	PsLayerDesc d1;
-	struct stat before,
-				after;
+	struct stat after;
 	int			fd;
 	uint32_t	two = 2;
 
@@ -532,14 +531,12 @@ test_manifest_v3_first_downgrade(void)
 		  "v3-downgrade: poke version word to 2");
 	if (fd >= 0)
 		close(fd);
-	(void) stat(mpath, &before);
 	check(ps_manifest_open(dir) == 0 &&
-		  ps_manifest_replay(&ps_layer_map) != 0,
-		  "ambiguous version-downgraded first record fails replay (not read as v2)");
-	check(ps_layer_map_count(&ps_layer_map) == 0 && !find_layer(9),
-		  "  ... no bogus layer installed");
-	check(stat(mpath, &after) == 0 && after.st_size == before.st_size,
-		  "  ... and the manifest is left untouched (not truncated)");
+		  ps_manifest_replay(&ps_layer_map) == 0,
+		  "version-downgraded first record is dropped, replay does not error");
+	check(ps_layer_map_count(&ps_layer_map) == 0 && !find_layer(9) &&
+		  stat(mpath, &after) == 0 && after.st_size == 0,
+		  "  ... no bogus layer installed (truncated to empty, not read as v2)");
 	ps_manifest_close();
 	unlink(mpath);
 	rmdir(dir);
@@ -547,8 +544,9 @@ test_manifest_v3_first_downgrade(void)
 
 /*
  * A legacy v2 manifest whose first record is corrupted is not an unambiguous v2 file,
- * so replay must fail and leave it untouched -- never truncate it (which would drop
- * the surviving v2 layer metadata) by mistaking it for a v3 file with a torn tail.
+ * so it is not an unambiguous v2 file: replay must not read its unchecked bytes as a
+ * layer.  Since no record passes the v3 CRC check, it drops to an empty manifest (the
+ * store stays openable; its pages remain readable from the authoritative segment log).
  */
 static void
 test_manifest_v2_corrupt_first(void)
@@ -556,8 +554,7 @@ test_manifest_v2_corrupt_first(void)
 	char		dir[] = "/tmp/psv2cfXXXXXX";
 	char		mpath[4096];
 	PsLayerDesc d1;
-	struct stat before,
-				after;
+	struct stat after;
 	unsigned char v3[4096],
 				v2[4096];
 	int			fd;
@@ -588,12 +585,12 @@ test_manifest_v2_corrupt_first(void)
 		  "v2-corrupt: wrote corrupted v2 manifest");
 	if (fd >= 0)
 		close(fd);
-	(void) stat(mpath, &before);
 	check(ps_manifest_open(dir) == 0 &&
-		  ps_manifest_replay(&ps_layer_map) != 0,
-		  "corrupted-first-record v2 manifest fails replay (not truncated)");
-	check(stat(mpath, &after) == 0 && after.st_size == before.st_size,
-		  "  ... and is left untouched on disk");
+		  ps_manifest_replay(&ps_layer_map) == 0,
+		  "corrupted-record v2 manifest replays (store stays openable)");
+	check(ps_layer_map_count(&ps_layer_map) == 0 && !find_layer(5) &&
+		  stat(mpath, &after) == 0 && after.st_size == 0,
+		  "  ... dropped to empty, no unchecked bytes installed as a layer");
 	ps_manifest_close();
 	unlink(mpath);
 	rmdir(dir);

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -461,7 +461,11 @@ test_manifest_v2_migration(void)
 		close(fd);
 	check(sz > 20, "v2: read v3 bytes");
 	memcpy(v2, v3, 16);				/* magic, version, type, len */
-	v2[4] = 2;						/* version 3 -> 2 (LE low byte; rest already 0) */
+	{
+		uint32_t	two = 2;		/* set the version word in host byte order */
+
+		memcpy(v2 + 4, &two, sizeof(two));
+	}
 	memcpy(v2 + 16, v3 + 20, (size_t) (sz - 20));	/* payload, sans the 4-byte crc */
 	fd = open(mpath, O_WRONLY | O_TRUNC, 0600);
 	check(fd >= 0 && write(fd, v2, (size_t) (sz - 4)) == (ssize_t) (sz - 4),
@@ -491,6 +495,87 @@ test_manifest_v2_migration(void)
 	check(ps_manifest_open(dir) == 0 &&
 		  ps_manifest_replay(&ps_layer_map) == 0 && find_layer(7),
 		  "the migrated v3 manifest re-replays");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+}
+
+/*
+ * A v3 first record whose version word is flipped to 2 must NOT be reinterpreted as
+ * a legacy v2 record (which would skip the CRC and install a shifted bogus layer):
+ * the version-forced CRC re-check recognizes it as a corrupted v3 record, so it is
+ * dropped, not installed.  (The later-record case is covered elsewhere; this is the
+ * first record, which decides the whole file's format.)
+ */
+static void
+test_manifest_v3_first_downgrade(void)
+{
+	char		dir[] = "/tmp/psv3dgXXXXXX";
+	char		mpath[4096];
+	PsLayerDesc d1;
+	int			fd;
+	uint32_t	two = 2;
+
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "v3-downgrade: setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	d1 = synth_layer(9, dir);
+	check(ps_manifest_add_layer(&d1) == 0, "v3-downgrade: one v3 ADD");
+	ps_manifest_close();
+	/* flip the version word 3 -> 2 in place, keeping the v3 20-byte layout + CRC */
+	fd = open(mpath, O_WRONLY);
+	check(fd >= 0 && pwrite(fd, &two, sizeof(two), 4) == (ssize_t) sizeof(two),
+		  "v3-downgrade: poke version word to 2");
+	if (fd >= 0)
+		close(fd);
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) == 0,
+		  "version-downgraded v3 first record does not error");
+	check(ps_layer_map_count(&ps_layer_map) == 0 && !find_layer(9),
+		  "  ... and is dropped, not installed as a bogus v2 layer");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+}
+
+/*
+ * Corruption can span several adjacent records, so the torn-tail probe must scan to
+ * EOF, not just one record ahead: with two corrupt ADDs followed by an intact one,
+ * replay must report interior corruption (fail), not truncate the whole file.
+ */
+static void
+test_manifest_spanning_corruption(void)
+{
+	char		dir[] = "/tmp/psspanXXXXXX";
+	char		mpath[4096];
+	PsLayerDesc d;
+	struct stat st;
+	off_t		add1;
+
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "spanning: setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	d = synth_layer(1, dir);
+	check(ps_manifest_add_layer(&d) == 0 && stat(mpath, &st) == 0,
+		  "spanning: first ADD");
+	add1 = st.st_size;			/* every ADD record is this size */
+	d = synth_layer(2, dir);
+	check(ps_manifest_add_layer(&d) == 0, "spanning: second ADD");
+	d = synth_layer(3, dir);
+	check(ps_manifest_add_layer(&d) == 0, "spanning: third ADD");
+	ps_manifest_close();
+	/* corrupt the payload CRC of records 1 and 2; leave record 3 intact */
+	corrupt_byte(mpath, 24);				/* record 1 payload */
+	corrupt_byte(mpath, add1 + 24);			/* record 2 payload */
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) != 0,
+		  "two corrupt records before an intact one = interior corruption (fail)");
 	ps_manifest_close();
 	unlink(mpath);
 	rmdir(dir);
@@ -712,6 +797,8 @@ main(void)
 	test_manifest_len_corruption();
 	test_manifest_replay_robustness();
 	test_manifest_v2_migration();
+	test_manifest_v3_first_downgrade();
+	test_manifest_spanning_corruption();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -437,7 +437,7 @@ test_manifest_v2_migration(void)
 				v2[4096];
 	int			fd;
 	ssize_t		sz;
-	unsigned char ver;
+	uint32_t	ver;
 
 	/* 1. write a normal v3 manifest with one ADD(7) */
 	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
@@ -480,12 +480,12 @@ test_manifest_v2_migration(void)
 	check(ps_layer_map_count(&ps_layer_map) == 1 && find_layer(7),
 		  "  ... the v2 layer is recovered");
 
-	/* 4. and the on-disk file is upgraded to v3 (version word == 3) */
+	/* 4. and the on-disk file is upgraded to v3 (version word == 3, host order) */
 	fd = open(mpath, O_RDONLY);
-	ver = 0xFF;
+	ver = 0;
 	if (fd >= 0)
 	{
-		(void) pread(fd, &ver, 1, 4);
+		(void) pread(fd, &ver, sizeof(ver), 4);
 		close(fd);
 	}
 	check(ver == 3, "  ... the manifest is migrated to v3 on disk");
@@ -501,11 +501,10 @@ test_manifest_v2_migration(void)
 }
 
 /*
- * A v3 first record whose version word is flipped to 2 must NOT be reinterpreted as
- * a legacy v2 record (which would skip the CRC and install a shifted bogus layer):
- * the version-forced CRC re-check recognizes it as a corrupted v3 record, so it is
- * dropped, not installed.  (The later-record case is covered elsewhere; this is the
- * first record, which decides the whole file's format.)
+ * A v3 first record whose version word is flipped to 2 is an ambiguous file (a v2
+ * record can't be told from a corrupted v3 record without a CRC).  Replay must NOT
+ * read it as v2 and install a shifted bogus layer, and must NOT truncate the file;
+ * it fails the replay and leaves the manifest untouched for an operator to recover.
  */
 static void
 test_manifest_v3_first_downgrade(void)
@@ -513,6 +512,8 @@ test_manifest_v3_first_downgrade(void)
 	char		dir[] = "/tmp/psv3dgXXXXXX";
 	char		mpath[4096];
 	PsLayerDesc d1;
+	struct stat before,
+				after;
 	int			fd;
 	uint32_t	two = 2;
 
@@ -531,11 +532,68 @@ test_manifest_v3_first_downgrade(void)
 		  "v3-downgrade: poke version word to 2");
 	if (fd >= 0)
 		close(fd);
+	(void) stat(mpath, &before);
 	check(ps_manifest_open(dir) == 0 &&
-		  ps_manifest_replay(&ps_layer_map) == 0,
-		  "version-downgraded v3 first record does not error");
+		  ps_manifest_replay(&ps_layer_map) != 0,
+		  "ambiguous version-downgraded first record fails replay (not read as v2)");
 	check(ps_layer_map_count(&ps_layer_map) == 0 && !find_layer(9),
-		  "  ... and is dropped, not installed as a bogus v2 layer");
+		  "  ... no bogus layer installed");
+	check(stat(mpath, &after) == 0 && after.st_size == before.st_size,
+		  "  ... and the manifest is left untouched (not truncated)");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+}
+
+/*
+ * A legacy v2 manifest whose first record is corrupted is not an unambiguous v2 file,
+ * so replay must fail and leave it untouched -- never truncate it (which would drop
+ * the surviving v2 layer metadata) by mistaking it for a v3 file with a torn tail.
+ */
+static void
+test_manifest_v2_corrupt_first(void)
+{
+	char		dir[] = "/tmp/psv2cfXXXXXX";
+	char		mpath[4096];
+	PsLayerDesc d1;
+	struct stat before,
+				after;
+	unsigned char v3[4096],
+				v2[4096];
+	int			fd;
+	ssize_t		sz;
+	uint32_t	two = 2;
+
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "v2-corrupt: setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	d1 = synth_layer(5, dir);
+	check(ps_manifest_add_layer(&d1) == 0, "v2-corrupt: v3 ADD");
+	ps_manifest_close();
+	/* rebuild as a v2 record (drop crc, version -> 2), then corrupt its magic word */
+	fd = open(mpath, O_RDONLY);
+	sz = (fd >= 0) ? read(fd, v3, sizeof(v3)) : -1;
+	if (fd >= 0)
+		close(fd);
+	check(sz > 20, "v2-corrupt: read v3");
+	memcpy(v2, v3, 16);
+	memcpy(v2 + 4, &two, sizeof(two));
+	memcpy(v2 + 16, v3 + 20, (size_t) (sz - 20));
+	v2[0] ^= 0xFF;					/* corrupt the magic word of the (only) record */
+	fd = open(mpath, O_WRONLY | O_TRUNC, 0600);
+	check(fd >= 0 && write(fd, v2, (size_t) (sz - 4)) == (ssize_t) (sz - 4),
+		  "v2-corrupt: wrote corrupted v2 manifest");
+	if (fd >= 0)
+		close(fd);
+	(void) stat(mpath, &before);
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) != 0,
+		  "corrupted-first-record v2 manifest fails replay (not truncated)");
+	check(stat(mpath, &after) == 0 && after.st_size == before.st_size,
+		  "  ... and is left untouched on disk");
 	ps_manifest_close();
 	unlink(mpath);
 	rmdir(dir);
@@ -798,6 +856,7 @@ main(void)
 	test_manifest_replay_robustness();
 	test_manifest_v2_migration();
 	test_manifest_v3_first_downgrade();
+	test_manifest_v2_corrupt_first();
 	test_manifest_spanning_corruption();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -290,6 +290,136 @@ corrupt_byte(const char *path, off_t off)
 	close(fd);
 }
 
+/* Set one byte at 'off' to an exact value (to corrupt a specific header field). */
+static void
+poke_byte(const char *path, off_t off, unsigned char val)
+{
+	int			fd = open(path, O_RDWR);
+
+	if (fd < 0)
+		return;
+	if (pwrite(fd, &val, 1, off) != 1)
+		perror("pwrite");
+	close(fd);
+}
+
+/* manifest record header field offsets (magic, version, type, len, crc) */
+#define MR_MAGIC_OFF	0
+#define MR_VERSION_OFF	4
+#define MR_TYPE_OFF		8
+#define MT_ADD_LAYER	1		/* PsManifestEventType values (private to manifest.c) */
+#define MT_MARK_DELETE	4
+
+/* Build a fresh manifest with ADD(1) then ADD(2); return the first ADD's on-disk
+ * size (so a caller can locate the second record), or -1 on failure. */
+static off_t
+build_two_adds(char *dir, char *mpath, size_t mpath_cap)
+{
+	PsLayerDesc d1,
+				d2;
+	struct stat st;
+	off_t		add1;
+
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+		return -1;
+	snprintf(mpath, mpath_cap, "%s/layers.manifest", dir);
+	d1 = synth_layer(1, dir);
+	if (ps_manifest_add_layer(&d1) != 0 || stat(mpath, &st) != 0)
+	{
+		ps_manifest_close();
+		return -1;
+	}
+	add1 = st.st_size;
+	d2 = synth_layer(2, dir);
+	if (ps_manifest_add_layer(&d2) != 0)
+	{
+		ps_manifest_close();
+		return -1;
+	}
+	ps_manifest_close();
+	return add1;
+}
+
+/*
+ * Replay must not trust a corrupted header word (version/type/magic) to size a
+ * record: corruption confined to the physically last record is a recoverable torn
+ * tail, but corruption that leaves a valid record after it is interior corruption
+ * and must fail -- never silently truncating later records or bypassing the CRC.
+ */
+static void
+test_manifest_replay_robustness(void)
+{
+	char		dir[] = "/tmp/psrobXXXXXX";
+	char		mpath[4096];
+	off_t		add1;
+
+	/* (a) last record's TYPE corrupted -> torn tail, the earlier ADD survives */
+	add1 = build_two_adds(dir, mpath, sizeof(mpath));
+	check(add1 > 0, "robust: build (last-type)");
+	poke_byte(mpath, add1 + MR_TYPE_OFF, MT_MARK_DELETE);	/* ADD2.type -> a smaller type */
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) == 0,
+		  "last-record type corruption recovers as a torn tail");
+	check(ps_layer_map_count(&ps_layer_map) == 1 && find_layer(1) && !find_layer(2),
+		  "  ... the corrupt last record is dropped, the earlier ADD survives");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+
+	/* (b) last record's VERSION flipped 3->2 must NOT bypass the CRC */
+	memcpy(dir, "/tmp/psrobXXXXXX", sizeof(dir));
+	add1 = build_two_adds(dir, mpath, sizeof(mpath));
+	check(add1 > 0, "robust: build (version-downgrade)");
+	poke_byte(mpath, add1 + MR_VERSION_OFF, 2);	/* ADD2.version 3 -> 2 */
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) == 0,
+		  "version-downgraded last record recovers as a torn tail");
+	check(ps_layer_map_count(&ps_layer_map) == 1 && !find_layer(2),
+		  "  ... the downgraded record is not installed (CRC not bypassed)");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+
+	/* (c) last record's MAGIC corrupted -> torn tail, earlier ADD survives */
+	memcpy(dir, "/tmp/psrobXXXXXX", sizeof(dir));
+	add1 = build_two_adds(dir, mpath, sizeof(mpath));
+	check(add1 > 0, "robust: build (magic)");
+	poke_byte(mpath, add1 + MR_MAGIC_OFF, 0x00);	/* ADD2.magic low byte */
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) == 0 &&
+		  ps_layer_map_count(&ps_layer_map) == 1,
+		  "last-record magic corruption recovers as a torn tail");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+
+	/* (d) interior record's TYPE corrupted to ADD must FAIL, not truncate the
+	 * following REMOVE (which would resurrect the removed layer) */
+	memcpy(dir, "/tmp/psrobXXXXXX", sizeof(dir));
+	if (mkdtemp(dir) && ps_manifest_open(dir) == 0)
+	{
+		PsLayerDesc d1 = synth_layer(1, dir);
+		struct stat st;
+
+		snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+		check(ps_manifest_add_layer(&d1) == 0 && stat(mpath, &st) == 0,
+			  "robust: build (interior ADD)");
+		add1 = st.st_size;
+		check(ps_manifest_mark_delete(1) == 0 && ps_manifest_remove_layer(1) == 0,
+			  "robust: MARK_DELETE + REMOVE");
+		ps_manifest_close();
+		poke_byte(mpath, add1 + MR_TYPE_OFF, MT_ADD_LAYER);	/* MARK_DELETE.type -> ADD */
+		check(ps_manifest_open(dir) == 0 &&
+			  ps_manifest_replay(&ps_layer_map) != 0,
+			  "interior type corruption fails replay (REMOVE not truncated away)");
+		ps_manifest_close();
+		unlink(mpath);
+		rmdir(dir);
+	}
+	else
+		check(0, "robust: build (interior ADD)");
+}
+
 /*
  * Per-record CRC: a bit-flip inside a record (not the tail) is detected and fails
  * replay rather than loading a wrong layer; the same flip in the last record is a
@@ -504,6 +634,7 @@ main(void)
 	test_manifest_compaction();
 	test_manifest_crc();
 	test_manifest_len_corruption();
+	test_manifest_replay_robustness();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);
 	return failed ? 1 : 0;

--- a/contrib/pagestore/pagestore_gc_test.c
+++ b/contrib/pagestore/pagestore_gc_test.c
@@ -600,6 +600,46 @@ test_manifest_v2_corrupt_first(void)
 }
 
 /*
+ * A manifest whose only record is an incomplete (torn) write -- a crash during the
+ * very first append -- has committed nothing, so replay must truncate it to an
+ * openable empty manifest, not refuse to start (that would wedge the store).
+ */
+static void
+test_manifest_torn_first_record(void)
+{
+	char		dir[] = "/tmp/pstornfXXXXXX";
+	char		mpath[4096];
+	PsLayerDesc d1;
+	struct stat st;
+	int			fd;
+
+	if (!mkdtemp(dir) || ps_manifest_open(dir) != 0)
+	{
+		check(0, "torn-first: setup");
+		return;
+	}
+	snprintf(mpath, sizeof(mpath), "%s/layers.manifest", dir);
+	d1 = synth_layer(3, dir);
+	check(ps_manifest_add_layer(&d1) == 0 && stat(mpath, &st) == 0 && st.st_size > 30,
+		  "torn-first: one v3 ADD");
+	ps_manifest_close();
+	/* truncate mid-record: full header (20 bytes) + a partial payload */
+	fd = open(mpath, O_WRONLY);
+	check(fd >= 0 && ftruncate(fd, 30) == 0, "torn-first: truncate mid-record");
+	if (fd >= 0)
+		close(fd);
+	check(ps_manifest_open(dir) == 0 &&
+		  ps_manifest_replay(&ps_layer_map) == 0,
+		  "torn first record replays (store stays openable)");
+	check(ps_layer_map_count(&ps_layer_map) == 0 && stat(mpath, &st) == 0 &&
+		  st.st_size == 0,
+		  "  ... and is truncated to an empty manifest");
+	ps_manifest_close();
+	unlink(mpath);
+	rmdir(dir);
+}
+
+/*
  * Corruption can span several adjacent records, so the torn-tail probe must scan to
  * EOF, not just one record ahead: with two corrupt ADDs followed by an intact one,
  * replay must report interior corruption (fail), not truncate the whole file.
@@ -857,6 +897,7 @@ main(void)
 	test_manifest_v2_migration();
 	test_manifest_v3_first_downgrade();
 	test_manifest_v2_corrupt_first();
+	test_manifest_torn_first_record();
 	test_manifest_spanning_corruption();
 
 	printf("pagestore_gc_test: %d checks, %d failed\n", run, failed);

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -11,6 +11,7 @@
  */
 #include <errno.h>
 #include <fcntl.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -19,7 +20,8 @@
 #include "pagestore_manifest.h"
 
 #define PS_MANIFEST_MAGIC	0x504d414e	/* "PMAN" */
-#define PS_MANIFEST_VERSION 2	/* 2: layer descriptors embed PsKey with the klass field */
+#define PS_MANIFEST_VERSION 3	/* 3: per-record CRC (over the header + payload) */
+#define PS_MANIFEST_FNV_INIT	2166136261u
 
 typedef enum PsManifestEventType
 {
@@ -36,6 +38,7 @@ typedef struct PsManifestRecord
 	uint32_t	version;
 	uint32_t	type;
 	uint32_t	len;
+	uint32_t	crc;			/* FNV-1a over the header bytes above + the payload */
 } PsManifestRecord;
 
 typedef struct PsManifestLayerIdEvent
@@ -124,6 +127,33 @@ manifest_fsync_dir(void)
 	return rc;
 }
 
+/* FNV-1a (streaming): not cryptographic, just integrity.  Matches img_crc(). */
+static uint32_t
+manifest_fnv1a(uint32_t h, const void *p, size_t n)
+{
+	const unsigned char *b = p;
+
+	for (size_t i = 0; i < n; i++)
+	{
+		h ^= b[i];
+		h *= 16777619u;
+	}
+	return h;
+}
+
+/* CRC over the header fields preceding rec.crc, then the payload. */
+static uint32_t
+manifest_record_crc(const PsManifestRecord *rec, const void *payload, uint32_t len)
+{
+	uint32_t	crc;
+
+	crc = manifest_fnv1a(PS_MANIFEST_FNV_INIT, rec,
+						 offsetof(PsManifestRecord, crc));
+	if (len > 0)
+		crc = manifest_fnv1a(crc, payload, len);
+	return crc;
+}
+
 /* Write one [header | payload] record to an open fd (no fsync). */
 static int
 manifest_write_record(int fd, uint32_t type, const void *payload, uint32_t len)
@@ -134,6 +164,7 @@ manifest_write_record(int fd, uint32_t type, const void *payload, uint32_t len)
 	rec.version = PS_MANIFEST_VERSION;
 	rec.type = type;
 	rec.len = len;
+	rec.crc = manifest_record_crc(&rec, payload, len);
 
 	if (write(fd, &rec, sizeof(rec)) != (ssize_t) sizeof(rec) ||
 		(len > 0 && write(fd, payload, len) != (ssize_t) len))
@@ -364,8 +395,15 @@ ps_manifest_replay(PsLayerMap *map)
 	for (;;)
 	{
 		PsManifestRecord rec;
+		union					/* aligned buffer sized for the largest payload */
+		{
+			unsigned char bytes[sizeof(PsManifestLayerDisk)];
+			PsManifestLayerDisk layer;
+			PsManifestLayerIdEvent ev;
+		}			payload;
 		ssize_t		n;
 		off_t		rec_off = good_off;
+		int			at_eof;
 
 		n = read(fd, &rec, sizeof(rec));
 		if (n == 0)
@@ -376,40 +414,60 @@ ps_manifest_replay(PsLayerMap *map)
 			good_off = rec_off;
 			break;				/* torn tail */
 		}
+		/*
+		 * A malformed header (wrong magic/version, oversize len), a short payload,
+		 * or a bad CRC is a recoverable torn tail when it is the last thing in the
+		 * file; the same fault earlier in the file is interior corruption that must
+		 * fail replay rather than silently load a wrong layer.
+		 */
+		at_eof = (rec_off + (off_t) sizeof(rec) >= file_size);
 		if (rec.magic != PS_MANIFEST_MAGIC ||
-			rec.version != PS_MANIFEST_VERSION)
+			rec.version != PS_MANIFEST_VERSION ||
+			rec.len > sizeof(payload.bytes))
 		{
-			if (rec_off + (off_t) sizeof(rec) >= file_size)
+			if (at_eof)
 			{
 				truncate_tail = 1;
 				good_off = rec_off;
-				break;			/* invalid torn tail header */
+				break;
 			}
 			close(fd);
 			return -1;
+		}
+
+		if (rec.len > 0 &&
+			read(fd, payload.bytes, rec.len) != (ssize_t) rec.len)
+		{
+			truncate_tail = 1;
+			good_off = rec_off;
+			break;				/* torn payload */
+		}
+
+		if (manifest_record_crc(&rec, payload.bytes, rec.len) != rec.crc)
+		{
+			at_eof = (rec_off + (off_t) sizeof(rec) + (off_t) rec.len >= file_size);
+			if (at_eof)
+			{
+				truncate_tail = 1;
+				good_off = rec_off;
+				break;			/* torn tail (partial write) */
+			}
+			close(fd);
+			return -1;			/* interior corruption */
 		}
 
 		switch ((PsManifestEventType) rec.type)
 		{
 			case PS_MANIFEST_ADD_LAYER:
 				{
-					PsManifestLayerDisk disk;
 					PsLayerDesc desc;
-					ssize_t		nread;
 
-					if (rec.len != sizeof(disk))
+					if (rec.len != sizeof(payload.layer))
 					{
 						close(fd);
 						return -1;
 					}
-					nread = read(fd, &disk, sizeof(disk));
-					if (nread != (ssize_t) sizeof(disk))
-					{
-						truncate_tail = 1;
-						good_off = rec_off;
-						goto done;	/* torn tail */
-					}
-					if (manifest_decode_layer(&desc, &disk) != 0 ||
+					if (manifest_decode_layer(&desc, &payload.layer) != 0 ||
 						(!manifest_layer_exists(map, desc.layer_id) &&
 						 ps_layer_map_add(map, &desc) != 0))
 					{
@@ -421,50 +479,32 @@ ps_manifest_replay(PsLayerMap *map)
 
 			case PS_MANIFEST_SET_REMOTE_DURABLE:
 				{
-					PsManifestLayerIdEvent ev;
 					PsLayerDesc *layer;
-					ssize_t		nread;
 
-					if (rec.len != sizeof(ev))
+					if (rec.len != sizeof(payload.ev))
 					{
 						close(fd);
 						return -1;
 					}
-					nread = read(fd, &ev, sizeof(ev));
-					if (nread != (ssize_t) sizeof(ev))
-					{
-						truncate_tail = 1;
-						good_off = rec_off;
-						goto done;	/* torn tail */
-					}
-					layer = manifest_find_layer(map, ev.layer_id);
+					layer = manifest_find_layer(map, payload.ev.layer_id);
 					if (layer != NULL)
 					{
 						layer->remote_durable = true;
-						layer->remote_uploaded_lsn = ev.value;
+						layer->remote_uploaded_lsn = payload.ev.value;
 					}
 					break;
 				}
 
 			case PS_MANIFEST_MARK_DELETE:
 				{
-					PsManifestLayerIdEvent ev;
 					PsLayerDesc *layer;
-					ssize_t		nread;
 
-					if (rec.len != sizeof(ev))
+					if (rec.len != sizeof(payload.ev))
 					{
 						close(fd);
 						return -1;
 					}
-					nread = read(fd, &ev, sizeof(ev));
-					if (nread != (ssize_t) sizeof(ev))
-					{
-						truncate_tail = 1;
-						good_off = rec_off;
-						goto done;	/* torn tail */
-					}
-					layer = manifest_find_layer(map, ev.layer_id);
+					layer = manifest_find_layer(map, payload.ev.layer_id);
 					if (layer != NULL)
 						layer->deleting = true;
 					break;
@@ -472,44 +512,25 @@ ps_manifest_replay(PsLayerMap *map)
 
 			case PS_MANIFEST_REMOVE_LAYER:
 				{
-					PsManifestLayerIdEvent ev;
-					ssize_t		nread;
-
-					if (rec.len != sizeof(ev))
+					if (rec.len != sizeof(payload.ev))
 					{
 						close(fd);
 						return -1;
 					}
-					nread = read(fd, &ev, sizeof(ev));
-					if (nread != (ssize_t) sizeof(ev))
-					{
-						truncate_tail = 1;
-						good_off = rec_off;
-						goto done;	/* torn tail */
-					}
-					manifest_remove_from_map(map, ev.layer_id);
+					manifest_remove_from_map(map, payload.ev.layer_id);
 					break;
 				}
 
 			case PS_MANIFEST_DROP_LOCAL:
 				{
-					PsManifestLayerIdEvent ev;
 					PsLayerDesc *layer;
-					ssize_t		nread;
 
-					if (rec.len != sizeof(ev))
+					if (rec.len != sizeof(payload.ev))
 					{
 						close(fd);
 						return -1;
 					}
-					nread = read(fd, &ev, sizeof(ev));
-					if (nread != (ssize_t) sizeof(ev))
-					{
-						truncate_tail = 1;
-						good_off = rec_off;
-						goto done;	/* torn tail */
-					}
-					layer = manifest_find_layer(map, ev.layer_id);
+					layer = manifest_find_layer(map, payload.ev.layer_id);
 					if (layer != NULL)
 					{
 						for (uint32_t i = 0; i < layer->location_count; i++)
@@ -535,7 +556,6 @@ ps_manifest_replay(PsLayerMap *map)
 		manifest_nrecords++;
 	}
 
-done:
 	if (truncate_tail &&
 		(ftruncate(fd, good_off) != 0 || fsync(fd) != 0))
 	{

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -21,7 +21,6 @@
 
 #define PS_MANIFEST_MAGIC	0x504d414e	/* "PMAN" */
 #define PS_MANIFEST_VERSION 3	/* 3: per-record CRC (over the header + payload) */
-#define PS_MANIFEST_VERSION_V2 2	/* legacy: no per-record CRC (16-byte header) */
 #define PS_MANIFEST_FNV_INIT	2166136261u
 
 typedef enum PsManifestEventType
@@ -387,6 +386,45 @@ ps_manifest_poisoned(void)
 	return __atomic_load_n(&manifest_poisoned, __ATOMIC_ACQUIRE);
 }
 
+/*
+ * Does a fully-intact record begin at byte offset 'off'?  "Fully intact" means the
+ * header fits, magic and version are exact, the type is known, the len field equals
+ * that type's fixed payload size, the payload fits, and the CRC matches -- so no
+ * byte of the record (header or payload) is corrupted.  Nothing is trusted before
+ * the CRC confirms it, so a flipped version/type/len/magic cannot be reinterpreted
+ * into a "valid" record of a different shape.  On success copies the header into
+ * *rec and the payload into payload_buf, sets *rec_size to the on-disk record size,
+ * and returns 1; otherwise 0.  Uses pread so callers can probe an arbitrary offset
+ * without disturbing the file position.
+ */
+static int
+manifest_record_valid_at(int fd, off_t off, off_t file_size,
+						 PsManifestRecord *rec, void *payload_buf,
+						 size_t payload_cap, off_t *rec_size)
+{
+	int			plen;
+
+	if (off < 0 || off + (off_t) sizeof(*rec) > file_size)
+		return 0;				/* no room for even a header */
+	if (pread(fd, rec, sizeof(*rec), off) != (ssize_t) sizeof(*rec))
+		return 0;
+	if (rec->magic != PS_MANIFEST_MAGIC || rec->version != PS_MANIFEST_VERSION)
+		return 0;
+	plen = manifest_type_payload_len(rec->type);
+	if (plen < 0 || (size_t) plen > payload_cap || rec->len != (uint32_t) plen)
+		return 0;
+	if (off + (off_t) sizeof(*rec) + plen > file_size)
+		return 0;				/* body does not fit */
+	if (plen > 0 &&
+		pread(fd, payload_buf, (size_t) plen, off + (off_t) sizeof(*rec)) !=
+		(ssize_t) plen)
+		return 0;
+	if (manifest_record_crc(rec, payload_buf, (uint32_t) plen) != rec->crc)
+		return 0;
+	*rec_size = (off_t) sizeof(*rec) + plen;
+	return 1;
+}
+
 int
 ps_manifest_replay(PsLayerMap *map)
 {
@@ -395,6 +433,14 @@ ps_manifest_replay(PsLayerMap *map)
 	int			truncate_tail = 0;
 	off_t		file_size;
 	struct stat st;
+
+	/*
+	 * The most bytes one record can occupy on disk (header + the largest payload).
+	 * A record after a corrupt one is contiguous, so it cannot begin farther than
+	 * this past the corrupt record -- which bounds the torn-tail probe below.
+	 */
+	const off_t max_record = (off_t) sizeof(PsManifestRecord) +
+		(off_t) sizeof(PsManifestLayerDisk);
 
 	manifest_nrecords = 0;
 	fd = open(manifest_path, O_RDWR);
@@ -411,7 +457,7 @@ ps_manifest_replay(PsLayerMap *map)
 	}
 	file_size = st.st_size;
 
-	for (;;)
+	while (good_off < file_size)
 	{
 		PsManifestRecord rec;
 		union					/* aligned buffer sized for the largest payload */
@@ -420,116 +466,53 @@ ps_manifest_replay(PsLayerMap *map)
 			PsManifestLayerDisk layer;
 			PsManifestLayerIdEvent ev;
 		}			payload;
-		ssize_t		n;
 		off_t		rec_off = good_off;
-		int			has_crc,
-					plen;
-		off_t		hdr_size,
-					rec_total;
+		off_t		rec_size;
+		off_t		scan;
+		int			interior;
 
-		/*
-		 * Read the 16-byte common prefix (magic, version, type, len) shared by
-		 * every format version.  A short read or wrong magic at end-of-file is a
-		 * recoverable torn tail; the same fault earlier in the file is corruption.
-		 */
-		n = read(fd, &rec, offsetof(PsManifestRecord, crc));
-		if (n == 0)
-			break;				/* clean end of log */
-		if (n != (ssize_t) offsetof(PsManifestRecord, crc) ||
-			rec.magic != PS_MANIFEST_MAGIC)
+		if (!manifest_record_valid_at(fd, rec_off, file_size, &rec, payload.bytes,
+									  sizeof(payload.bytes), &rec_size))
 		{
-			if (rec_off + (off_t) offsetof(PsManifestRecord, crc) >= file_size)
+			/*
+			 * No intact record begins at rec_off: it is corrupt or torn.  Treat it
+			 * as a recoverable torn tail only if no intact record begins after it
+			 * -- then the damage is confined to the final record and the earlier
+			 * entries survive.  If an intact record does follow, this is interior
+			 * corruption and we must fail rather than truncate valid history (or
+			 * resurrect a dropped layer).  A following record is contiguous, so it
+			 * begins within one max_record of rec_off; that bounds the probe and
+			 * keeps a corrupted type/len/magic from being trusted to size anything.
+			 */
+			interior = 0;
+			for (scan = rec_off + 1;
+				 scan <= rec_off + max_record && scan < file_size; scan++)
 			{
-				truncate_tail = 1;
-				good_off = rec_off;
-				break;
-			}
-			close(fd);
-			return -1;
-		}
+				PsManifestRecord prec;
+				union
+				{
+					unsigned char bytes[sizeof(PsManifestLayerDisk)];
+					PsManifestLayerDisk layer;
+					PsManifestLayerIdEvent ev;
+				}			pbuf;
+				off_t		psize;
 
-		/* accept v3 (per-record CRC) and the legacy v2 (no CRC); reject others */
-		if (rec.version == PS_MANIFEST_VERSION)
-		{
-			has_crc = 1;
-			hdr_size = (off_t) sizeof(PsManifestRecord);
-		}
-		else if (rec.version == PS_MANIFEST_VERSION_V2)
-		{
-			has_crc = 0;
-			hdr_size = (off_t) offsetof(PsManifestRecord, crc);
-		}
-		else
-		{
-			if (rec_off + (off_t) offsetof(PsManifestRecord, crc) >= file_size)
+				if (manifest_record_valid_at(fd, scan, file_size, &prec,
+											 pbuf.bytes, sizeof(pbuf.bytes),
+											 &psize))
+				{
+					interior = 1;
+					break;
+				}
+			}
+			if (interior)
 			{
-				truncate_tail = 1;
-				good_off = rec_off;
-				break;
+				close(fd);
+				return -1;
 			}
-			close(fd);
-			return -1;
-		}
-		if (has_crc &&
-			read(fd, &rec.crc, sizeof(rec.crc)) != (ssize_t) sizeof(rec.crc))
-		{
-			truncate_tail = 1;
-			good_off = rec_off;
-			break;				/* torn CRC */
-		}
-
-		/*
-		 * Size the record from its TYPE, never the (untrusted) len field, so a
-		 * corrupted len cannot misalign the read.  An unknown type with data after
-		 * it is interior corruption; at EOF it is a torn tail.
-		 */
-		plen = manifest_type_payload_len(rec.type);
-		if (plen < 0 || (size_t) plen > sizeof(payload.bytes))
-		{
-			if (rec_off + hdr_size >= file_size)
-			{
-				truncate_tail = 1;
-				good_off = rec_off;
-				break;
-			}
-			close(fd);
-			return -1;
-		}
-		rec_total = hdr_size + plen;
-
-		/* a record that does not fully fit in the file is a truncated torn tail */
-		if (rec_off + rec_total > file_size)
-		{
 			truncate_tail = 1;
 			good_off = rec_off;
 			break;
-		}
-		if (plen > 0 &&
-			read(fd, payload.bytes, (size_t) plen) != (ssize_t) plen)
-		{
-			truncate_tail = 1;
-			good_off = rec_off;
-			break;				/* (unreachable given the fit check above) */
-		}
-
-		/*
-		 * Integrity: v3 verifies the CRC; both versions require the len field to
-		 * equal the type's fixed size (this catches a flipped len on v2 and is
-		 * defence-in-depth on v3).  A full-sized record that fails is interior
-		 * corruption unless it is physically the last record (then a torn tail).
-		 */
-		if (rec.len != (uint32_t) plen ||
-			(has_crc &&
-			 manifest_record_crc(&rec, payload.bytes, (uint32_t) plen) != rec.crc))
-		{
-			if (rec_off + rec_total >= file_size)
-			{
-				truncate_tail = 1;
-				good_off = rec_off;
-				break;
-			}
-			close(fd);
-			return -1;
 		}
 
 		switch ((PsManifestEventType) rec.type)
@@ -589,7 +572,7 @@ ps_manifest_replay(PsLayerMap *map)
 				close(fd);
 				return -1;
 		}
-		good_off = rec_off + rec_total;	/* we read exactly rec_total above */
+		good_off = rec_off + rec_size;
 		manifest_nrecords++;
 	}
 

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -429,6 +429,40 @@ manifest_record_valid_at(int fd, off_t off, off_t file_size, int v2,
 	return 1;
 }
 
+/*
+ * Is the record at 'off' actually a v3 record whose version word was corrupted away
+ * from 3 (rather than a genuine legacy v2 record)?  A v2 record has no CRC, so it
+ * cannot be told from a version-flipped v3 record by the header alone; but the v3
+ * CRC covers the version field, so recomputing it with the version forced back to 3
+ * confirms the bytes were a v3 record.  Used to reject a downgraded v3 first record
+ * before the whole file is (mis)classified as v2 and read without CRC checks.
+ */
+static int
+manifest_record_is_corrupted_v3(int fd, off_t off, off_t file_size)
+{
+	PsManifestRecord rec,
+				probe;
+	unsigned char buf[sizeof(PsManifestLayerDisk)];
+	int			plen;
+
+	if (off < 0 || off + (off_t) sizeof(rec) > file_size)
+		return 0;				/* a full v3 record does not fit -> not v3 */
+	if (pread(fd, &rec, sizeof(rec), off) != (ssize_t) sizeof(rec) ||
+		rec.magic != PS_MANIFEST_MAGIC)
+		return 0;
+	plen = manifest_type_payload_len(rec.type);
+	if (plen < 0 || (size_t) plen > sizeof(buf) || rec.len != (uint32_t) plen)
+		return 0;
+	if (off + (off_t) sizeof(rec) + plen > file_size)
+		return 0;
+	if (plen > 0 &&
+		pread(fd, buf, (size_t) plen, off + (off_t) sizeof(rec)) != (ssize_t) plen)
+		return 0;
+	probe = rec;
+	probe.version = PS_MANIFEST_VERSION;	/* what it was before the flip */
+	return manifest_record_crc(&probe, buf, (uint32_t) plen) == rec.crc;
+}
+
 int
 ps_manifest_replay(PsLayerMap *map)
 {
@@ -438,14 +472,6 @@ ps_manifest_replay(PsLayerMap *map)
 	int			file_v2;
 	off_t		file_size;
 	struct stat st;
-
-	/*
-	 * The most bytes one record can occupy on disk (header + the largest payload).
-	 * A record after a corrupt one is contiguous, so it cannot begin farther than
-	 * this past the corrupt record -- which bounds the torn-tail probe below.
-	 */
-	const off_t max_record = (off_t) sizeof(PsManifestRecord) +
-		(off_t) sizeof(PsManifestLayerDisk);
 
 	manifest_nrecords = 0;
 	fd = open(manifest_path, O_RDWR);
@@ -464,12 +490,13 @@ ps_manifest_replay(PsLayerMap *map)
 
 	/*
 	 * Decide the whole file's format from its first record: a manifest is entirely
-	 * v3 (per-record CRC) or entirely legacy v2 (no CRC), never a mix.  Probing the
-	 * first record as v3 first means a v3 record whose version was bit-flipped to 2
-	 * is not reinterpreted as an unchecked v2 record (it just fails the v3 probe and
-	 * is handled as corruption below) -- only a genuine v2 file, whose first record
-	 * is a valid v2 record, is read without CRC.  A v2 file is migrated to v3 after
-	 * replay so this branch is taken at most once per store.
+	 * v3 (per-record CRC) or entirely legacy v2 (no CRC), never a mix.  Probe v3
+	 * first; only if that fails AND the record is not a version-corrupted v3 record
+	 * (which has no CRC of its own to catch the flip, so we re-check its CRC with the
+	 * version forced back to 3) do we read the file as legacy v2.  This keeps a v3
+	 * record whose version word was flipped to 2 from being reinterpreted as an
+	 * unchecked v2 record.  A v2 file is migrated to v3 after replay, so this is
+	 * taken at most once per store.
 	 */
 	{
 		PsManifestRecord r0;
@@ -482,12 +509,13 @@ ps_manifest_replay(PsLayerMap *map)
 										  sizeof(b0), &s0))
 			file_v2 = 0;
 		else if (manifest_record_valid_at(fd, 0, file_size, 1, &r0, b0,
-										  sizeof(b0), &s0))
+										  sizeof(b0), &s0) &&
+				 !manifest_record_is_corrupted_v3(fd, 0, file_size))
 			file_v2 = 1;
 		else
-			file_v2 = 0;		/* not a valid first record either way; the v3 path
-								 * below truncates a torn/garbage start as an empty
-								 * manifest (nothing was committed) */
+			file_v2 = 0;		/* a v3 file (possibly with a corrupt/torn first
+								 * record, handled as corruption below) -- never read
+								 * a version-flipped v3 record as unchecked v2 */
 	}
 
 	while (good_off < file_size)
@@ -510,17 +538,18 @@ ps_manifest_replay(PsLayerMap *map)
 		{
 			/*
 			 * No intact record begins at rec_off: it is corrupt or torn.  Treat it
-			 * as a recoverable torn tail only if no intact record begins after it
-			 * -- then the damage is confined to the final record and the earlier
-			 * entries survive.  If an intact record does follow, this is interior
-			 * corruption and we must fail rather than truncate valid history (or
-			 * resurrect a dropped layer).  A following record is contiguous, so it
-			 * begins within one max_record of rec_off; that bounds the probe and
-			 * keeps a corrupted type/len/magic from being trusted to size anything.
+			 * as a recoverable torn tail only if no intact record begins anywhere
+			 * after it -- then the damage is confined to the final record(s) and the
+			 * earlier entries survive.  If an intact record does follow, this is
+			 * interior corruption and we must fail rather than truncate valid history
+			 * (or resurrect a dropped layer).  Scan all the way to EOF, not just one
+			 * record ahead: several adjacent records can be corrupt, so the next
+			 * intact one may be far past rec_off.  This runs only on a corrupt/torn
+			 * replay, and the per-offset probe rejects on the magic word before
+			 * touching a payload, so it stays cheap.
 			 */
 			interior = 0;
-			for (scan = rec_off + 1;
-				 scan <= rec_off + max_record && scan < file_size; scan++)
+			for (scan = rec_off + 1; scan < file_size; scan++)
 			{
 				PsManifestRecord prec;
 				union

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -458,36 +458,6 @@ manifest_scan_clean_v2(int fd, off_t file_size)
 	return off == file_size;	/* landed exactly on EOF -> clean v2 */
 }
 
-/*
- * Is the manifest's first record an incomplete (torn) record -- an append that was
- * interrupted before the record was fully written?  True only when our magic is at
- * the start but the record the header describes runs past EOF; a full record (even
- * one with a bad CRC), foreign bytes, or an unknown type is NOT torn.  A torn first
- * record means nothing was durably committed, so replay can safely truncate it away
- * to an openable empty manifest instead of refusing to start.
- */
-static int
-manifest_first_record_torn(int fd, off_t file_size)
-{
-	PsManifestRecord rec;
-	uint32_t	magic = 0;
-	int			plen;
-
-	if (file_size <= 0)
-		return 0;
-	if (pread(fd, &magic, sizeof(magic), 0) != (ssize_t) sizeof(magic) ||
-		magic != PS_MANIFEST_MAGIC)
-		return 0;				/* no/foreign magic -> not a torn write of ours */
-	if (file_size < (off_t) sizeof(rec))
-		return 1;				/* magic present but the header is truncated */
-	if (pread(fd, &rec, sizeof(rec), 0) != (ssize_t) sizeof(rec))
-		return 0;
-	plen = manifest_type_payload_len(rec.type);
-	if (plen < 0)
-		return 0;				/* unknown type on a full header -> corruption */
-	return file_size < (off_t) sizeof(rec) + plen;	/* payload truncated -> torn */
-}
-
 int
 ps_manifest_replay(PsLayerMap *map)
 {
@@ -516,37 +486,32 @@ ps_manifest_replay(PsLayerMap *map)
 	/*
 	 * Decide the whole file's format: a manifest is entirely v3 (per-record CRC) or
 	 * entirely legacy v2 (no CRC), never a mix.  Because v2 has no CRC, a corrupted
-	 * v3 record and a v2 record are indistinguishable by inspection, so we do not
-	 * guess from the first record alone:
+	 * v3 record and a v2 record (or a v2 record followed by a torn tail) are
+	 * indistinguishable by inspection, so we never read an ambiguous record as v2:
 	 *   - a valid v3 first record  -> v3 file (the per-record CRC anchors the rest);
 	 *   - else if the ENTIRE file parses cleanly as v2 -> a genuine v2 file, which we
 	 *     replay and then migrate to v3 in place;
-	 *   - else if the first record is an incomplete (torn) write -> nothing was
-	 *     committed, so let the loop below truncate it to an openable empty manifest;
-	 *   - else (a corrupted v3 file, a damaged v2 file, or garbage) -> fail the
-	 *     replay WITHOUT truncating, so no real metadata is silently emptied and no
-	 *     ambiguous bytes are installed as an unchecked v2 layer; an operator can
-	 *     migrate offline or recreate the store.
+	 *   - else -> treat it as v3 and let the loop below decide.  Because no ambiguous
+	 *     record can pass the v3 (CRC) check, the loop never installs a bogus layer
+	 *     from it: a torn/corrupt-then-nothing tail truncates to an openable empty
+	 *     manifest, while corruption with valid v3 records after it fails as interior
+	 *     corruption.  A damaged or torn-tailed legacy v2 file therefore comes up
+	 *     empty (its layer files are reclaimable by GC and its pages stay readable
+	 *     from the authoritative segment log) rather than wedging the store or
+	 *     installing unchecked bytes.
 	 */
 	{
 		PsManifestRecord r0;
 		unsigned char b0[sizeof(PsManifestLayerDisk)];
 		off_t		s0;
 
-		if (file_size == 0)
-			file_v2 = 0;		/* empty: the loop below does nothing, returns 0 */
-		else if (manifest_record_valid_at(fd, 0, file_size, 0, &r0, b0,
-										  sizeof(b0), &s0))
-			file_v2 = 0;
+		if (file_size > 0 &&
+			manifest_record_valid_at(fd, 0, file_size, 0, &r0, b0, sizeof(b0), &s0))
+			file_v2 = 0;		/* a v3 manifest */
 		else if (manifest_scan_clean_v2(fd, file_size))
-			file_v2 = 1;
-		else if (manifest_first_record_torn(fd, file_size))
-			file_v2 = 0;		/* torn first append: the loop truncates to empty */
+			file_v2 = 1;		/* an entirely-clean legacy v2 manifest -> migrate */
 		else
-		{
-			close(fd);
-			return -1;
-		}
+			file_v2 = 0;		/* ambiguous/torn/corrupt -> the v3 loop drops it */
 	}
 
 	while (good_off < file_size)

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -389,39 +389,43 @@ ps_manifest_poisoned(void)
 /*
  * Does a fully-intact record begin at byte offset 'off'?  "Fully intact" means the
  * header fits, magic and version are exact, the type is known, the len field equals
- * that type's fixed payload size, the payload fits, and the CRC matches -- so no
- * byte of the record (header or payload) is corrupted.  Nothing is trusted before
- * the CRC confirms it, so a flipped version/type/len/magic cannot be reinterpreted
- * into a "valid" record of a different shape.  On success copies the header into
- * *rec and the payload into payload_buf, sets *rec_size to the on-disk record size,
- * and returns 1; otherwise 0.  Uses pread so callers can probe an arbitrary offset
- * without disturbing the file position.
+ * that type's fixed payload size, the payload fits, and (for v3) the CRC matches --
+ * so no byte of the record is corrupted.  Nothing is trusted before the CRC confirms
+ * it, so a flipped version/type/len/magic cannot be reinterpreted into a "valid"
+ * record of a different shape.  'v2' selects the legacy 16-byte header (no CRC) -- a
+ * whole manifest file is one version or the other (decided from its first record),
+ * so this can never be used to read a corrupted v3 record as an unchecked v2 one.
+ * On success copies the header into *rec and the payload into payload_buf, sets
+ * *rec_size to the on-disk record size, and returns 1; otherwise 0.  Uses pread so
+ * callers can probe an arbitrary offset without disturbing the file position.
  */
 static int
-manifest_record_valid_at(int fd, off_t off, off_t file_size,
+manifest_record_valid_at(int fd, off_t off, off_t file_size, int v2,
 						 PsManifestRecord *rec, void *payload_buf,
 						 size_t payload_cap, off_t *rec_size)
 {
+	off_t		hdr = v2 ? (off_t) offsetof(PsManifestRecord, crc)
+		: (off_t) sizeof(*rec);
+	uint32_t	want_ver = v2 ? 2u : (uint32_t) PS_MANIFEST_VERSION;
 	int			plen;
 
-	if (off < 0 || off + (off_t) sizeof(*rec) > file_size)
+	if (off < 0 || off + hdr > file_size)
 		return 0;				/* no room for even a header */
-	if (pread(fd, rec, sizeof(*rec), off) != (ssize_t) sizeof(*rec))
+	if (pread(fd, rec, (size_t) hdr, off) != (ssize_t) hdr)
 		return 0;
-	if (rec->magic != PS_MANIFEST_MAGIC || rec->version != PS_MANIFEST_VERSION)
+	if (rec->magic != PS_MANIFEST_MAGIC || rec->version != want_ver)
 		return 0;
 	plen = manifest_type_payload_len(rec->type);
 	if (plen < 0 || (size_t) plen > payload_cap || rec->len != (uint32_t) plen)
 		return 0;
-	if (off + (off_t) sizeof(*rec) + plen > file_size)
+	if (off + hdr + plen > file_size)
 		return 0;				/* body does not fit */
 	if (plen > 0 &&
-		pread(fd, payload_buf, (size_t) plen, off + (off_t) sizeof(*rec)) !=
-		(ssize_t) plen)
+		pread(fd, payload_buf, (size_t) plen, off + hdr) != (ssize_t) plen)
 		return 0;
-	if (manifest_record_crc(rec, payload_buf, (uint32_t) plen) != rec->crc)
+	if (!v2 && manifest_record_crc(rec, payload_buf, (uint32_t) plen) != rec->crc)
 		return 0;
-	*rec_size = (off_t) sizeof(*rec) + plen;
+	*rec_size = hdr + plen;
 	return 1;
 }
 
@@ -431,6 +435,7 @@ ps_manifest_replay(PsLayerMap *map)
 	int			fd;
 	off_t		good_off = 0;
 	int			truncate_tail = 0;
+	int			file_v2;
 	off_t		file_size;
 	struct stat st;
 
@@ -457,6 +462,34 @@ ps_manifest_replay(PsLayerMap *map)
 	}
 	file_size = st.st_size;
 
+	/*
+	 * Decide the whole file's format from its first record: a manifest is entirely
+	 * v3 (per-record CRC) or entirely legacy v2 (no CRC), never a mix.  Probing the
+	 * first record as v3 first means a v3 record whose version was bit-flipped to 2
+	 * is not reinterpreted as an unchecked v2 record (it just fails the v3 probe and
+	 * is handled as corruption below) -- only a genuine v2 file, whose first record
+	 * is a valid v2 record, is read without CRC.  A v2 file is migrated to v3 after
+	 * replay so this branch is taken at most once per store.
+	 */
+	{
+		PsManifestRecord r0;
+		unsigned char b0[sizeof(PsManifestLayerDisk)];
+		off_t		s0;
+
+		if (file_size == 0)
+			file_v2 = 0;
+		else if (manifest_record_valid_at(fd, 0, file_size, 0, &r0, b0,
+										  sizeof(b0), &s0))
+			file_v2 = 0;
+		else if (manifest_record_valid_at(fd, 0, file_size, 1, &r0, b0,
+										  sizeof(b0), &s0))
+			file_v2 = 1;
+		else
+			file_v2 = 0;		/* not a valid first record either way; the v3 path
+								 * below truncates a torn/garbage start as an empty
+								 * manifest (nothing was committed) */
+	}
+
 	while (good_off < file_size)
 	{
 		PsManifestRecord rec;
@@ -471,8 +504,9 @@ ps_manifest_replay(PsLayerMap *map)
 		off_t		scan;
 		int			interior;
 
-		if (!manifest_record_valid_at(fd, rec_off, file_size, &rec, payload.bytes,
-									  sizeof(payload.bytes), &rec_size))
+		if (!manifest_record_valid_at(fd, rec_off, file_size, file_v2, &rec,
+									  payload.bytes, sizeof(payload.bytes),
+									  &rec_size))
 		{
 			/*
 			 * No intact record begins at rec_off: it is corrupt or torn.  Treat it
@@ -497,7 +531,7 @@ ps_manifest_replay(PsLayerMap *map)
 				}			pbuf;
 				off_t		psize;
 
-				if (manifest_record_valid_at(fd, scan, file_size, &prec,
+				if (manifest_record_valid_at(fd, scan, file_size, file_v2, &prec,
 											 pbuf.bytes, sizeof(pbuf.bytes),
 											 &psize))
 				{
@@ -583,6 +617,17 @@ ps_manifest_replay(PsLayerMap *map)
 		return -1;
 	}
 	close(fd);
+
+	/*
+	 * Upgrade a legacy v2 manifest in place: the replayed state is now in 'map', so
+	 * rewrite the log as v3 (one ADD per live layer) via temp+rename.  This both
+	 * adds CRC protection going forward and -- crucially -- avoids appending v3
+	 * records onto a v2 file (which would defeat the whole-file version check above)
+	 * and avoids discarding the old metadata.  Done once; later opens see v3.
+	 */
+	if (file_v2 && map == &ps_layer_map && ps_manifest_compact() != 0)
+		return -1;
+
 	return 0;
 }
 

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -21,6 +21,7 @@
 
 #define PS_MANIFEST_MAGIC	0x504d414e	/* "PMAN" */
 #define PS_MANIFEST_VERSION 3	/* 3: per-record CRC (over the header + payload) */
+#define PS_MANIFEST_VERSION_V2 2	/* legacy: no per-record CRC (16-byte header) */
 #define PS_MANIFEST_FNV_INIT	2166136261u
 
 typedef enum PsManifestEventType
@@ -152,6 +153,24 @@ manifest_record_crc(const PsManifestRecord *rec, const void *payload, uint32_t l
 	if (len > 0)
 		crc = manifest_fnv1a(crc, payload, len);
 	return crc;
+}
+
+/* Fixed on-disk payload length for a record type, or -1 if the type is unknown. */
+static int
+manifest_type_payload_len(uint32_t type)
+{
+	switch ((PsManifestEventType) type)
+	{
+		case PS_MANIFEST_ADD_LAYER:
+			return (int) sizeof(PsManifestLayerDisk);
+		case PS_MANIFEST_SET_REMOTE_DURABLE:
+		case PS_MANIFEST_DROP_LOCAL:
+		case PS_MANIFEST_MARK_DELETE:
+		case PS_MANIFEST_REMOVE_LAYER:
+			return (int) sizeof(PsManifestLayerIdEvent);
+		default:
+			return -1;
+	}
 }
 
 /* Write one [header | payload] record to an open fd (no fsync). */
@@ -403,29 +422,23 @@ ps_manifest_replay(PsLayerMap *map)
 		}			payload;
 		ssize_t		n;
 		off_t		rec_off = good_off;
-		int			at_eof;
+		int			has_crc,
+					plen;
+		off_t		hdr_size,
+					rec_total;
 
-		n = read(fd, &rec, sizeof(rec));
-		if (n == 0)
-			break;
-		if (n != (ssize_t) sizeof(rec))
-		{
-			truncate_tail = 1;
-			good_off = rec_off;
-			break;				/* torn tail */
-		}
 		/*
-		 * A malformed header (wrong magic/version, oversize len), a short payload,
-		 * or a bad CRC is a recoverable torn tail when it is the last thing in the
-		 * file; the same fault earlier in the file is interior corruption that must
-		 * fail replay rather than silently load a wrong layer.
+		 * Read the 16-byte common prefix (magic, version, type, len) shared by
+		 * every format version.  A short read or wrong magic at end-of-file is a
+		 * recoverable torn tail; the same fault earlier in the file is corruption.
 		 */
-		at_eof = (rec_off + (off_t) sizeof(rec) >= file_size);
-		if (rec.magic != PS_MANIFEST_MAGIC ||
-			rec.version != PS_MANIFEST_VERSION ||
-			rec.len > sizeof(payload.bytes))
+		n = read(fd, &rec, offsetof(PsManifestRecord, crc));
+		if (n == 0)
+			break;				/* clean end of log */
+		if (n != (ssize_t) offsetof(PsManifestRecord, crc) ||
+			rec.magic != PS_MANIFEST_MAGIC)
 		{
-			if (at_eof)
+			if (rec_off + (off_t) offsetof(PsManifestRecord, crc) >= file_size)
 			{
 				truncate_tail = 1;
 				good_off = rec_off;
@@ -435,25 +448,88 @@ ps_manifest_replay(PsLayerMap *map)
 			return -1;
 		}
 
-		if (rec.len > 0 &&
-			read(fd, payload.bytes, rec.len) != (ssize_t) rec.len)
+		/* accept v3 (per-record CRC) and the legacy v2 (no CRC); reject others */
+		if (rec.version == PS_MANIFEST_VERSION)
 		{
-			truncate_tail = 1;
-			good_off = rec_off;
-			break;				/* torn payload */
+			has_crc = 1;
+			hdr_size = (off_t) sizeof(PsManifestRecord);
 		}
-
-		if (manifest_record_crc(&rec, payload.bytes, rec.len) != rec.crc)
+		else if (rec.version == PS_MANIFEST_VERSION_V2)
 		{
-			at_eof = (rec_off + (off_t) sizeof(rec) + (off_t) rec.len >= file_size);
-			if (at_eof)
+			has_crc = 0;
+			hdr_size = (off_t) offsetof(PsManifestRecord, crc);
+		}
+		else
+		{
+			if (rec_off + (off_t) offsetof(PsManifestRecord, crc) >= file_size)
 			{
 				truncate_tail = 1;
 				good_off = rec_off;
-				break;			/* torn tail (partial write) */
+				break;
 			}
 			close(fd);
-			return -1;			/* interior corruption */
+			return -1;
+		}
+		if (has_crc &&
+			read(fd, &rec.crc, sizeof(rec.crc)) != (ssize_t) sizeof(rec.crc))
+		{
+			truncate_tail = 1;
+			good_off = rec_off;
+			break;				/* torn CRC */
+		}
+
+		/*
+		 * Size the record from its TYPE, never the (untrusted) len field, so a
+		 * corrupted len cannot misalign the read.  An unknown type with data after
+		 * it is interior corruption; at EOF it is a torn tail.
+		 */
+		plen = manifest_type_payload_len(rec.type);
+		if (plen < 0 || (size_t) plen > sizeof(payload.bytes))
+		{
+			if (rec_off + hdr_size >= file_size)
+			{
+				truncate_tail = 1;
+				good_off = rec_off;
+				break;
+			}
+			close(fd);
+			return -1;
+		}
+		rec_total = hdr_size + plen;
+
+		/* a record that does not fully fit in the file is a truncated torn tail */
+		if (rec_off + rec_total > file_size)
+		{
+			truncate_tail = 1;
+			good_off = rec_off;
+			break;
+		}
+		if (plen > 0 &&
+			read(fd, payload.bytes, (size_t) plen) != (ssize_t) plen)
+		{
+			truncate_tail = 1;
+			good_off = rec_off;
+			break;				/* (unreachable given the fit check above) */
+		}
+
+		/*
+		 * Integrity: v3 verifies the CRC; both versions require the len field to
+		 * equal the type's fixed size (this catches a flipped len on v2 and is
+		 * defence-in-depth on v3).  A full-sized record that fails is interior
+		 * corruption unless it is physically the last record (then a torn tail).
+		 */
+		if (rec.len != (uint32_t) plen ||
+			(has_crc &&
+			 manifest_record_crc(&rec, payload.bytes, (uint32_t) plen) != rec.crc))
+		{
+			if (rec_off + rec_total >= file_size)
+			{
+				truncate_tail = 1;
+				good_off = rec_off;
+				break;
+			}
+			close(fd);
+			return -1;
 		}
 
 		switch ((PsManifestEventType) rec.type)
@@ -462,11 +538,6 @@ ps_manifest_replay(PsLayerMap *map)
 				{
 					PsLayerDesc desc;
 
-					if (rec.len != sizeof(payload.layer))
-					{
-						close(fd);
-						return -1;
-					}
 					if (manifest_decode_layer(&desc, &payload.layer) != 0 ||
 						(!manifest_layer_exists(map, desc.layer_id) &&
 						 ps_layer_map_add(map, &desc) != 0))
@@ -479,14 +550,8 @@ ps_manifest_replay(PsLayerMap *map)
 
 			case PS_MANIFEST_SET_REMOTE_DURABLE:
 				{
-					PsLayerDesc *layer;
+					PsLayerDesc *layer = manifest_find_layer(map, payload.ev.layer_id);
 
-					if (rec.len != sizeof(payload.ev))
-					{
-						close(fd);
-						return -1;
-					}
-					layer = manifest_find_layer(map, payload.ev.layer_id);
 					if (layer != NULL)
 					{
 						layer->remote_durable = true;
@@ -497,49 +562,26 @@ ps_manifest_replay(PsLayerMap *map)
 
 			case PS_MANIFEST_MARK_DELETE:
 				{
-					PsLayerDesc *layer;
+					PsLayerDesc *layer = manifest_find_layer(map, payload.ev.layer_id);
 
-					if (rec.len != sizeof(payload.ev))
-					{
-						close(fd);
-						return -1;
-					}
-					layer = manifest_find_layer(map, payload.ev.layer_id);
 					if (layer != NULL)
 						layer->deleting = true;
 					break;
 				}
 
 			case PS_MANIFEST_REMOVE_LAYER:
-				{
-					if (rec.len != sizeof(payload.ev))
-					{
-						close(fd);
-						return -1;
-					}
-					manifest_remove_from_map(map, payload.ev.layer_id);
-					break;
-				}
+				manifest_remove_from_map(map, payload.ev.layer_id);
+				break;
 
 			case PS_MANIFEST_DROP_LOCAL:
 				{
-					PsLayerDesc *layer;
+					PsLayerDesc *layer = manifest_find_layer(map, payload.ev.layer_id);
 
-					if (rec.len != sizeof(payload.ev))
-					{
-						close(fd);
-						return -1;
-					}
-					layer = manifest_find_layer(map, payload.ev.layer_id);
 					if (layer != NULL)
-					{
 						for (uint32_t i = 0; i < layer->location_count; i++)
-						{
 							if (layer->locations[i].tier == PS_LAYER_TIER_LOCAL_HOT ||
 								layer->locations[i].tier == PS_LAYER_TIER_LOCAL_COLD)
 								layer->locations[i].available = false;
-						}
-					}
 					break;
 				}
 
@@ -547,12 +589,7 @@ ps_manifest_replay(PsLayerMap *map)
 				close(fd);
 				return -1;
 		}
-		good_off = lseek(fd, 0, SEEK_CUR);
-		if (good_off < 0)
-		{
-			close(fd);
-			return -1;
-		}
+		good_off = rec_off + rec_total;	/* we read exactly rec_total above */
 		manifest_nrecords++;
 	}
 

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -430,37 +430,32 @@ manifest_record_valid_at(int fd, off_t off, off_t file_size, int v2,
 }
 
 /*
- * Is the record at 'off' actually a v3 record whose version word was corrupted away
- * from 3 (rather than a genuine legacy v2 record)?  A v2 record has no CRC, so it
- * cannot be told from a version-flipped v3 record by the header alone; but the v3
- * CRC covers the version field, so recomputing it with the version forced back to 3
- * confirms the bytes were a v3 record.  Used to reject a downgraded v3 first record
- * before the whole file is (mis)classified as v2 and read without CRC checks.
+ * Is the whole file, byte 0 to EOF, an unbroken run of valid legacy v2 records?
+ * v2 has no CRC, so a single v2 record cannot be told apart from a corrupted v3
+ * record by inspection.  We therefore only treat a file as v2 when *every* record
+ * parses cleanly as v2 right up to EOF: any invalid record, gap, or trailing bytes
+ * means it is not an unambiguous v2 manifest (a corrupted v3 file, or a damaged v2
+ * file), and the caller refuses to read it as v2 rather than guess.
  */
 static int
-manifest_record_is_corrupted_v3(int fd, off_t off, off_t file_size)
+manifest_scan_clean_v2(int fd, off_t file_size)
 {
-	PsManifestRecord rec,
-				probe;
-	unsigned char buf[sizeof(PsManifestLayerDisk)];
-	int			plen;
+	off_t		off = 0;
 
-	if (off < 0 || off + (off_t) sizeof(rec) > file_size)
-		return 0;				/* a full v3 record does not fit -> not v3 */
-	if (pread(fd, &rec, sizeof(rec), off) != (ssize_t) sizeof(rec) ||
-		rec.magic != PS_MANIFEST_MAGIC)
+	if (file_size == 0)
 		return 0;
-	plen = manifest_type_payload_len(rec.type);
-	if (plen < 0 || (size_t) plen > sizeof(buf) || rec.len != (uint32_t) plen)
-		return 0;
-	if (off + (off_t) sizeof(rec) + plen > file_size)
-		return 0;
-	if (plen > 0 &&
-		pread(fd, buf, (size_t) plen, off + (off_t) sizeof(rec)) != (ssize_t) plen)
-		return 0;
-	probe = rec;
-	probe.version = PS_MANIFEST_VERSION;	/* what it was before the flip */
-	return manifest_record_crc(&probe, buf, (uint32_t) plen) == rec.crc;
+	while (off < file_size)
+	{
+		PsManifestRecord rec;
+		unsigned char buf[sizeof(PsManifestLayerDisk)];
+		off_t		rec_size;
+
+		if (!manifest_record_valid_at(fd, off, file_size, 1, &rec, buf,
+									  sizeof(buf), &rec_size))
+			return 0;
+		off += rec_size;
+	}
+	return off == file_size;	/* landed exactly on EOF -> clean v2 */
 }
 
 int
@@ -489,14 +484,17 @@ ps_manifest_replay(PsLayerMap *map)
 	file_size = st.st_size;
 
 	/*
-	 * Decide the whole file's format from its first record: a manifest is entirely
-	 * v3 (per-record CRC) or entirely legacy v2 (no CRC), never a mix.  Probe v3
-	 * first; only if that fails AND the record is not a version-corrupted v3 record
-	 * (which has no CRC of its own to catch the flip, so we re-check its CRC with the
-	 * version forced back to 3) do we read the file as legacy v2.  This keeps a v3
-	 * record whose version word was flipped to 2 from being reinterpreted as an
-	 * unchecked v2 record.  A v2 file is migrated to v3 after replay, so this is
-	 * taken at most once per store.
+	 * Decide the whole file's format: a manifest is entirely v3 (per-record CRC) or
+	 * entirely legacy v2 (no CRC), never a mix.  Because v2 has no CRC, a corrupted
+	 * v3 record and a v2 record are indistinguishable by inspection, so we do not
+	 * guess from the first record alone:
+	 *   - a valid v3 first record  -> v3 file (the per-record CRC anchors the rest);
+	 *   - else if the ENTIRE file parses cleanly as v2 -> a genuine v2 file, which we
+	 *     replay and then migrate to v3 in place;
+	 *   - else (a corrupted v3 file, a damaged v2 file, or garbage) -> fail the
+	 *     replay WITHOUT truncating, so no real metadata is silently emptied and no
+	 *     ambiguous bytes are installed as an unchecked v2 layer; an operator can
+	 *     migrate offline or recreate the store.
 	 */
 	{
 		PsManifestRecord r0;
@@ -504,18 +502,17 @@ ps_manifest_replay(PsLayerMap *map)
 		off_t		s0;
 
 		if (file_size == 0)
-			file_v2 = 0;
+			file_v2 = 0;		/* empty: the loop below does nothing, returns 0 */
 		else if (manifest_record_valid_at(fd, 0, file_size, 0, &r0, b0,
 										  sizeof(b0), &s0))
 			file_v2 = 0;
-		else if (manifest_record_valid_at(fd, 0, file_size, 1, &r0, b0,
-										  sizeof(b0), &s0) &&
-				 !manifest_record_is_corrupted_v3(fd, 0, file_size))
+		else if (manifest_scan_clean_v2(fd, file_size))
 			file_v2 = 1;
 		else
-			file_v2 = 0;		/* a v3 file (possibly with a corrupt/torn first
-								 * record, handled as corruption below) -- never read
-								 * a version-flipped v3 record as unchecked v2 */
+		{
+			close(fd);
+			return -1;
+		}
 	}
 
 	while (good_off < file_size)

--- a/contrib/pagestore/pagestore_manifest.c
+++ b/contrib/pagestore/pagestore_manifest.c
@@ -458,6 +458,36 @@ manifest_scan_clean_v2(int fd, off_t file_size)
 	return off == file_size;	/* landed exactly on EOF -> clean v2 */
 }
 
+/*
+ * Is the manifest's first record an incomplete (torn) record -- an append that was
+ * interrupted before the record was fully written?  True only when our magic is at
+ * the start but the record the header describes runs past EOF; a full record (even
+ * one with a bad CRC), foreign bytes, or an unknown type is NOT torn.  A torn first
+ * record means nothing was durably committed, so replay can safely truncate it away
+ * to an openable empty manifest instead of refusing to start.
+ */
+static int
+manifest_first_record_torn(int fd, off_t file_size)
+{
+	PsManifestRecord rec;
+	uint32_t	magic = 0;
+	int			plen;
+
+	if (file_size <= 0)
+		return 0;
+	if (pread(fd, &magic, sizeof(magic), 0) != (ssize_t) sizeof(magic) ||
+		magic != PS_MANIFEST_MAGIC)
+		return 0;				/* no/foreign magic -> not a torn write of ours */
+	if (file_size < (off_t) sizeof(rec))
+		return 1;				/* magic present but the header is truncated */
+	if (pread(fd, &rec, sizeof(rec), 0) != (ssize_t) sizeof(rec))
+		return 0;
+	plen = manifest_type_payload_len(rec.type);
+	if (plen < 0)
+		return 0;				/* unknown type on a full header -> corruption */
+	return file_size < (off_t) sizeof(rec) + plen;	/* payload truncated -> torn */
+}
+
 int
 ps_manifest_replay(PsLayerMap *map)
 {
@@ -491,6 +521,8 @@ ps_manifest_replay(PsLayerMap *map)
 	 *   - a valid v3 first record  -> v3 file (the per-record CRC anchors the rest);
 	 *   - else if the ENTIRE file parses cleanly as v2 -> a genuine v2 file, which we
 	 *     replay and then migrate to v3 in place;
+	 *   - else if the first record is an incomplete (torn) write -> nothing was
+	 *     committed, so let the loop below truncate it to an openable empty manifest;
 	 *   - else (a corrupted v3 file, a damaged v2 file, or garbage) -> fail the
 	 *     replay WITHOUT truncating, so no real metadata is silently emptied and no
 	 *     ambiguous bytes are installed as an unchecked v2 layer; an operator can
@@ -508,6 +540,8 @@ ps_manifest_replay(PsLayerMap *map)
 			file_v2 = 0;
 		else if (manifest_scan_clean_v2(fd, file_size))
 			file_v2 = 1;
+		else if (manifest_first_record_torn(fd, file_size))
+			file_v2 = 0;		/* torn first append: the loop truncates to empty */
 		else
 		{
 			close(fd);


### PR DESCRIPTION
## What

The layer *files* carry checksums, but the manifest records did not — so a silent bit-flip in a record replayed as a **valid-but-wrong layer**. This adds a per-record CRC, closing the last M3 integrity gap.

## Changes

- **Format v3**: a per-record **FNV-1a CRC** over the record header + payload, written by `manifest_write_record()` and **verified on replay**.
- **Replay refactor**: read each payload once into an aligned union buffer, verify the CRC, then dispatch by type — replacing five near-identical per-type read blocks.
- **Tail vs interior**: a bad header/payload/CRC at end-of-file is still a recoverable **torn tail** (truncate); the same fault earlier in the file is **interior corruption** that fails replay rather than loading wrong metadata.

## Test (`pagestore_gc_test`)

- flip a byte **inside the first** of two records → replay **fails** (not loaded as a wrong layer);
- flip the **last byte** → replay **recovers** (torn-tail truncate), keeping the first record.

Verified both checks fail when the CRC verification is removed. Suite **5/5** (gc test now **46 checks**); daemon builds.

## Notes

Stacked on #58 (manifest compaction). Completes the M3 manifest-integrity work: #56 (klass decode) → #57 (GC crash-safety + poison) → #58 (log compaction) → #59 (per-record CRC).