### PR TITLE
pagestore: ship a clean SLRU snapshot to the store, keyed by a cutoff (M4 step 1)

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -704,12 +704,16 @@ pagestore_localsvc_obj_read(uint32 klass, const PageStoreRelKey *key,
  * As-of read of a non-relation object block (honours branch ancestry).  Returns
  * true if a version <= 'version' was found; on a miss returns false and leaves
  * 'page' zero-filled (so callers can fail closed rather than read a phantom page).
+ * If 'resolved' is non-NULL, it receives the version actually resolved (the newest
+ * <= 'version'), so a caller wanting an exact-cutoff hit can compare it.
  */
 bool
 pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
-							   BlockNumber block, uint64 version, void *page)
+							   BlockNumber block, uint64 version, void *page,
+							   uint64 *resolved)
 {
 	PsChannel  *ch = ls_chan_for_key_klass(key, klass);
+	bool		found;
 
 	ls_fill_key(ch, key);
 	ch->key.klass = klass;
@@ -718,7 +722,10 @@ pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
 	ch->req_lsn = version;
 	ls_exec(ch);
 	memcpy(page, ch->data, BLCKSZ);
-	return ch->result != 0;
+	found = ch->result != 0;
+	if (resolved)
+		*resolved = found ? ch->req_lsn : 0;		/* daemon wrote the resolved ver */
+	return found;
 }
 
 /* Called from _PG_init to register the GUCs owned by this backend. */

--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -700,8 +700,12 @@ pagestore_localsvc_obj_read(uint32 klass, const PageStoreRelKey *key,
 	memcpy(page, ch->data, BLCKSZ);
 }
 
-/* As-of read of a non-relation object block (honours branch ancestry). */
-void
+/*
+ * As-of read of a non-relation object block (honours branch ancestry).  Returns
+ * true if a version <= 'version' was found; on a miss returns false and leaves
+ * 'page' zero-filled (so callers can fail closed rather than read a phantom page).
+ */
+bool
 pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
 							   BlockNumber block, uint64 version, void *page)
 {
@@ -714,6 +718,7 @@ pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
 	ch->req_lsn = version;
 	ls_exec(ch);
 	memcpy(page, ch->data, BLCKSZ);
+	return ch->result != 0;
 }
 
 /* Called from _PG_init to register the GUCs owned by this backend. */

--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -650,7 +650,7 @@ pagestore_localsvc_walidx_get(const PageStoreRelKey *key, BlockNumber block,
  */
 void
 pagestore_localsvc_obj_write(uint32 klass, const PageStoreRelKey *key,
-							 BlockNumber block, const void *page)
+							 BlockNumber block, const void *page, uint64 version)
 {
 	PsChannel  *ch = ls_chan_for_key_klass(key, klass);
 	BlockNumber nb;
@@ -675,6 +675,12 @@ pagestore_localsvc_obj_write(uint32 klass, const PageStoreRelKey *key,
 	ch->blocknum = block;
 	ch->nblocks = 1;
 	ch->skip_fsync = 0;
+	/*
+	 * For an SLRU-class object the daemon versions the write by req_lsn (the
+	 * caller's cutoff/dirtying LSN), so a snapshot reads back as-of an LSN >= that
+	 * version; ignored for other classes (relation = pd_lsn, control = counter).
+	 */
+	ch->req_lsn = version;
 	memcpy(ch->data, page, BLCKSZ);
 	ls_exec(ch);
 }
@@ -690,6 +696,22 @@ pagestore_localsvc_obj_read(uint32 klass, const PageStoreRelKey *key,
 	ch->opcode = PS_OP_READV;
 	ch->blocknum = block;
 	ch->nblocks = 1;
+	ls_exec(ch);
+	memcpy(page, ch->data, BLCKSZ);
+}
+
+/* As-of read of a non-relation object block (honours branch ancestry). */
+void
+pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
+							   BlockNumber block, uint64 version, void *page)
+{
+	PsChannel  *ch = ls_chan_for_key_klass(key, klass);
+
+	ls_fill_key(ch, key);
+	ch->key.klass = klass;
+	ch->opcode = PS_OP_READ_AT;
+	ch->blocknum = block;
+	ch->req_lsn = version;
 	ls_exec(ch);
 	memcpy(page, ch->data, BLCKSZ);
 }

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -275,6 +275,32 @@ sleep 0.5
 crash_ck2=$($P -c "SELECT md5(string_agg(v,',' ORDER BY id)) FROM crash;")
 assert "$crash_ck2" "$crash_ck" "un-flushed rows survive a daemon crash+restart (segment-log recovery)"
 
+# --- 16. SLRU snapshot shipping (M4 step 1): ship clog to the store, keyed by C ----
+# CHECKPOINT flushes pg_xact to a clean on-disk image; the single-client test has no
+# concurrent commits, so the current LSN bounds it (a valid quiescent cutoff C).  Ship
+# it and require: the shipped page reads back as-of C identical to the on-disk page,
+# and is NOT visible below C (i.e. it is versioned by C, not a daemon counter).
+$P -c "CREATE FUNCTION pagestore_ship_slru_snapshot(text, pg_lsn) RETURNS bigint
+        AS 'pagestore','pagestore_ship_slru_snapshot' LANGUAGE C;
+       CREATE FUNCTION pagestore_slru_read_at(text, int, pg_lsn) RETURNS bytea
+        AS 'pagestore','pagestore_slru_read_at' LANGUAGE C;" >/dev/null
+$P -c "CHECKPOINT;" >/dev/null
+cutoff=$($P -c "SELECT pg_current_wal_lsn();")
+seg=$($P -c "SELECT name FROM pg_ls_dir('pg_xact') AS name ORDER BY name LIMIT 1;")
+pageno=$(( 16#$seg * 32 ))			# first page of the lowest clog segment
+shipped=$($P -c "SELECT pagestore_ship_slru_snapshot('pg_xact', '$cutoff');")
+if [ "${shipped:-0}" -gt 0 ]; then
+	echo "ok   - shipped $shipped clog page(s) to the store (cutoff $cutoff)"
+else
+	echo "FAIL - no clog pages shipped"; fail=1
+fi
+local_md5=$($P -c "SELECT md5(pg_read_binary_file('pg_xact/$seg', 0, 8192));")
+store_md5=$($P -c "SELECT md5(pagestore_slru_read_at('pg_xact', $pageno, '$cutoff'));")
+assert "$store_md5" "$local_md5" "clog page read from the store as-of C matches the on-disk page"
+zero_md5=$($P -c "SELECT md5(decode(repeat('00',8192),'hex'));")
+before_md5=$($P -c "SELECT md5(pagestore_slru_read_at('pg_xact', $pageno, '0/1'));")
+assert "$before_md5" "$zero_md5" "clog snapshot is not visible below its cutoff C (versioned by C)"
+
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
 exit $fail

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -281,9 +281,9 @@ assert "$crash_ck2" "$crash_ck" "un-flushed rows survive a daemon crash+restart 
 # it and require: the shipped page reads back as-of C identical to the on-disk page,
 # and is NOT visible below C (i.e. it is versioned by C, not a daemon counter).
 $P -c "CREATE FUNCTION pagestore_ship_slru_snapshot(text, pg_lsn) RETURNS bigint
-        AS 'pagestore','pagestore_ship_slru_snapshot' LANGUAGE C;
+        AS 'pagestore','pagestore_ship_slru_snapshot' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_slru_read_at(text, int, pg_lsn) RETURNS bytea
-        AS 'pagestore','pagestore_slru_read_at' LANGUAGE C;" >/dev/null
+        AS 'pagestore','pagestore_slru_read_at' LANGUAGE C STRICT;" >/dev/null
 $P -c "CHECKPOINT;" >/dev/null
 cutoff=$($P -c "SELECT pg_current_wal_lsn();")
 seg=$($P -c "SELECT name FROM pg_ls_dir('pg_xact') AS name ORDER BY name LIMIT 1;")
@@ -297,9 +297,10 @@ fi
 local_md5=$($P -c "SELECT md5(pg_read_binary_file('pg_xact/$seg', 0, 8192));")
 store_md5=$($P -c "SELECT md5(pagestore_slru_read_at('pg_xact', $pageno, '$cutoff'));")
 assert "$store_md5" "$local_md5" "clog page read from the store as-of C matches the on-disk page"
-zero_md5=$($P -c "SELECT md5(decode(repeat('00',8192),'hex'));")
-before_md5=$($P -c "SELECT md5(pagestore_slru_read_at('pg_xact', $pageno, '0/1'));")
-assert "$before_md5" "$zero_md5" "clog snapshot is not visible below its cutoff C (versioned by C)"
+# below C the page has no version: the read reports a miss (NULL), not a zero page a
+# caller could mistake for real all-zero clog state
+before_null=$($P -c "SELECT pagestore_slru_read_at('pg_xact', $pageno, '0/1') IS NULL;")
+assert "$before_null" "t" "clog snapshot is not visible below its cutoff C (read misses -> NULL)"
 
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -1278,8 +1278,20 @@ pagestore_ship_slru_snapshot(PG_FUNCTION_ARGS)
 		char		segpath[MAXPGPATH];
 		int			fd;
 		int			pageidx;
+		size_t		namelen = strlen(de->d_name);
 
-		/* SLRU segment files are named by hex segno; skip "." / ".." / others */
+		/*
+		 * Mirror SlruScanDirectory()'s filename test so we ship only real segment
+		 * files: the in-scope SLRUs all use short names, which SlruCorrectSegment-
+		 * FilenameLength() allows to be 4, 5 or 6 upper-case hex characters (the
+		 * "%04X" width is a minimum, so a segno past 0xFFFF -- e.g. advanced
+		 * commit_ts / multixact members -- yields 5-6 chars).  Anything else in the
+		 * directory (a stray or long-name file) is skipped, not shipped as bogus
+		 * SLRU pages.
+		 */
+		if (namelen < 4 || namelen > 6 ||
+			strspn(de->d_name, "0123456789ABCDEF") != namelen)
+			continue;
 		errno = 0;
 		segno = strtoll(de->d_name, &endp, 16);
 		if (endp == de->d_name || *endp != '\0' || errno != 0 || segno < 0)
@@ -1342,10 +1354,16 @@ pagestore_slru_read_at(PG_FUNCTION_ARGS)
 	slru_check_dir(slru);
 
 	slru_obj_key(&key, slru);
-	/* preserve the miss signal: a page with no version <= lsn returns NULL, not a
-	 * zero page that a caller could mistake for real all-zero clog state */
+	/*
+	 * As-of read: return the newest snapshot version <= lsn (so a base shipped at
+	 * cutoff C still reads back when requested at a later L >= C), or NULL on a genuine
+	 * miss (no version <= lsn) so a caller never mistakes a zero page for real clog
+	 * state.  Exact-cutoff matching -- the tombstone guard that stops an older image
+	 * resurfacing after a truncation -- lives in the branch reconstruct/seed, which
+	 * read the base at the chosen cutoff itself (resolved == that cutoff).
+	 */
 	if (!pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key, (BlockNumber) pageno,
-										(uint64) lsn, out))
+										(uint64) lsn, out, NULL))
 		PG_RETURN_NULL();
 
 	result = (bytea *) palloc(BLCKSZ + VARHDRSZ);

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -1208,6 +1208,28 @@ slru_klass_id(const char *name)
 	return h;
 }
 
+/* The WAL-logged, uint32-page SLRUs M4 may snapshot/reconstruct.  A whitelist: the
+ * SQL helpers take a directory name, so without it a caller could point them at
+ * 'base/<db>' or 'global' and snapshot ordinary relation files (whose numeric names
+ * also parse as hex) under an SLRU key. */
+static const char *const ps_slru_dirs[] = {
+	"pg_xact",
+	"pg_multixact/offsets",
+	"pg_multixact/members",
+	"pg_commit_ts",
+};
+
+static void
+slru_check_dir(const char *slru)
+{
+	for (int i = 0; i < (int) lengthof(ps_slru_dirs); i++)
+		if (strcmp(ps_slru_dirs[i], slru) == 0)
+			return;
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("\"%s\" is not an in-scope SLRU directory", slru)));
+}
+
 static void
 slru_obj_key(PageStoreRelKey *key, const char *slru)
 {
@@ -1241,6 +1263,7 @@ pagestore_ship_slru_snapshot(PG_FUNCTION_ARGS)
 	if (strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") != 0)
 		ereport(ERROR,
 				(errmsg("pagestore.backend must be 'localsvc'")));
+	slru_check_dir(slru);
 
 	dir = AllocateDir(slru);
 	if (dir == NULL)
@@ -1316,10 +1339,14 @@ pagestore_slru_read_at(PG_FUNCTION_ARGS)
 	if (strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") != 0)
 		ereport(ERROR,
 				(errmsg("pagestore.backend must be 'localsvc'")));
+	slru_check_dir(slru);
 
 	slru_obj_key(&key, slru);
-	pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key, (BlockNumber) pageno,
-								   (uint64) lsn, out);
+	/* preserve the miss signal: a page with no version <= lsn returns NULL, not a
+	 * zero page that a caller could mistake for real all-zero clog state */
+	if (!pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key, (BlockNumber) pageno,
+										(uint64) lsn, out))
+		PG_RETURN_NULL();
 
 	result = (bytea *) palloc(BLCKSZ + VARHDRSZ);
 	SET_VARSIZE(result, BLCKSZ + VARHDRSZ);

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -35,6 +35,7 @@
 
 #include "access/relation.h"
 #include "access/rmgr.h"
+#include "access/slru.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"
 #include "access/xlogutils.h"
@@ -48,8 +49,10 @@
 #include "port/pg_iovec.h"
 #include "storage/aio.h"
 #include "storage/bufpage.h"
+#include "storage/fd.h"
 #include "storage/md.h"
 #include "storage/smgr.h"
+#include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/pg_lsn.h"
 #include "utils/rel.h"
@@ -1138,7 +1141,7 @@ pagestore_object_roundtrip(PG_FUNCTION_ARGS)
 	key.forkNum = 0;
 
 	out = palloc(BLCKSZ);
-	pagestore_localsvc_obj_write((uint32) klass, &key, 0, VARDATA_ANY(inpage));
+	pagestore_localsvc_obj_write((uint32) klass, &key, 0, VARDATA_ANY(inpage), 0);
 	pagestore_localsvc_obj_read((uint32) klass, &key, 0, out);
 
 	result = (bytea *) palloc(BLCKSZ + VARHDRSZ);
@@ -1172,6 +1175,151 @@ pagestore_object_get(PG_FUNCTION_ARGS)
 
 	out = palloc(BLCKSZ);
 	pagestore_localsvc_obj_read((uint32) klass, &key, 0, out);
+
+	result = (bytea *) palloc(BLCKSZ + VARHDRSZ);
+	SET_VARSIZE(result, BLCKSZ + VARHDRSZ);
+	memcpy(VARDATA(result), out, BLCKSZ);
+	PG_RETURN_BYTEA_P(result);
+}
+
+/*
+ * SLRU snapshot shipping (M4 step 1).
+ *
+ * An SLRU directory's segment files are a clean as-of image once they are flushed
+ * and no longer being written.  We ship every page of an in-scope SLRU (clog,
+ * multixact offsets/members, commit-ts) to the store, versioning each by a cutoff C
+ * so a branch reads the snapshot as-of an LSN >= C (the seed base; per-update WAL in
+ * (C, L] then brings it to exactly L).  The store key is
+ *   PsKey{ klass = PS_KLASS_SLRU, relNumber = slru_klass_id(dir), block = pageno }.
+ */
+
+/* Stable per-SLRU object id from its directory name (FNV-1a; libc-only). */
+static uint32
+slru_klass_id(const char *name)
+{
+	uint32		h = 2166136261u;
+	const unsigned char *p;
+
+	for (p = (const unsigned char *) name; *p != '\0'; p++)
+	{
+		h ^= *p;
+		h *= 16777619u;
+	}
+	return h;
+}
+
+static void
+slru_obj_key(PageStoreRelKey *key, const char *slru)
+{
+	key->spcOid = 0;
+	key->dbOid = 0;
+	key->relNumber = (RelFileNumber) slru_klass_id(slru);
+	key->forkNum = 0;
+}
+
+/*
+ * pagestore_ship_slru_snapshot(slru text, cutoff pg_lsn) returns bigint
+ *
+ * Ship a clean whole-segment snapshot of SLRU directory 'slru' (e.g. 'pg_xact')
+ * keyed by 'cutoff'.  'cutoff' must provably upper-bound the on-disk segments'
+ * contents -- the caller captures it at a quiescent point (a clean
+ * shutdown/restartpoint, or under a brief SLRU write barrier).  The online,
+ * automatically-triggered, proven-C path is a follow-up.  Returns the page count;
+ * fails closed (ereport) on any read/IPC error rather than shipping a partial snap.
+ */
+PG_FUNCTION_INFO_V1(pagestore_ship_slru_snapshot);
+Datum
+pagestore_ship_slru_snapshot(PG_FUNCTION_ARGS)
+{
+	char	   *slru = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	XLogRecPtr	cutoff = PG_GETARG_LSN(1);
+	DIR		   *dir;
+	struct dirent *de;
+	int64		shipped = 0;
+	char	   *page = palloc(BLCKSZ);
+
+	if (strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") != 0)
+		ereport(ERROR,
+				(errmsg("pagestore.backend must be 'localsvc'")));
+
+	dir = AllocateDir(slru);
+	if (dir == NULL)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open SLRU directory \"%s\": %m", slru)));
+
+	while ((de = ReadDir(dir, slru)) != NULL)
+	{
+		int64		segno;
+		char	   *endp;
+		char		segpath[MAXPGPATH];
+		int			fd;
+		int			pageidx;
+
+		/* SLRU segment files are named by hex segno; skip "." / ".." / others */
+		errno = 0;
+		segno = strtoll(de->d_name, &endp, 16);
+		if (endp == de->d_name || *endp != '\0' || errno != 0 || segno < 0)
+			continue;
+
+		snprintf(segpath, sizeof(segpath), "%s/%s", slru, de->d_name);
+		fd = OpenTransientFile(segpath, O_RDONLY | PG_BINARY);
+		if (fd < 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not open SLRU segment \"%s\": %m", segpath)));
+
+		for (pageidx = 0; pageidx < SLRU_PAGES_PER_SEGMENT; pageidx++)
+		{
+			int			n = read(fd, page, BLCKSZ);
+			PageStoreRelKey key;
+
+			if (n == 0)
+				break;			/* fewer than a full segment's pages on disk */
+			if (n != BLCKSZ)
+			{
+				CloseTransientFile(fd);
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("short read on SLRU segment \"%s\"", segpath)));
+			}
+			slru_obj_key(&key, slru);
+			pagestore_localsvc_obj_write(PS_KLASS_SLRU, &key,
+										 (BlockNumber) (segno * SLRU_PAGES_PER_SEGMENT
+														+ pageidx),
+										 page, (uint64) cutoff);
+			shipped++;
+		}
+		CloseTransientFile(fd);
+	}
+	FreeDir(dir);
+
+	PG_RETURN_INT64(shipped);
+}
+
+/*
+ * pagestore_slru_read_at(slru text, pageno int, lsn pg_lsn) returns bytea -- read an
+ * SLRU page back from the store as-of 'lsn' (verifies a shipped snapshot; the branch
+ * seed path reads its base pages this way).
+ */
+PG_FUNCTION_INFO_V1(pagestore_slru_read_at);
+Datum
+pagestore_slru_read_at(PG_FUNCTION_ARGS)
+{
+	char	   *slru = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	int32		pageno = PG_GETARG_INT32(1);
+	XLogRecPtr	lsn = PG_GETARG_LSN(2);
+	PageStoreRelKey key;
+	char	   *out = palloc(BLCKSZ);
+	bytea	   *result;
+
+	if (strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") != 0)
+		ereport(ERROR,
+				(errmsg("pagestore.backend must be 'localsvc'")));
+
+	slru_obj_key(&key, slru);
+	pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key, (BlockNumber) pageno,
+								   (uint64) lsn, out);
 
 	result = (bytea *) palloc(BLCKSZ + VARHDRSZ);
 	SET_VARSIZE(result, BLCKSZ + VARHDRSZ);

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -160,8 +160,12 @@ extern int	pagestore_localsvc_wal_read(uint32 timeline, uint64 start_lsn,
 										uint32 len, void *out);
 extern uint32 pagestore_localsvc_timeline(void);
 extern void pagestore_localsvc_obj_write(uint32 klass, const PageStoreRelKey *key,
-										 BlockNumber block, const void *page);
+										 BlockNumber block, const void *page,
+										 uint64 version);
 extern void pagestore_localsvc_obj_read(uint32 klass, const PageStoreRelKey *key,
 										BlockNumber block, void *page);
+extern void pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
+										   BlockNumber block, uint64 version,
+										   void *page);
 
 #endif							/* PAGESTORE_BACKEND_H */

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -166,6 +166,6 @@ extern void pagestore_localsvc_obj_read(uint32 klass, const PageStoreRelKey *key
 										BlockNumber block, void *page);
 extern bool pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
 										   BlockNumber block, uint64 version,
-										   void *page);
+										   void *page, uint64 *resolved);
 
 #endif							/* PAGESTORE_BACKEND_H */

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -164,7 +164,7 @@ extern void pagestore_localsvc_obj_write(uint32 klass, const PageStoreRelKey *ke
 										 uint64 version);
 extern void pagestore_localsvc_obj_read(uint32 klass, const PageStoreRelKey *key,
 										BlockNumber block, void *page);
-extern void pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
+extern bool pagestore_localsvc_obj_read_at(uint32 klass, const PageStoreRelKey *key,
 										   BlockNumber block, uint64 version,
 										   void *page);
 

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -1276,7 +1276,7 @@ layer_map_lookup(uint32_t timeline, const PsKey *key, uint32_t block,
  */
 int
 read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
-			 uint64_t read_lsn, unsigned char *out)
+			 uint64_t read_lsn, unsigned char *out, uint64_t *out_ver)
 {
 	Shard	   *s = shard_for(key);	/* same shard across the ancestry walk */
 	TlWalk		w = tl_walk_first(timeline, read_lsn);
@@ -1303,6 +1303,11 @@ read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
 			 * bypass both and read the authoritative segment.
 			 */
 			int			poisoned = ps_manifest_poisoned();
+
+			/* the resolved version (newest <= read_lsn); a caller that needs an
+			 * exact-cutoff match -- e.g. an SLRU snapshot read -- compares it. */
+			if (out_ver)
+				*out_ver = pv->lsn;
 
 			/* fast path: materialized-page cache, keyed by the resolved version */
 			if (!poisoned && ps_pgcache_lookup(tl, key, block, pv->lsn, out))

--- a/contrib/pagestore/pagestore_core.h
+++ b/contrib/pagestore/pagestore_core.h
@@ -85,7 +85,7 @@ extern int	read_version(const PageVer *v, unsigned char *out);
  * page is unwritten.
  */
 extern int	read_resolve(uint32_t timeline, const PsKey *key, uint32_t block,
-						 uint64_t read_lsn, unsigned char *out);
+						 uint64_t read_lsn, unsigned char *out, uint64_t *out_ver);
 extern void fork_grow(uint32_t timeline, const PsKey *key, uint32_t to_nblocks);
 
 /*

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -96,20 +96,29 @@ handle_request(PsChannel *ch)
 			{
 				unsigned char *dst = ch->data + (size_t) i * page_size;
 
-				if (!read_resolve(tl, &ch->key, ch->blocknum + i, UINT64_MAX, dst))
+				if (!read_resolve(tl, &ch->key, ch->blocknum + i, UINT64_MAX, dst, NULL))
 					memset(dst, 0, page_size);	/* unwritten -> zeros */
 			}
 			break;
 
 		case PS_OP_READ_AT:
 			/* as-of read on this timeline, honoring branch ancestry.  Report
-			 * found-ness in ch->result so a caller can tell a real all-zero page
-			 * from one that has no version <= req_lsn (e.g. an absent SLRU base
-			 * snapshot), rather than mistaking the zero-fill for committed state. */
-			if (read_resolve(tl, &ch->key, ch->blocknum, ch->req_lsn, ch->data))
-				ch->result = 1;
-			else
-				memset(ch->data, 0, page_size);		/* not found: result stays 0 */
+			 * found-ness in ch->result, and the resolved version back in ch->req_lsn,
+			 * so a caller can tell a real all-zero page from one that has no version
+			 * <= req_lsn, and an SLRU snapshot reader can require an exact-cutoff hit
+			 * (resolved == requested) rather than an older newest-<= image. */
+			{
+				uint64_t	resolved = 0;
+
+				if (read_resolve(tl, &ch->key, ch->blocknum, ch->req_lsn, ch->data,
+								 &resolved))
+				{
+					ch->result = 1;
+					ch->req_lsn = resolved;
+				}
+				else
+					memset(ch->data, 0, page_size);	/* not found: result stays 0 */
+			}
 			break;
 
 		default:

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -102,9 +102,14 @@ handle_request(PsChannel *ch)
 			break;
 
 		case PS_OP_READ_AT:
-			/* as-of read on this timeline, honoring branch ancestry */
-			if (!read_resolve(tl, &ch->key, ch->blocknum, ch->req_lsn, ch->data))
-				memset(ch->data, 0, page_size);
+			/* as-of read on this timeline, honoring branch ancestry.  Report
+			 * found-ness in ch->result so a caller can tell a real all-zero page
+			 * from one that has no version <= req_lsn (e.g. an absent SLRU base
+			 * snapshot), rather than mistaking the zero-fill for committed state. */
+			if (read_resolve(tl, &ch->key, ch->blocknum, ch->req_lsn, ch->data))
+				ch->result = 1;
+			else
+				memset(ch->data, 0, page_size);		/* not found: result stays 0 */
 			break;
 
 		default:

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -88,7 +88,12 @@ read_done(void *arg, int ok)
 	ReqState   *rs = bc->rs;
 
 	if (ok)						/* the engine delivered the page into bc->dst */
+	{
 		ps_pgcache_insert(bc->tl, &bc->key, bc->block, bc->lsn, bc->dst);
+		/* a READ_AT only counts as found once its page has actually landed */
+		if (rs->ch->opcode == PS_OP_READ_AT)
+			rs->ch->result = 1;
+	}
 	if (--rs->pending == 0)
 	{
 		rs->active = 0;			/* clear before publishing DONE */
@@ -233,10 +238,14 @@ begin(uint32_t i, PsChannel *ch)
 					ps_store_release(&ch->state, PS_STATE_DONE);
 					return;
 				}
-				ch->result = 1;			/* found a version <= req_lsn */
+				/* report the resolved version for an exact-cutoff SLRU read; defer
+				 * found-ness (ch->result) until the page actually lands, so a failed
+				 * async read does not advertise a zero-filled page as found */
+				ch->req_lsn = v->lsn;
 				if (ps_pgcache_lookup(tl, &ch->key, ch->blocknum, v->lsn,
 									  ch->data))
 				{
+					ch->result = 1;			/* served from RAM: page is present */
 					ps_store_release(&ch->state, PS_STATE_DONE);	/* RAM hit */
 					return;
 				}

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -229,10 +229,11 @@ begin(uint32_t i, PsChannel *ch)
 
 				if (!v)
 				{
-					memset(ch->data, 0, page_size);
+					memset(ch->data, 0, page_size);		/* not found: result 0 */
 					ps_store_release(&ch->state, PS_STATE_DONE);
 					return;
 				}
+				ch->result = 1;			/* found a version <= req_lsn */
 				if (ps_pgcache_lookup(tl, &ch->key, ch->blocknum, v->lsn,
 									  ch->data))
 				{

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -29,7 +29,8 @@
 #include <stdint.h>
 
 #define PS_SHM_MAGIC		0x50414753	/* "PAGS" */
-#define PS_SHM_VERSION		7	/* 7: walidx_get returns timeline-tagged PsWalRec */
+#define PS_SHM_VERSION		8	/* 8: READ_AT reports found-ness in ch->result;
+								 * 7: walidx_get returns timeline-tagged PsWalRec */
 
 /* Default logical page size (overridable via the daemon's --page-size). */
 #define PS_DEFAULT_PAGE_SIZE	8192


### PR DESCRIPTION
## What

The **parent-side SLRU snapshot capture + ship** — M4 step 1 proper, stacked on #61 (the SLRU-class caller-supplied versioning it depends on).

The M4 branch seed starts from a parent SLRU snapshot **keyed by a proven cutoff `C`**, read back as-of `L ≥ C`. This adds the mechanism to produce and read that snapshot:

- `pagestore_localsvc_obj_write()` gains a `version` argument (passed as `req_lsn`, so an SLRU page is versioned by the cutoff); new `pagestore_localsvc_obj_read_at()` for the as-of read-back.
- **`pagestore_ship_slru_snapshot(slru text, cutoff pg_lsn)`** reads every segment of an in-scope SLRU directory (`pg_xact`, `pg_multixact/{offsets,members}`, `pg_commit_ts`) and ships each page keyed by `PsKey{ klass=PS_KLASS_SLRU, relNumber=slru_klass_id(dir), block=pageno }`, versioned by the cutoff. **Fails closed** on any read/IPC error.
- **`pagestore_slru_read_at(slru, pageno, lsn)`** reads a page back as-of `lsn`.

## Cutoff `C`

The caller must capture `cutoff` at a **quiescent point** (a clean shutdown/restartpoint, or under a brief SLRU write barrier) so it provably bounds the segments' contents. The **automatic, online-correct, proven-`C` trigger is the next PR** (a checkpoint hook). This PR provides the mechanism and is correct for the quiescent case.

## Test

`integration_test.sh`: CHECKPOINT (flush clog to a clean image), ship `pg_xact` at the current LSN, and require:
- the shipped page read as-of `C` equals the on-disk page, and
- it is **invisible below `C`** — proving it's versioned by `C`, not a daemon counter.

clog is exercised; multixact/commit-ts use the same generic path. Standalone + integration suites pass.

## Next in M4 step 1

- Automatic capture at checkpoint with a **proven `C`** (core hook after the completion record; quiescent-shutdown first, online write-barrier next).