### PR TITLE
pagestore: version SLRU-class writes by the caller's LSN (M4 step-1 foundation)

### DIFF
--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1123,7 +1123,7 @@ page_lsn(const unsigned char *page)
  */
 int
 append_page(uint32_t timeline, const PsKey *key, uint32_t block,
-			const unsigned char *page)
+			const unsigned char *page, uint64_t version)
 {
 	SegRecHdr	hdr;
 	uint64_t	reclen = sizeof(SegRecHdr) + page_size;
@@ -1142,15 +1142,19 @@ append_page(uint32_t timeline, const PsKey *key, uint32_t block,
 	hdr.key = *key;
 	hdr.block = block;
 	/*
-	 * Version key.  A relation page carries a real monotonic pd_lsn; non-relation
-	 * objects (SLRU/control) do not -- their first 8 bytes are payload, not an LSN
-	 * -- so versioning them from page_lsn() can make an overwrite compare lower
-	 * than the prior version and silently lose (and poison the pgcache for that
-	 * pseudo-LSN).  Derive a monotonic version from the existing chain instead
-	 * (newest across ancestry + 1) so the latest object write always wins.
+	 * Version key.  A relation page carries a real monotonic pd_lsn.  An SLRU object
+	 * is versioned by the caller-supplied 'version' -- the dirtying/cutoff WAL LSN --
+	 * stored verbatim so it stays directly comparable to a branch's as-of cutoff
+	 * (the seed path keys a snapshot by its proven cutoff C and reads it as-of L>=C);
+	 * a daemon counter would not be comparable.  Other non-relation objects (the
+	 * control file) carry no LSN in their bytes, so versioning them from page_lsn()
+	 * could make an overwrite compare lower and silently lose (and poison the pgcache
+	 * for that pseudo-LSN); derive a monotonic latest-wins version from the chain.
 	 */
 	if (key->klass == PS_KLASS_RELATION)
 		hdr.lsn = page_lsn(page);
+	else if (key->klass == PS_KLASS_SLRU)
+		hdr.lsn = version;
 	else
 	{
 		PageVer    *cur;

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -66,9 +66,15 @@ extern void ps_core_read_stats(uint64_t *mem, uint64_t *layer, uint64_t *seg);
  */
 extern int	ps_handle_meta(PsChannel *ch);
 
-/* Page byte-I/O helpers used by the frontends' byte-op handlers. */
+/*
+ * Page byte-I/O helpers used by the frontends' byte-op handlers.  'version' is the
+ * caller-supplied version LSN for an SLRU-class write (the dirtying/cutoff WAL LSN,
+ * stored verbatim so it stays comparable to a branch cutoff); it is ignored for
+ * relation pages (versioned by pd_lsn) and other non-relation objects (versioned by
+ * a monotonic latest-wins counter).
+ */
 extern int	append_page(uint32_t timeline, const PsKey *key, uint32_t block,
-						const unsigned char *page);
+						const unsigned char *page, uint64_t version);
 extern PageVer *read_through(uint32_t timeline, const PsKey *key, uint32_t block,
 							 uint64_t read_lsn);
 extern int	read_version(const PageVer *v, unsigned char *out);

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -68,7 +68,7 @@ handle_request(PsChannel *ch)
 	switch ((PsOpcode) ch->opcode)
 	{
 		case PS_OP_EXTEND:
-			if (append_page(tl, &ch->key, ch->blocknum, ch->data) != 0)
+			if (append_page(tl, &ch->key, ch->blocknum, ch->data, ch->req_lsn) != 0)
 				ch->status = PS_STATUS_ERROR;
 			else
 				fork_grow(tl, &ch->key, ch->blocknum + 1);
@@ -78,7 +78,8 @@ handle_request(PsChannel *ch)
 			for (uint32_t i = 0; i < ch->nblocks; i++)
 			{
 				if (append_page(tl, &ch->key, ch->blocknum + i,
-								 ch->data + (size_t) i * page_size) != 0)
+								 ch->data + (size_t) i * page_size,
+								 ch->req_lsn) != 0)
 				{
 					ch->status = PS_STATUS_ERROR;
 					break;

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -149,7 +149,7 @@ begin(uint32_t i, PsChannel *ch)
 	switch ((PsOpcode) ch->opcode)
 	{
 		case PS_OP_EXTEND:
-			if (append_page(tl, &ch->key, ch->blocknum, ch->data) != 0)
+			if (append_page(tl, &ch->key, ch->blocknum, ch->data, ch->req_lsn) != 0)
 				ch->status = PS_STATUS_ERROR;
 			else
 				fork_grow(tl, &ch->key, ch->blocknum + 1);
@@ -160,7 +160,8 @@ begin(uint32_t i, PsChannel *ch)
 			for (uint32_t b = 0; b < ch->nblocks; b++)
 			{
 				if (append_page(tl, &ch->key, ch->blocknum + b,
-								 ch->data + (size_t) b * page_size) != 0)
+								 ch->data + (size_t) b * page_size,
+								 ch->req_lsn) != 0)
 				{
 					ch->status = PS_STATUS_ERROR;
 					break;

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -295,6 +295,42 @@ op_read_at(uint32_t rel, int32_t fork, uint32_t block, uint64_t lsn,
 	memcpy(out, ch->data, cl_page_size);
 }
 
+/*
+ * SLRU-class write: the version is the caller-supplied LSN (req_lsn), NOT pd_lsn or
+ * a daemon counter -- so a snapshot keyed by its proven cutoff C reads back as-of an
+ * LSN >= C.  'obj' is the SLRU object id (slru_klass_id); 'block' is the segment.
+ */
+static void
+op_write_slru(uint32_t obj, uint32_t block, const unsigned char *page,
+			  uint64_t version)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	cl_setkey(ch, obj, 0);			/* fork 0 */
+	ch->key.klass = PS_KLASS_SLRU;
+	ch->opcode = PS_OP_WRITEV;
+	ch->blocknum = block;
+	ch->nblocks = 1;
+	ch->req_lsn = version;
+	memcpy(ch->data, page, cl_page_size);
+	cl_exec();
+}
+
+/* SLRU-class as-of read (READ_AT zero-fills on no-version-<=lsn). */
+static void
+op_read_at_slru(uint32_t obj, uint32_t block, uint64_t lsn, unsigned char *out)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	cl_setkey(ch, obj, 0);			/* fork 0 */
+	ch->key.klass = PS_KLASS_SLRU;
+	ch->opcode = PS_OP_READ_AT;
+	ch->blocknum = block;
+	ch->req_lsn = lsn;
+	cl_exec();
+	memcpy(out, ch->data, cl_page_size);
+}
+
 /* --- timeline-aware operations (for branch tests) --- */
 
 /* Create timeline new_tl as a branch of parent_tl forked at branch_lsn. */
@@ -631,6 +667,30 @@ run_suite(const char *daemon_path, const char *tmpbase, uint32_t page_size)
 	check(page_has_tag(rb, page_size, 200), "read_at(9000) returns new version");
 	op_read_at(REL_A, FORK0, 0, ~0ull, rb);
 	check(page_has_tag(rb, page_size, 200), "read_at(max) returns newest");
+
+	/* --- SLRU-class versioning: version is the caller's LSN, not a daemon counter ---
+	 * Two snapshots of an SLRU segment keyed by cutoffs C1=5000 and C2=9000.  An
+	 * as-of read must resolve by those exact LSNs; a daemon max+1 counter (1,2) would
+	 * make read_at(7000) and read_at(4000) resolve wrongly. */
+	{
+		const uint32_t SLRU_OBJ = 4242;	/* an slru_klass_id stand-in */
+
+		fill_page(pa, page_size, 0, 111);	/* pd_lsn irrelevant for SLRU; tag 111 */
+		op_write_slru(SLRU_OBJ, 0, pa, 5000);
+		fill_page(pb, page_size, 0, 222);
+		op_write_slru(SLRU_OBJ, 0, pb, 9000);
+
+		op_read_at_slru(SLRU_OBJ, 0, 7000, rb);
+		check(page_has_tag(rb, page_size, 111),
+			  "slru read_at(7000) = C1 snapshot (version is the caller LSN 5000)");
+		op_read_at_slru(SLRU_OBJ, 0, 9000, rb);
+		check(page_has_tag(rb, page_size, 222), "slru read_at(9000) = C2 snapshot");
+		op_read_at_slru(SLRU_OBJ, 0, 4000, rb);
+		check(page_all_zero(rb, page_size),
+			  "slru read_at(4000) = none (no snapshot at/below 4000; not a counter)");
+		op_read_at_slru(SLRU_OBJ, 0, ~0ull, rb);
+		check(page_has_tag(rb, page_size, 222), "slru read_at(max) = newest snapshot");
+	}
 
 	client_detach();
 


### PR DESCRIPTION
## What

First piece of **M4 step 1** (parent SLRU snapshot shipping), per `SLRU_ON_STORE_DESIGN.md`.

M4 seeds a branch's transaction status from a parent SLRU snapshot **keyed by a proven cutoff `C`**, read back as-of the branch LSN `L ≥ C`. For that to work, the snapshot's stored version must equal `C` and stay comparable to a branch cutoff.

But `append_page()` versioned every non-relation object by a daemon **`max+1` counter** — not an LSN, not comparable to `L` — so an as-of read could never resolve a snapshot by its cutoff (the design explicitly forbids this: *"never a daemon max+1 counter"*).

## Change

- `append_page()` gains a `version` argument. An **SLRU-class** write (`PsKey.klass == PS_KLASS_SLRU`) is versioned by it **verbatim** (the shipping side passes the cutoff/dirtying WAL LSN in `ch->req_lsn` through the EXTEND/WRITEV handlers).
- **Unchanged:** relation pages still version by `pd_lsn`; the control file still uses the monotonic latest-wins counter.

## Test

`pagestore_test`: two SLRU snapshots keyed by `C1=5000` and `C2=9000` resolve by those exact LSNs — `read_at(7000)=C1`, `read_at(9000)=C2`, `read_at(4000)=none` — which a `max+1` counter (1,2) would get wrong. **Verified the checks fail under the old counter versioning.** Standalone + integration suites pass.

## Next in M4 step 1

- Parent-side capture: a checkpoint hook that reads the clean SLRU segments and ships them via WRITEV keyed by `(timeline, slru-id, segno)` with `version = C`.
- Establishing the **proven cutoff `C`** (at/after the checkpoint completion record; quiescent-shutdown first, online write-barrier next).

Based on `feat/pagestore-manifest-compact` (the M3 tip).