### PR TITLE
pagestore: multixact offsets applier — reconstruct the multixid→offset map (M4)

### DIFF
--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -456,6 +456,57 @@ assert "$($P -c "SELECT pagestore_commit_ts_asof('$ctsB'::xid, '$ctsC', '$ctsL',
 assert "$($P -c "SELECT pagestore_commit_ts_asof('$ctsA'::xid, '$ctsC', '$ctsL', ('$ctsA'::xid::text::bigint + 1)::text::xid) IS NULL;")" "t" \
 	"commit-ts: a xid below the as-of-L horizon (oldestCommitTsXid) returns NULL despite stale page bytes"
 
+# --- 21. multixact offsets applier: reconstruct the multixid->offset map as-of L --------
+# A multixact needs two concurrent lockers, so hold a FOR SHARE lock in a background session
+# while a second session also locks the row, creating multixact mA.  Reconstructing the
+# offsets SLRU as-of L must give mA the same starting member offset the parent recorded on
+# disk (a byte-for-byte check against the live pg_multixact/offsets file).
+$P -c "CREATE FUNCTION pagestore_multixact_offset_asof(xid, pg_lsn, pg_lsn) RETURNS bigint
+        AS 'pagestore','pagestore_multixact_offset_asof' LANGUAGE C STRICT;
+       CREATE FUNCTION pagestore_multixact_offsets_page_asof(int, pg_lsn, pg_lsn) RETURNS bytea
+        AS 'pagestore','pagestore_multixact_offsets_page_asof' LANGUAGE C STRICT;" >/dev/null
+$P -c "CREATE TABLE mx(id int primary key, note text) TABLESPACE ts; INSERT INTO mx VALUES (1,'a');" >/dev/null
+$P -c "CHECKPOINT;" >/dev/null
+mxC=$($P -c "SELECT pg_current_wal_lsn();")                       # base cutoff C
+$P -c "SELECT pagestore_ship_slru_snapshot('pg_multixact/offsets', '$mxC');" >/dev/null
+# session A holds a FOR SHARE lock across the second locker
+("$BIN/psql" -h 127.0.0.1 -p $PORT -U postgres -tA \
+	-c "BEGIN; SELECT id FROM mx WHERE id=1 FOR SHARE; SELECT pg_sleep(8); COMMIT;" >/dev/null 2>&1) &
+mxlocker=$!
+# wait until A actually holds the ROW lock -- its xid lands in the tuple's xmax -- rather
+# than a fixed sleep (or a relation-level RowShareLock that is taken before the tuple lock),
+# so a slow host can't let B lock and commit the row alone
+for _ in $(seq 1 100); do
+	[ "$($P -c "SELECT (xmax <> '0'::xid)::int FROM mx WHERE id=1;" 2>/dev/null)" = "1" ] && break
+	sleep 0.1
+done
+# session B locks the same row while A still holds -> a multixact is created
+$P -c "BEGIN; SELECT id FROM mx WHERE id=1 FOR SHARE; COMMIT;" >/dev/null
+mA=$($P -c "SELECT xmax FROM mx WHERE id=1;")                     # the row's xmax is the multixact id
+$P -c "CHECKPOINT;" >/dev/null
+mxL=$($P -c "SELECT pg_current_wal_lsn();")                       # fork LSN L (after mA)
+wait "$mxlocker"		# only the locker; a bare wait would also block on the daemon
+# confirm mA really is a multixact (its two FOR SHARE members), not a plain xid
+mxMembers=$($P -c "SELECT count(*) FROM pg_get_multixact_members('$mA');" 2>/dev/null)
+assert "$mxMembers" "2" "a multixact (mA=$mA) was created by two concurrent FOR SHARE lockers"
+mxRecon=$($P -c "SELECT pagestore_multixact_offset_asof('$mA'::xid, '$mxC', '$mxL');")  # offset, for step 21
+# assert the scalar helper itself (a multixact's member offset is always >= 1; offset 0 is
+# skipped), so an error or zero from it fails the test rather than being silently ignored;
+# its exact value is then checked transitively below via mPage = mxRecon/mpp
+assert "$([ "${mxRecon:-x}" -gt 0 ] 2>/dev/null && echo ok || echo "bad:$mxRecon")" "ok" \
+	"multixact offsets: scalar offset_asof(mA) returns a valid (>0) member offset"
+# derive the SLRU page geometry from the server's block_size instead of hardcoding 8192:
+# MULTIXACT_OFFSETS_PER_PAGE = BLCKSZ/4, and SLRU_PAGES_PER_SEGMENT = 32 (block-size independent)
+bs=$($P -c "SELECT current_setting('block_size')::int;")
+opp=$(( bs / 4 ))
+# byte-for-byte: the reconstructed offsets page == the parent's live pg_multixact/offsets
+# file (endian-agnostic, unlike decoding the uint32; also checks the successor slot mA+1)
+mxPage=$(( mA / opp ))
+mxRP=$($P -c "SELECT md5(pagestore_multixact_offsets_page_asof($mxPage, '$mxC', '$mxL'));")
+mxSeg=$(printf '%04X' $(( mxPage / 32 )))
+mxLP=$($P -c "SELECT md5(pg_read_binary_file('pg_multixact/offsets/$mxSeg', $(( (mxPage % 32) * bs )), $bs));")
+assert "$mxRP" "$mxLP" "multixact offsets: reconstructed page as-of L == the parent's live offsets file"
+
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"
 exit $fail

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -35,6 +35,7 @@
 
 #include "access/clog.h"
 #include "access/commit_ts.h"
+#include "access/multixact.h"
 #include "access/relation.h"
 #include "access/rmgr.h"
 #include "access/slru.h"
@@ -1943,6 +1944,230 @@ pagestore_commit_ts_asof(PG_FUNCTION_ARGS)
 	if (ts == 0)
 		PG_RETURN_NULL();		/* no commit timestamp recorded for this xid */
 	PG_RETURN_TIMESTAMPTZ(ts);
+}
+
+/*
+ * multixact offsets reconstruction (M4): the same shape as the clog applier, for
+ * pg_multixact/offsets -- the multixid -> member-offset map.  Each XLOG_MULTIXACT_CREATE_ID
+ * record assigns one multixid its starting offset into the members file (what
+ * RecordNewMultiXact writes to the offsets SLRU), so reconstruction loads the offsets
+ * snapshot as of the base cutoff C and replays the create records in (C, L], writing each
+ * new multixid's offset into its page.  Offsets are fixed-width MultiXactOffset (uint32),
+ * MULTIXACT_OFFSETS_PER_PAGE to a page.  (The members file -- offset -> member list -- is
+ * the second half, a follow-up; this reconstructs the offsets map only.)
+ */
+#define PS_MXOFF_PER_PAGE	(BLCKSZ / (int) sizeof(MultiXactOffset))
+
+/* Write multixid's member offset into offsets page 'pageno' in 'page' if it lives there. */
+static void
+ps_mxoff_set(char *page, int64 pageno, MultiXactId multi, MultiXactOffset offset)
+{
+	int			entryno;
+
+	if (!MultiXactIdIsValid(multi) ||
+		(int64) (multi / PS_MXOFF_PER_PAGE) != pageno)
+		return;
+	entryno = multi % PS_MXOFF_PER_PAGE;
+	memcpy(page + (Size) entryno * sizeof(MultiXactOffset), &offset,
+		   sizeof(MultiXactOffset));
+}
+
+/* Replay (base_lsn, target_lsn] onto offsets page 'pageno'.  Mirrors ps_clog_apply_range:
+ * same straddle/zeropage/truncate/completeness handling, applying create-id offsets. */
+static PsClogReplay
+ps_mxoff_apply_range(char *page, int64 pageno, XLogRecPtr base_lsn,
+					 XLogRecPtr target_lsn)
+{
+	ReadLocalXLogPageNoWaitPrivate *pd = palloc0(sizeof(*pd));
+	XLogReaderState *reader;
+	char	   *errm = NULL;
+	XLogRecPtr	scanned = base_lsn;
+	XLogRecPtr	readfrom;
+	PsClogReplay r = {false, false, false};
+
+	reader = XLogReaderAllocate(wal_segment_size, NULL,
+								XL_ROUTINE(.page_read = &read_local_xlog_page_no_wait,
+										   .segment_open = &wal_segment_open,
+										   .segment_close = &wal_segment_close),
+								pd);
+	if (reader == NULL)
+		ereport(ERROR, (errmsg("pagestore: could not allocate a WAL reader")));
+
+	{
+		XLogSegNo	segno;
+
+		XLByteToSeg(base_lsn, segno, wal_segment_size);
+		XLogSegNoOffsetToRecPtr(segno, 0, wal_segment_size, readfrom);
+	}
+	readfrom = XLogFindNextRecord(reader, readfrom);
+	if (!XLogRecPtrIsInvalid(readfrom))
+		XLogBeginRead(reader, readfrom);
+	while (!XLogRecPtrIsInvalid(readfrom) && XLogReadRecord(reader, &errm) != NULL)
+	{
+		uint8		info;
+
+		if (reader->EndRecPtr > scanned)
+			scanned = reader->EndRecPtr;
+		if (reader->EndRecPtr > target_lsn)
+			break;
+		if (reader->EndRecPtr <= base_lsn)
+			continue;
+		if (XLogRecGetRmid(reader) != RM_MULTIXACT_ID)
+			continue;
+		info = XLogRecGetInfo(reader) & XLR_RMGR_INFO_MASK;
+
+		if (info == XLOG_MULTIXACT_ZERO_OFF_PAGE)
+		{
+			int64		zp;
+
+			memcpy(&zp, XLogRecGetData(reader), sizeof(zp));
+			if (zp == pageno)
+			{
+				memset(page, 0, BLCKSZ);
+				r.page_zeroed = true;
+				r.page_truncated = false;
+			}
+		}
+		else if (info == XLOG_MULTIXACT_CREATE_ID)
+		{
+			xl_multixact_create *xlrec =
+				(xl_multixact_create *) XLogRecGetData(reader);
+			MultiXactOffset next = xlrec->moff + xlrec->nmembers;
+			MultiXactId succ;
+
+			/* RecordNewMultiXact writes this multixid's offset *and* the next
+			 * multixid's slot with the end offset (skipping 0 on wrap, like
+			 * GetNewMultiXactId), so a faithful page carries the successor entry
+			 * too -- and a consumer needs it to size this multixid's member run.
+			 * The successor wraps MaxMultiXactId -> FirstMultiXactId, matching
+			 * GetNewMultiXactId, so a fork across multixid wraparound is exact. */
+			ps_mxoff_set(page, pageno, xlrec->mid, xlrec->moff);
+			if (next == 0)
+				next = 1;
+			succ = (xlrec->mid == MaxMultiXactId) ? FirstMultiXactId : xlrec->mid + 1;
+			ps_mxoff_set(page, pageno, succ, next);
+		}
+		else if (info == XLOG_MULTIXACT_TRUNCATE_ID)
+		{
+			xl_multixact_truncate xlrec;
+			MultiXactId cutoff;
+
+			memcpy(&xlrec, XLogRecGetData(reader), SizeOfMultiXactTruncate);
+			/* PerformOffsetsTruncation truncates to
+			 * MultiXactIdToOffsetPage(PreviousMultiXactId(endTruncOff)), keeping
+			 * that page's segment; a page is dropped only if its segment is below
+			 * it.  The bounded fork window cannot wrap, so segment order suffices. */
+			cutoff = (xlrec.endTruncOff == FirstMultiXactId) ? MaxMultiXactId
+				: xlrec.endTruncOff - 1;
+			if (pageno / SLRU_PAGES_PER_SEGMENT <
+				((int64) cutoff / PS_MXOFF_PER_PAGE) / SLRU_PAGES_PER_SEGMENT)
+				r.page_truncated = true;
+		}
+	}
+
+	r.reached_target = (scanned >= target_lsn) ||
+		(!XLogRecPtrIsInvalid(readfrom) && errm == NULL &&
+		 ps_local_wal_limit() >= target_lsn);
+	XLogReaderFree(reader);
+	pfree(pd);
+	return r;
+}
+
+/* Load the base offsets page (snapshot as-of base_lsn) and replay (base, L].  Same
+ * fail-closed contract as ps_clog_reconstruct. */
+static bool
+ps_mxoff_reconstruct(char *page, int64 pageno, XLogRecPtr base_lsn,
+					 XLogRecPtr target_lsn)
+{
+	PageStoreRelKey key;
+	bool		base_found;
+	uint64		resolved = 0;
+	PsClogReplay r;
+
+	if (strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") != 0)
+		ereport(ERROR,
+				(errmsg("pagestore.backend must be 'localsvc'")));
+	if (target_lsn < base_lsn)
+		ereport(ERROR,
+				(errmsg("target LSN precedes the base cutoff")));
+
+	slru_obj_key(&key, "pg_multixact/offsets");
+	base_found = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
+												(BlockNumber) pageno,
+												(uint64) base_lsn, page, &resolved) &&
+		resolved == (uint64) base_lsn;
+
+	if (target_lsn == base_lsn)
+	{
+		if (!base_found)
+			ereport(ERROR,
+					(errmsg("pagestore: base offsets snapshot for page %lld is absent at %X/%08X",
+							(long long) pageno, LSN_FORMAT_ARGS(base_lsn))));
+		return true;
+	}
+
+	r = ps_mxoff_apply_range(page, pageno, base_lsn, target_lsn);
+
+	if (!r.reached_target && target_lsn != PG_UINT64_MAX)
+		ereport(ERROR,
+				(errmsg("pagestore: WAL ends before the target LSN; cannot reconstruct multixact offsets as of %X/%08X",
+						LSN_FORMAT_ARGS(target_lsn))));
+	if (r.page_truncated)
+		return false;
+	if (!base_found && !r.page_zeroed)
+		ereport(ERROR,
+				(errmsg("pagestore: base offsets snapshot for page %lld is absent at %X/%08X",
+						(long long) pageno, LSN_FORMAT_ARGS(base_lsn))));
+	return true;
+}
+
+/*
+ * pagestore_multixact_offset_asof(multi xid, base pg_lsn, target pg_lsn) returns bigint --
+ * multixid 'multi's starting member offset as of 'target', or NULL if its offsets page was
+ * truncated away.
+ */
+PG_FUNCTION_INFO_V1(pagestore_multixact_offset_asof);
+Datum
+pagestore_multixact_offset_asof(PG_FUNCTION_ARGS)
+{
+	MultiXactId multi = PG_GETARG_TRANSACTIONID(0);
+	XLogRecPtr	base = PG_GETARG_LSN(1);
+	XLogRecPtr	target = PG_GETARG_LSN(2);
+	int64		pageno = multi / PS_MXOFF_PER_PAGE;
+	int			entryno = multi % PS_MXOFF_PER_PAGE;
+	char	   *page = palloc(BLCKSZ);
+	MultiXactOffset offset;
+
+	if (!ps_mxoff_reconstruct(page, pageno, base, target))
+		PG_RETURN_NULL();		/* multi's offsets page truncated away by the target LSN */
+
+	memcpy(&offset, page + (Size) entryno * sizeof(MultiXactOffset),
+		   sizeof(MultiXactOffset));
+	PG_RETURN_INT64((int64) offset);
+}
+
+/*
+ * pagestore_multixact_offsets_page_asof(pageno int, base pg_lsn, target pg_lsn) returns
+ * bytea -- the offsets page reconstructed as of 'target', or NULL if truncated away.  Lets
+ * a caller compare the reconstructed page to the live file byte-for-byte (endian-agnostic).
+ */
+PG_FUNCTION_INFO_V1(pagestore_multixact_offsets_page_asof);
+Datum
+pagestore_multixact_offsets_page_asof(PG_FUNCTION_ARGS)
+{
+	int32		pageno = PG_GETARG_INT32(0);
+	XLogRecPtr	base = PG_GETARG_LSN(1);
+	XLogRecPtr	target = PG_GETARG_LSN(2);
+	char	   *page = palloc(BLCKSZ);
+	bytea	   *result;
+
+	if (!ps_mxoff_reconstruct(page, pageno, base, target))
+		PG_RETURN_NULL();
+
+	result = (bytea *) palloc(BLCKSZ + VARHDRSZ);
+	SET_VARSIZE(result, BLCKSZ + VARHDRSZ);
+	memcpy(VARDATA(result), page, BLCKSZ);
+	PG_RETURN_BYTEA_P(result);
 }
 
 /*


### PR DESCRIPTION
## What

Extends the M4 SLRU reconstruction to **`pg_multixact/offsets`** — the `multixid → member-offset` map — the same shape as the clog applier (#63).

Each `XLOG_MULTIXACT_CREATE_ID` record assigns one multixid its starting offset into the members file (what `RecordNewMultiXact` writes to the offsets SLRU), so reconstruction:
- loads the offsets snapshot at the base cutoff `C`, then
- replays the create records in `(C, L]`, writing each new multixid's offset into its page.

Offsets are fixed-width `MultiXactOffset` (uint32), `MULTIXACT_OFFSETS_PER_PAGE` to a page.

## Reuses the hardened clog machinery

WAL-segment-aligned start (a create straddling `C` is still applied), record-aligned at `L`, `XLOG_MULTIXACT_ZERO_OFF_PAGE` handling, `XLOG_MULTIXACT_TRUNCATE_ID` (segment-aware, bounded-window) page omission, and the same fail-closed completeness check (incomplete / recycled-start / decode-error WAL, replay-aware on a standby).

## Scope

This is the **offsets half**. The members file (`offset → member list`, with its packed member-group byte layout) is the second half and a follow-up — after which a full multixact can be resolved as-of `L`. (multixact and commit-ts (#66/#67) are the two SLRUs beyond clog; this is the harder one, split into offsets→members.)

## Test

`pagestore_multixact_offset_asof(multi, base, target)` returns the starting offset. `integration_test.sh` step 20: two concurrent `FOR SHARE` lockers create a **real** multixact (confirmed via `pg_get_multixact_members` = 2 members), and its reconstructed offset as-of `L` equals the parent's **live `pg_multixact/offsets`** file **byte-for-byte**. Standalone (5/5) + integration suites pass.