### PR TITLE
pagestore: seed commit-ts and multixact for branch boot

### DIFF
--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -446,6 +446,7 @@ $P -c "SELECT pagestore_ship_slru_snapshot('pg_commit_ts', '$ctsC');" >/dev/null
 # data-writing xacts so the commit (and its timestamp) is sync-flushed for the WAL reader
 ctsA=$($P -c "WITH w AS (INSERT INTO cts VALUES (1) RETURNING 1) SELECT pg_current_xact_id();")
 ctsL=$($P -c "SELECT pg_current_wal_lsn();")                      # L: after xidA's commit
+cts_next=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
 ctsB=$($P -c "WITH w AS (INSERT INTO cts VALUES (2) RETURNING 1) SELECT pg_current_xact_id();")
 # oldest='3' (below all our xids) disables the horizon check for these baseline assertions
 assert "$($P -c "SELECT pagestore_commit_ts_asof('$ctsA'::xid, '$ctsC', '$ctsL', '3'::xid) IS NOT NULL;")" "t" \
@@ -460,7 +461,6 @@ assert "$($P -c "SELECT pagestore_commit_ts_asof('$ctsB'::xid, '$ctsC', '$ctsL',
 assert "$($P -c "SELECT pagestore_commit_ts_asof('$ctsA'::xid, '$ctsC', '$ctsL', ('$ctsA'::xid::text::bigint + 1)::text::xid) IS NULL;")" "t" \
 	"commit-ts: a xid below the as-of-L horizon (oldestCommitTsXid) returns NULL despite stale page bytes"
 CTSSEED=$(mktemp -d)
-cts_next=$(($ctsB + 1))
 ctsSeeded=$($P -c "SELECT pagestore_seed_commit_ts('$CTSSEED', '$ctsC', '$ctsL', '3'::xid, '$cts_next'::text::xid);")
 assert "$([ "${ctsSeeded:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
 	"commit-ts seed materialized branch pg_commit_ts as-of L ($ctsSeeded page(s))"

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -432,7 +432,11 @@ rm -rf "$(dirname "$SEEDOUT")"
 # xidB (> L); reconstructing as-of L must give xidA its real commit timestamp (matching the
 # parent's pg_xact_commit_timestamp) and xidB none -- per-record replay, no coalescing.
 $P -c "CREATE FUNCTION pagestore_commit_ts_asof(xid, pg_lsn, pg_lsn, xid) RETURNS timestamptz
-        AS 'pagestore','pagestore_commit_ts_asof' LANGUAGE C STRICT;" >/dev/null
+        AS 'pagestore','pagestore_commit_ts_asof' LANGUAGE C STRICT;
+       CREATE FUNCTION pagestore_commit_ts_page_asof(int, pg_lsn, pg_lsn) RETURNS bytea
+        AS 'pagestore','pagestore_commit_ts_page_asof' LANGUAGE C STRICT;
+       CREATE FUNCTION pagestore_seed_commit_ts(text, pg_lsn, pg_lsn, xid, xid) RETURNS bigint
+        AS 'pagestore','pagestore_seed_commit_ts' LANGUAGE C STRICT;" >/dev/null
 echo "track_commit_timestamp = on" >> "$DATA/postgresql.conf"   # needs a restart to activate
 "$BIN/pg_ctl" -D "$DATA" -w restart >/dev/null 2>&1
 $P -c "CREATE TABLE cts(id int) TABLESPACE ts;" >/dev/null
@@ -455,6 +459,20 @@ assert "$($P -c "SELECT pagestore_commit_ts_asof('$ctsB'::xid, '$ctsC', '$ctsL',
 # oldestCommitTsXid rejection after a truncation / before an activation)
 assert "$($P -c "SELECT pagestore_commit_ts_asof('$ctsA'::xid, '$ctsC', '$ctsL', ('$ctsA'::xid::text::bigint + 1)::text::xid) IS NULL;")" "t" \
 	"commit-ts: a xid below the as-of-L horizon (oldestCommitTsXid) returns NULL despite stale page bytes"
+CTSSEED=$(mktemp -d)
+cts_next=$(($ctsB + 1))
+ctsSeeded=$($P -c "SELECT pagestore_seed_commit_ts('$CTSSEED', '$ctsC', '$ctsL', '3'::xid, '$cts_next'::text::xid);")
+assert "$([ "${ctsSeeded:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
+	"commit-ts seed materialized branch pg_commit_ts as-of L ($ctsSeeded page(s))"
+bs=$($P -c "SELECT current_setting('block_size')::int;")
+cts_entry_size=10
+cts_per_page=$(( bs / cts_entry_size ))
+ctsPage=$(( ctsA / cts_per_page ))
+ctsSeg=$(printf '%04X' $(( ctsPage / 32 )))
+ctsSeedMd5=$($P -c "SELECT md5(pg_read_binary_file('$CTSSEED/pg_commit_ts/$ctsSeg', $(( (ctsPage % 32) * bs )), $bs));")
+ctsReconMd5=$($P -c "SELECT md5(pagestore_commit_ts_page_asof($ctsPage, '$ctsC', '$ctsL'));")
+assert "$ctsSeedMd5" "$ctsReconMd5" "commit-ts seed page == reconstructed as-of-L page"
+rm -rf "$CTSSEED"
 
 # --- 21. multixact offsets applier: reconstruct the multixid->offset map as-of L --------
 # A multixact needs two concurrent lockers, so hold a FOR SHARE lock in a background session
@@ -513,7 +531,9 @@ assert "$mxRP" "$mxLP" "multixact offsets: reconstructed page as-of L == the par
 # equal the parent's live pg_multixact/members file byte-for-byte.  With the offsets half,
 # this resolves mA's members: the page holds its two FOR SHARE lockers at offset mOff.
 $P -c "CREATE FUNCTION pagestore_multixact_members_page_asof(int, pg_lsn, pg_lsn) RETURNS bytea
-        AS 'pagestore','pagestore_multixact_members_page_asof' LANGUAGE C STRICT;" >/dev/null
+        AS 'pagestore','pagestore_multixact_members_page_asof' LANGUAGE C STRICT;
+       CREATE FUNCTION pagestore_seed_multixact(text, pg_lsn, pg_lsn, xid, xid, bigint, bigint) RETURNS bigint
+        AS 'pagestore','pagestore_seed_multixact' LANGUAGE C STRICT;" >/dev/null
 mOff=$mxRecon                                          # mA's first member offset (step 20)
 # MULTIXACT_MEMBERS_PER_PAGE = (block_size / MULTIXACT_MEMBERGROUP_SIZE) * members-per-group;
 # the group is 4 flag bytes + 4 TransactionIds = 20 bytes, 4 members each (block-size derived)
@@ -530,6 +550,16 @@ assert "$mbRecon" "$mbLive" "multixact members: reconstructed page as-of L == th
 # rather than decoding the TransactionIds, which keeps the check endian-agnostic.)
 mbParent=$($P -c "SELECT count(*) FROM pg_get_multixact_members('$mA');" 2>/dev/null)
 assert "$mbParent" "2" "multixact members: the parent resolves mA to its two members from those pages"
+MXSEED=$(mktemp -d)
+mxNext=$(( mA + 1 ))
+mxSeeded=$($P -c "SELECT pagestore_seed_multixact('$MXSEED', '$mxC', '$mxL', '$mA'::xid, '$mxNext'::text::xid, $mOff, $((mOff + mxMembers)));")
+assert "$([ "${mxSeeded:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
+	"multixact seed materialized offsets+members SLRUs as-of L ($mxSeeded page(s))"
+mxSeedOff=$($P -c "SELECT md5(pg_read_binary_file('$MXSEED/pg_multixact/offsets/$mxSeg', $(( (mxPage % 32) * bs )), $bs));")
+mxSeedMem=$($P -c "SELECT md5(pg_read_binary_file('$MXSEED/pg_multixact/members/$mbSeg', $(( (mPage % 32) * bs )), $bs));")
+assert "$mxSeedOff" "$mxRP" "multixact seed offsets page == reconstructed as-of-L page"
+assert "$mxSeedMem" "$mbRecon" "multixact seed members page == reconstructed as-of-L page"
+rm -rf "$MXSEED"
 
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -1946,6 +1946,25 @@ pagestore_commit_ts_asof(PG_FUNCTION_ARGS)
 	PG_RETURN_TIMESTAMPTZ(ts);
 }
 
+PG_FUNCTION_INFO_V1(pagestore_commit_ts_page_asof);
+Datum
+pagestore_commit_ts_page_asof(PG_FUNCTION_ARGS)
+{
+	int32		pageno = PG_GETARG_INT32(0);
+	XLogRecPtr	base = PG_GETARG_LSN(1);
+	XLogRecPtr	target = PG_GETARG_LSN(2);
+	char	   *page = palloc(BLCKSZ);
+	bytea	   *result;
+
+	if (!ps_commit_ts_reconstruct(page, pageno, base, target))
+		PG_RETURN_NULL();
+
+	result = (bytea *) palloc(BLCKSZ + VARHDRSZ);
+	SET_VARSIZE(result, BLCKSZ + VARHDRSZ);
+	memcpy(VARDATA(result), page, BLCKSZ);
+	PG_RETURN_BYTEA_P(result);
+}
+
 /*
  * multixact offsets reconstruction (M4): the same shape as the clog applier, for
  * pg_multixact/offsets -- the multixid -> member-offset map.  Each XLOG_MULTIXACT_CREATE_ID
@@ -2396,6 +2415,149 @@ pagestore_multixact_members_page_asof(PG_FUNCTION_ARGS)
 	PG_RETURN_BYTEA_P(result);
 }
 
+typedef bool (*SlruPageReconstructFn) (char *page, int64 pageno,
+									   XLogRecPtr base_lsn,
+									   XLogRecPtr target_lsn);
+
+static int64
+pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
+						  int64 page_lo, int64 page_hi,
+						  SlruPageReconstructFn reconstruct,
+						  XLogRecPtr base, XLogRecPtr target,
+						  const char *label)
+{
+	char		dstdir[MAXPGPATH];
+	char		stagedir[MAXPGPATH];
+	char	   *pages;
+	bool	   *present;
+	int64		seg_lo,
+				seg_hi,
+				req_lo,
+				req_hi,
+				seg,
+				p;
+	int			np;
+	int64		seeded = 0;
+
+	if (page_hi < page_lo)
+		return 0;
+	if (strlen(target_dir) + strlen(slru_dir) + sizeof("/.tmp/000000.tmp") > MAXPGPATH)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("branch target directory path is too long")));
+
+	req_lo = page_lo;
+	req_hi = page_hi;
+	seg_lo = req_lo / SLRU_PAGES_PER_SEGMENT;
+	page_lo = seg_lo * SLRU_PAGES_PER_SEGMENT;
+	seg_hi = req_hi / SLRU_PAGES_PER_SEGMENT;
+	page_hi = req_hi;
+	np = (int) (page_hi - page_lo + 1);
+
+	pages = palloc((Size) np * BLCKSZ);
+	present = palloc0(np * sizeof(bool));
+	for (p = 0; p < np; p++)
+	{
+		int64		pageno = page_lo + p;
+
+		if (pageno < req_lo)
+		{
+			memset(pages + p * BLCKSZ, 0, BLCKSZ);
+			continue;
+		}
+		present[p] = reconstruct(pages + p * BLCKSZ, pageno, base, target);
+	}
+
+	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
+	snprintf(dstdir, sizeof(dstdir), "%s/%s", target_dir, slru_dir);
+	snprintf(stagedir, sizeof(stagedir), "%s/%s.tmp", target_dir, slru_dir);
+
+	if (access(stagedir, F_OK) == 0 && !rmtree(stagedir, true))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not clear branch staging dir \"%s\"", stagedir)));
+	if (MakePGDirectory(stagedir) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch staging dir \"%s\": %m", stagedir)));
+
+	for (seg = seg_lo; seg <= seg_hi; seg++)
+	{
+		char		segpath[MAXPGPATH];
+		int64		first = seg * SLRU_PAGES_PER_SEGMENT;
+		int64		last = first + SLRU_PAGES_PER_SEGMENT - 1;
+		int			fd;
+		int64		trim_last = last;
+
+		while (trim_last >= first && !present[trim_last - page_lo])
+			trim_last--;
+		if (trim_last < first)
+			continue;
+
+		snprintf(segpath, sizeof(segpath), "%s/%04X", stagedir, (unsigned int) seg);
+		fd = OpenTransientFilePerm(segpath,
+								   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
+								   pg_file_create_mode);
+		if (fd < 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not create branch %s segment \"%s\": %m",
+							label, segpath)));
+		for (p = first; p <= trim_last; p++)
+		{
+			const char *src;
+			char		zerobuf[BLCKSZ];
+
+			if (present[p - page_lo])
+				src = pages + (p - page_lo) * BLCKSZ;
+			else
+			{
+				memset(zerobuf, 0, sizeof(zerobuf));
+				src = zerobuf;
+			}
+			if (write(fd, src, BLCKSZ) != BLCKSZ)
+			{
+				CloseTransientFile(fd);
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("could not write branch %s segment \"%s\": %m",
+								label, segpath)));
+			}
+			seeded++;
+		}
+		if (pg_fsync(fd) != 0)
+		{
+			CloseTransientFile(fd);
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not fsync branch %s segment \"%s\": %m",
+							label, segpath)));
+		}
+		if (CloseTransientFile(fd) != 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not close branch %s segment \"%s\": %m",
+							label, segpath)));
+	}
+	fsync_fname(stagedir, true);
+	if (access(dstdir, F_OK) == 0 && !rmtree(dstdir, true))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove existing %s dir \"%s\"", label, dstdir)));
+	if (rename(stagedir, dstdir) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not publish branch %s dir \"%s\": %m", label, dstdir)));
+	fsync_fname(target_dir, true);
+
+	pfree(present);
+	pfree(pages);
+	return seeded;
+}
+
 /*
  * pagestore_seed_clog(target_dir text, base pg_lsn, target pg_lsn,
  *					   oldest_xid xid, next_xid xid) returns bigint
@@ -2716,6 +2878,133 @@ pagestore_seed_clog(PG_FUNCTION_ARGS)
 				 errmsg("could not publish branch clog \"%s\": %m", dstdir)));
 	fsync_fname(target_dir, true);	/* the now-live pg_xact directory entry */
 
+	PG_RETURN_INT64(seeded);
+}
+
+/*
+ * pagestore_seed_commit_ts(target_dir text, base pg_lsn, target pg_lsn,
+ *                          oldest_xid xid, next_xid xid) returns bigint
+ *
+ * Materialize pg_commit_ts as of target into a branch data directory.  The xid
+ * horizon is the branch's commit-ts validity window as of target; pages outside
+ * it are intentionally not seeded.
+ */
+PG_FUNCTION_INFO_V1(pagestore_seed_commit_ts);
+Datum
+pagestore_seed_commit_ts(PG_FUNCTION_ARGS)
+{
+	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	XLogRecPtr	base = PG_GETARG_LSN(1);
+	XLogRecPtr	target = PG_GETARG_LSN(2);
+	TransactionId oldest_xid = PG_GETARG_TRANSACTIONID(3);
+	TransactionId next_xid = PG_GETARG_TRANSACTIONID(4);
+	int64		page_lo,
+				page_hi;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to seed branch commit-ts")));
+	if (strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") != 0)
+		ereport(ERROR,
+				(errmsg("pagestore.backend must be 'localsvc'")));
+	if (target < base)
+		ereport(ERROR,
+				(errmsg("target LSN precedes the base cutoff")));
+	if (!TransactionIdIsNormal(oldest_xid) || !TransactionIdIsNormal(next_xid) ||
+		TransactionIdFollows(oldest_xid, next_xid))
+		ereport(ERROR,
+				(errmsg("invalid fork xid horizon [%u, %u)", oldest_xid, next_xid)));
+	page_lo = ((int64) oldest_xid / PS_CTS_XACTS_PER_PAGE);
+	page_hi = ((int64) (next_xid - 1)) / PS_CTS_XACTS_PER_PAGE;
+	if (page_hi < page_lo)
+		ereport(ERROR,
+				(errmsg("fork xid horizon [%u, %u) spans XID wraparound; commit-ts seeding across wrap is not supported",
+						oldest_xid, next_xid)));
+
+	PG_RETURN_INT64(pagestore_seed_slru_pages(target_dir, "pg_commit_ts",
+											 page_lo, page_hi,
+											 ps_commit_ts_reconstruct,
+											 base, target, "commit-ts"));
+}
+
+/*
+ * pagestore_seed_multixact(target_dir text, base pg_lsn, target pg_lsn,
+ *                          oldest_multi xid, next_multi xid,
+ *                          oldest_member bigint, next_member bigint) returns bigint
+ *
+ * Materialize pg_multixact/offsets and pg_multixact/members as of target into a
+ * branch data directory.  The caller supplies the branch horizons from pg_control.
+ */
+PG_FUNCTION_INFO_V1(pagestore_seed_multixact);
+Datum
+pagestore_seed_multixact(PG_FUNCTION_ARGS)
+{
+	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	XLogRecPtr	base = PG_GETARG_LSN(1);
+	XLogRecPtr	target = PG_GETARG_LSN(2);
+	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(3);
+	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(4);
+	int64		oldest_member = PG_GETARG_INT64(5);
+	int64		next_member = PG_GETARG_INT64(6);
+	int64		off_page_lo,
+				off_page_hi,
+				mem_page_lo,
+				mem_page_hi;
+	int64		seeded = 0;
+	char		mxdir[MAXPGPATH];
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to seed branch multixact")));
+	if (strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") != 0)
+		ereport(ERROR,
+				(errmsg("pagestore.backend must be 'localsvc'")));
+	if (target < base)
+		ereport(ERROR,
+				(errmsg("target LSN precedes the base cutoff")));
+	if (!MultiXactIdIsValid(oldest_multi) || !MultiXactIdIsValid(next_multi) ||
+		oldest_multi > next_multi)
+		ereport(ERROR,
+				(errmsg("invalid fork multixact horizon [%u, %u)",
+						oldest_multi, next_multi)));
+	if (oldest_member < 0 || next_member < oldest_member ||
+		next_member > UINT32_MAX)
+		ereport(ERROR,
+				(errmsg("invalid fork multixact member horizon [%lld, %lld)",
+						(long long) oldest_member, (long long) next_member)));
+
+	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
+	snprintf(mxdir, sizeof(mxdir), "%s/pg_multixact", target_dir);
+	if (MakePGDirectory(mxdir) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch multixact dir \"%s\": %m", mxdir)));
+
+	if (next_multi > oldest_multi)
+	{
+		off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
+		off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
+		seeded += pagestore_seed_slru_pages(target_dir, "pg_multixact/offsets",
+											off_page_lo, off_page_hi,
+											ps_mxoff_reconstruct,
+											base, target, "multixact offsets");
+	}
+	if (next_member > oldest_member)
+	{
+		mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
+		mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
+		seeded += pagestore_seed_slru_pages(target_dir, "pg_multixact/members",
+											mem_page_lo, mem_page_hi,
+											ps_mxmemb_reconstruct,
+											base, target, "multixact members");
+	}
+
+	fsync_fname(mxdir, true);
 	PG_RETURN_INT64(seeded);
 }
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2518,7 +2518,8 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 				memset(zerobuf, 0, sizeof(zerobuf));
 				src = zerobuf;
 			}
-			if (write(fd, src, BLCKSZ) != BLCKSZ)
+			if (pg_pwrite(fd, src, BLCKSZ,
+						  (off_t) (p - first) * BLCKSZ) != BLCKSZ)
 			{
 				CloseTransientFile(fd);
 				ereport(ERROR,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -541,8 +541,10 @@ pagestore_index_wal_range(XLogRecPtr start, XLogRecPtr end)
 		}
 	}
 
-	XLogReaderFree(reader);
-	pfree(pd);
+	if (reader != NULL)
+		XLogReaderFree(reader);
+	if (pd != NULL)
+		pfree(pd);
 }
 
 /*
@@ -755,8 +757,10 @@ pagestore_redo_page(PG_FUNCTION_ARGS)
 		}
 	}
 
-	XLogReaderFree(reader);
-	pfree(pd);
+	if (reader != NULL)
+		XLogReaderFree(reader);
+	if (pd != NULL)
+		pfree(pd);
 	pfree(recs);
 	pfree(page);
 
@@ -1067,8 +1071,10 @@ pagestore_redo_page_asof(PG_FUNCTION_ARGS)
 	SET_VARSIZE(result, BLCKSZ + VARHDRSZ);
 	memcpy(VARDATA(result), page, BLCKSZ);
 
-	XLogReaderFree(reader);
-	pfree(pd);
+	if (reader != NULL)
+		XLogReaderFree(reader);
+	if (pd != NULL)
+		pfree(pd);
 	pfree(recs);
 	pfree(base);
 	pfree(page);
@@ -2420,7 +2426,8 @@ pagestore_multixact_members_page_asof(PG_FUNCTION_ARGS)
  */
 static bool
 ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
-								   int64 page_hi, XLogRecPtr base_lsn,
+								   int64 page_hi, int64 req_lo, int64 req_hi,
+								   XLogRecPtr base_lsn,
 								   XLogRecPtr target_lsn)
 {
 	PageStoreRelKey key;
@@ -2435,30 +2442,35 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 	XLogRecPtr	reached_from;
 	TransactionId xid;
 	TransactionId prepared_xid;
+	bool	   *base_found;
+	bool	   *zeroed;
+	bool	   *truncated;
 
 	if (target_lsn < base_lsn)
 		ereport(ERROR,
 				(errmsg("target LSN precedes the base cutoff")));
 
+	base_found = palloc0(np * sizeof(bool));
+	zeroed = palloc0(np * sizeof(bool));
+	truncated = palloc0(np * sizeof(bool));
 	slru_obj_key(&key, "pg_commit_ts");
 	for (int64 p = 0; p < np; p++)
 	{
 		uint64		resolved = 0;
-		bool		base_found;
 
-		base_found = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
+		base_found[p] = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
 												   (BlockNumber) (page_lo + p),
 												   (uint64) base_lsn,
 												   pages + p * BLCKSZ,
 												   &resolved) &&
 			resolved == (uint64) base_lsn;
-		present[p] = base_found;
-		if (!base_found)
+		present[p] = base_found[p];
+		if (!base_found[p])
 			memset(pages + p * BLCKSZ, 0, BLCKSZ);
 	}
 
 	if (target_lsn == base_lsn)
-		return true;
+		goto check_required_pages;
 
 	pd = palloc0(sizeof(*pd));
 	reader = XLogReaderAllocate(wal_segment_size, NULL,
@@ -2510,6 +2522,8 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 					idx = zp - page_lo;
 					memset(pages + idx * BLCKSZ, 0, BLCKSZ);
 					present[idx] = true;
+					zeroed[idx] = true;
+					truncated[idx] = false;
 				}
 			}
 			else if (cinfo == COMMIT_TS_TRUNCATE)
@@ -2526,7 +2540,10 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 				{
 					pageseg = (page_lo + p) / SLRU_PAGES_PER_SEGMENT;
 					if (pageseg < cut_seg)
+					{
 						present[p] = false;
+						truncated[p] = true;
+					}
 				}
 			}
 		}
@@ -2585,8 +2602,26 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 		ereport(ERROR,
 				(errmsg("pagestore: track_commit_timestamp was turned off in (base, target]; commit-ts reconstruction across a toggle is not supported")));
 
+check_required_pages:
+	for (int64 pageno = req_lo; pageno <= req_hi; pageno++)
+	{
+		int64		idx = pageno - page_lo;
+
+		if (truncated[idx])
+			ereport(ERROR,
+					(errmsg("pagestore: requested commit-ts page %lld was truncated before the target LSN",
+							(long long) pageno)));
+		if (!base_found[idx] && !zeroed[idx])
+			ereport(ERROR,
+					(errmsg("pagestore: base commit-ts snapshot for page %lld is absent at %X/%08X",
+							(long long) pageno, LSN_FORMAT_ARGS(base_lsn))));
+	}
+
 	XLogReaderFree(reader);
 	pfree(pd);
+	pfree(truncated);
+	pfree(zeroed);
+	pfree(base_found);
 	return true;
 }
 
@@ -2596,6 +2631,7 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 static bool
 ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 								int64 page_lo, int64 page_hi,
+								int64 req_lo, int64 req_hi,
 								XLogRecPtr base_lsn, XLogRecPtr target_lsn)
 {
 	PageStoreRelKey key;
@@ -2606,28 +2642,32 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 	XLogRecPtr	readfrom;
 	int64		np = page_hi - page_lo + 1;
 	uint64		resolved = 0;
+	bool	   *base_found;
+	bool	   *zeroed;
+	bool	   *truncated;
 
 	if (target_lsn < base_lsn)
 		ereport(ERROR,
 				(errmsg("target LSN precedes the base cutoff")));
 
+	base_found = palloc0(np * sizeof(bool));
+	zeroed = palloc0(np * sizeof(bool));
+	truncated = palloc0(np * sizeof(bool));
 	slru_obj_key(&key, "pg_multixact/offsets");
 	for (int64 p = 0; p < np; p++)
 	{
-		bool		base_found;
-
-		base_found = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
+		base_found[p] = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
 												   (BlockNumber) (page_lo + p),
 												   (uint64) base_lsn,
 												   pages + p * BLCKSZ,
 												   &resolved) &&
 			resolved == (uint64) base_lsn;
-		present[p] = base_found;
-		if (!base_found)
+		present[p] = base_found[p];
+		if (!base_found[p])
 			memset(pages + p * BLCKSZ, 0, BLCKSZ);
 	}
 	if (target_lsn == base_lsn)
-		return true;
+		goto check_required_pages;
 
 	pd = palloc0(sizeof(*pd));
 	reader = XLogReaderAllocate(wal_segment_size, NULL,
@@ -2672,6 +2712,8 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 				idx = zp - page_lo;
 				memset(pages + idx * BLCKSZ, 0, BLCKSZ);
 				present[idx] = true;
+				zeroed[idx] = true;
+				truncated[idx] = false;
 			}
 		}
 		else if (info == XLOG_MULTIXACT_CREATE_ID)
@@ -2718,7 +2760,10 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 				int64		pageseg = (page_lo + p) / SLRU_PAGES_PER_SEGMENT;
 
 				if (pageseg < cutoff_seg)
+				{
 					present[p] = false;
+					truncated[p] = true;
+				}
 			}
 		}
 	}
@@ -2730,8 +2775,26 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 				(errmsg("pagestore: WAL ends before the target LSN; cannot reconstruct multixact offsets as of %X/%08X",
 						LSN_FORMAT_ARGS(target_lsn))));
 
+check_required_pages:
+	for (int64 pageno = req_lo; pageno <= req_hi; pageno++)
+	{
+		int64		idx = pageno - page_lo;
+
+		if (truncated[idx])
+			ereport(ERROR,
+					(errmsg("pagestore: requested multixact offsets page %lld was truncated before the target LSN",
+							(long long) pageno)));
+		if (!base_found[idx] && !zeroed[idx])
+			ereport(ERROR,
+					(errmsg("pagestore: base offsets snapshot for page %lld is absent at %X/%08X",
+							(long long) pageno, LSN_FORMAT_ARGS(base_lsn))));
+	}
+
 	XLogReaderFree(reader);
 	pfree(pd);
+	pfree(truncated);
+	pfree(zeroed);
+	pfree(base_found);
 	return true;
 }
 
@@ -2741,6 +2804,7 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 static bool
 ps_mxmemb_seed_reconstruct_range(char *pages, bool *present,
 								int64 page_lo, int64 page_hi,
+								int64 req_lo, int64 req_hi,
 								XLogRecPtr base_lsn, XLogRecPtr target_lsn)
 {
 	PageStoreRelKey key;
@@ -2751,28 +2815,32 @@ ps_mxmemb_seed_reconstruct_range(char *pages, bool *present,
 	XLogRecPtr	readfrom;
 	int64		np = page_hi - page_lo + 1;
 	uint64		resolved = 0;
+	bool	   *base_found;
+	bool	   *zeroed;
+	bool	   *truncated;
 
 	if (target_lsn < base_lsn)
 		ereport(ERROR,
 				(errmsg("target LSN precedes the base cutoff")));
 
+	base_found = palloc0(np * sizeof(bool));
+	zeroed = palloc0(np * sizeof(bool));
+	truncated = palloc0(np * sizeof(bool));
 	slru_obj_key(&key, "pg_multixact/members");
 	for (int64 p = 0; p < np; p++)
 	{
-		bool		base_found;
-
-		base_found = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
+		base_found[p] = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
 												   (BlockNumber) (page_lo + p),
 												   (uint64) base_lsn,
 												   pages + p * BLCKSZ,
 												   &resolved) &&
 			resolved == (uint64) base_lsn;
-		present[p] = base_found;
-		if (!base_found)
+		present[p] = base_found[p];
+		if (!base_found[p])
 			memset(pages + p * BLCKSZ, 0, BLCKSZ);
 	}
 	if (target_lsn == base_lsn)
-		return true;
+		goto check_required_pages;
 
 	pd = palloc0(sizeof(*pd));
 	reader = XLogReaderAllocate(wal_segment_size, NULL,
@@ -2817,6 +2885,8 @@ ps_mxmemb_seed_reconstruct_range(char *pages, bool *present,
 				idx = zp - page_lo;
 				memset(pages + idx * BLCKSZ, 0, BLCKSZ);
 				present[idx] = true;
+				zeroed[idx] = true;
+				truncated[idx] = false;
 			}
 		}
 		else if (info == XLOG_MULTIXACT_CREATE_ID)
@@ -2852,7 +2922,10 @@ ps_mxmemb_seed_reconstruct_range(char *pages, bool *present,
 				if (ps_mxmemb_segment_truncated(segno,
 												xlrec.startTruncMemb,
 												xlrec.endTruncMemb))
+				{
 					present[p] = false;
+					truncated[p] = true;
+				}
 			}
 		}
 	}
@@ -2864,13 +2937,32 @@ ps_mxmemb_seed_reconstruct_range(char *pages, bool *present,
 				(errmsg("pagestore: WAL ends before the target LSN; cannot reconstruct multixact members as of %X/%08X",
 						LSN_FORMAT_ARGS(target_lsn))));
 
+check_required_pages:
+	for (int64 pageno = req_lo; pageno <= req_hi; pageno++)
+	{
+		int64		idx = pageno - page_lo;
+
+		if (truncated[idx])
+			ereport(ERROR,
+					(errmsg("pagestore: requested multixact members page %lld was truncated before the target LSN",
+							(long long) pageno)));
+		if (!base_found[idx] && !zeroed[idx])
+			ereport(ERROR,
+					(errmsg("pagestore: base members snapshot for page %lld is absent at %X/%08X",
+							(long long) pageno, LSN_FORMAT_ARGS(base_lsn))));
+	}
+
 	XLogReaderFree(reader);
 	pfree(pd);
+	pfree(truncated);
+	pfree(zeroed);
+	pfree(base_found);
 	return true;
 }
 
 typedef bool (*SlruPageRangeReconstructFn) (char *pages, bool *present,
 										   int64 page_lo, int64 page_hi,
+										   int64 req_lo, int64 req_hi,
 										   XLogRecPtr base_lsn,
 										   XLogRecPtr target_lsn);
 
@@ -2981,7 +3073,8 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 	present = palloc0(np * sizeof(bool));
 	for (p = 0; p < np; p++)
 		memset(pages + p * BLCKSZ, 0, BLCKSZ);
-	if (!reconstruct(pages, present, page_lo, page_hi, base, target))
+	if (!reconstruct(pages, present, page_lo, page_hi, req_lo, req_hi,
+					 base, target))
 	{
 		ereport(ERROR,
 				(errmsg("pagestore: failed to reconstruct %s pages in [%lld, %lld] as of %X/%08X",

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2479,7 +2479,7 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not clear branch staging dir \"%s\"", stagedir)));
-	if (MakePGDirectory(stagedir) != 0)
+	if (pg_mkdir_p(stagedir, pg_dir_create_mode) != 0 && errno != EEXIST)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch staging dir \"%s\": %m", stagedir)));

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2427,6 +2427,65 @@ typedef bool (*SlruPageReconstructFn) (char *page, int64 pageno,
 					 errmsg("branch target directory path is too long"))); \
 	} while (0)
 
+static void
+pagestore_write_zero_slru_page(const char *slru_dir, const char *label,
+							   int64 pageno)
+{
+	char		segpath[MAXPGPATH];
+	char		zerobuf[BLCKSZ];
+	int64		first = (pageno / SLRU_PAGES_PER_SEGMENT) * SLRU_PAGES_PER_SEGMENT;
+	int			pathlen;
+	int			fd;
+
+	pathlen = snprintf(segpath, sizeof(segpath), "%s/%04X", slru_dir,
+					   (unsigned int) (pageno / SLRU_PAGES_PER_SEGMENT));
+	PS_CHECK_PATH_FORMAT(pathlen, segpath);
+	fd = OpenTransientFilePerm(segpath,
+							   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
+							   pg_file_create_mode);
+	if (fd < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch %s bootstrap segment \"%s\": %m",
+						label, segpath)));
+	memset(zerobuf, 0, sizeof(zerobuf));
+	for (int64 p = first; p <= pageno; p++)
+	{
+		for (int done = 0; done < BLCKSZ;)
+		{
+			ssize_t		written;
+
+			errno = 0;
+			written = write(fd, zerobuf + done, BLCKSZ - done);
+			if (written <= 0)
+			{
+				if (written == 0)
+					errno = ENOSPC;
+				CloseTransientFile(fd);
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("could not write branch %s bootstrap segment \"%s\": %m",
+								label, segpath)));
+			}
+			done += written;
+		}
+	}
+	if (pg_fsync(fd) != 0)
+	{
+		CloseTransientFile(fd);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not fsync branch %s bootstrap segment \"%s\": %m",
+						label, segpath)));
+	}
+	if (CloseTransientFile(fd) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not close branch %s bootstrap segment \"%s\": %m",
+						label, segpath)));
+	fsync_fname(slru_dir, true);
+}
+
 static int64
 pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 						  int64 page_lo, int64 page_hi,
@@ -3056,7 +3115,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		if (oldest_multi < next_multi)
 		{
 			off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
-			off_page_hi = (int64) next_multi / PS_MXOFF_PER_PAGE;
+			off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
 			off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 													off_page_lo, off_page_hi,
 													ps_mxoff_reconstruct,
@@ -3073,7 +3132,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			if (next_multi > FirstMultiXactId)
 			{
 				off_page_lo = (int64) FirstMultiXactId / PS_MXOFF_PER_PAGE;
-				off_page_hi = (int64) next_multi / PS_MXOFF_PER_PAGE;
+				off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
 				off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 														off_page_lo, off_page_hi,
 														ps_mxoff_reconstruct,
@@ -3082,27 +3141,25 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			else
 			{
 				off_page_lo = (int64) next_multi / PS_MXOFF_PER_PAGE;
-				off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
-														off_page_lo, off_page_lo,
-														ps_mxoff_reconstruct,
-														base, target, "multixact offsets", false);
+				pagestore_write_zero_slru_page(offdir, "multixact offsets",
+											   off_page_lo);
+				off_seeded++;
 			}
 		}
 	}
 	else
 	{
 		off_page_lo = (int64) next_multi / PS_MXOFF_PER_PAGE;
-		off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
-												off_page_lo, off_page_lo,
-												ps_mxoff_reconstruct,
-												base, target, "multixact offsets", false);
+		pagestore_write_zero_slru_page(offdir, "multixact offsets",
+									   off_page_lo);
+		off_seeded++;
 	}
 	if (next_member != oldest_member)
 	{
 		if (oldest_member < next_member)
 		{
 			mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
-			mem_page_hi = next_member / PS_MXMEMB_PER_PAGE;
+			mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
 			mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 													mem_page_lo, mem_page_hi,
 													ps_mxmemb_reconstruct,
@@ -3119,7 +3176,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			if (next_member > 0)
 			{
 				mem_page_lo = 0;
-				mem_page_hi = next_member / PS_MXMEMB_PER_PAGE;
+				mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
 				mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 														mem_page_lo, mem_page_hi,
 														ps_mxmemb_reconstruct,
@@ -3127,20 +3184,17 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			}
 			else
 			{
-				mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
-														0, 0,
-														ps_mxmemb_reconstruct,
-														base, target, "multixact members", false);
+				pagestore_write_zero_slru_page(memdir, "multixact members", 0);
+				mem_seeded++;
 			}
 		}
 	}
 	else
 	{
 		mem_page_lo = next_member / PS_MXMEMB_PER_PAGE;
-		mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
-												mem_page_lo, mem_page_lo,
-												ps_mxmemb_reconstruct,
-												base, target, "multixact members", false);
+		pagestore_write_zero_slru_page(memdir, "multixact members",
+									   mem_page_lo);
+		mem_seeded++;
 	}
 	seeded += off_seeded + mem_seeded;
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2419,6 +2419,67 @@ typedef bool (*SlruPageReconstructFn) (char *page, int64 pageno,
 									   XLogRecPtr base_lsn,
 									   XLogRecPtr target_lsn);
 
+#define PS_CHECK_PATH_FORMAT(ret, buf) \
+	do { \
+		if ((ret) < 0 || (ret) >= (int) sizeof(buf)) \
+			ereport(ERROR, \
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE), \
+					 errmsg("branch target directory path is too long"))); \
+	} while (0)
+
+static void
+pagestore_write_zero_slru_bootstrap_page(const char *slru_dir, const char *label)
+{
+	char		segpath[MAXPGPATH];
+	char		zerobuf[BLCKSZ];
+	int			pathlen;
+	int			fd;
+
+	pathlen = snprintf(segpath, sizeof(segpath), "%s/%04X", slru_dir, 0);
+	PS_CHECK_PATH_FORMAT(pathlen, segpath);
+	fd = OpenTransientFilePerm(segpath,
+							   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
+							   pg_file_create_mode);
+	if (fd < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch %s bootstrap segment \"%s\": %m",
+						label, segpath)));
+	memset(zerobuf, 0, sizeof(zerobuf));
+	for (int done = 0; done < BLCKSZ;)
+	{
+		ssize_t		written;
+
+		errno = 0;
+		written = write(fd, zerobuf + done, BLCKSZ - done);
+		if (written <= 0)
+		{
+			if (written == 0)
+				errno = ENOSPC;
+			CloseTransientFile(fd);
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not write branch %s bootstrap segment \"%s\": %m",
+							label, segpath)));
+		}
+		done += written;
+	}
+	if (pg_fsync(fd) != 0)
+	{
+		CloseTransientFile(fd);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not fsync branch %s bootstrap segment \"%s\": %m",
+						label, segpath)));
+	}
+	if (CloseTransientFile(fd) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not close branch %s bootstrap segment \"%s\": %m",
+						label, segpath)));
+	fsync_fname(slru_dir, true);
+}
+
 static int64
 pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 						  int64 page_lo, int64 page_hi,
@@ -2438,6 +2499,7 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 				p;
 	int			np;
 	int64		seeded = 0;
+	int			pathlen;
 
 	if (page_hi < page_lo)
 		return 0;
@@ -2476,8 +2538,10 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
-	snprintf(dstdir, sizeof(dstdir), "%s/%s", target_dir, slru_dir);
-	snprintf(stagedir, sizeof(stagedir), "%s/%s.tmp", target_dir, slru_dir);
+	pathlen = snprintf(dstdir, sizeof(dstdir), "%s/%s", target_dir, slru_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, dstdir);
+	pathlen = snprintf(stagedir, sizeof(stagedir), "%s/%s.tmp", target_dir, slru_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, stagedir);
 
 	if (publish_dir)
 	{
@@ -2510,8 +2574,9 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 		if (trim_last < first)
 			continue;
 
-		snprintf(segpath, sizeof(segpath), "%s/%04X",
-				 publish_dir ? stagedir : dstdir, (unsigned int) seg);
+		pathlen = snprintf(segpath, sizeof(segpath), "%s/%04X",
+							publish_dir ? stagedir : dstdir, (unsigned int) seg);
+		PS_CHECK_PATH_FORMAT(pathlen, segpath);
 		fd = OpenTransientFilePerm(segpath,
 								   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
 								   pg_file_create_mode);
@@ -2983,6 +3048,9 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 				mxstage[MAXPGPATH],
 				offdir[MAXPGPATH],
 				memdir[MAXPGPATH];
+	int			pathlen;
+	int64		off_seeded = 0,
+				mem_seeded = 0;
 
 	if (!superuser())
 		ereport(ERROR,
@@ -3000,7 +3068,8 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errmsg("invalid fork multixact horizon [%u, %u)",
 						oldest_multi, next_multi)));
-	if (oldest_member < 0 || next_member < oldest_member ||
+	if (oldest_member < 0 || next_member < 0 ||
+		oldest_member > UINT32_MAX ||
 		next_member > UINT32_MAX)
 		ereport(ERROR,
 				(errmsg("invalid fork multixact member horizon [%lld, %lld)",
@@ -3010,10 +3079,14 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
-	snprintf(mxdir, sizeof(mxdir), "%s/pg_multixact", target_dir);
-	snprintf(mxstage, sizeof(mxstage), "%s/pg_multixact.tmp", target_dir);
-	snprintf(offdir, sizeof(offdir), "%s/offsets", mxstage);
-	snprintf(memdir, sizeof(memdir), "%s/members", mxstage);
+	pathlen = snprintf(mxdir, sizeof(mxdir), "%s/pg_multixact", target_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, mxdir);
+	pathlen = snprintf(mxstage, sizeof(mxstage), "%s/pg_multixact.tmp", target_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, mxstage);
+	pathlen = snprintf(offdir, sizeof(offdir), "%s/offsets", mxstage);
+	PS_CHECK_PATH_FORMAT(pathlen, offdir);
+	pathlen = snprintf(memdir, sizeof(memdir), "%s/members", mxstage);
+	PS_CHECK_PATH_FORMAT(pathlen, memdir);
 	if (access(mxstage, F_OK) == 0 && !rmtree(mxstage, true))
 		ereport(ERROR,
 				(errcode_for_file_access(),
@@ -3037,39 +3110,65 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		{
 			off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
 			off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
-			seeded += pagestore_seed_slru_pages(mxstage, "offsets",
-												off_page_lo, off_page_hi,
-												ps_mxoff_reconstruct,
-												base, target, "multixact offsets", false);
+			off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
+													off_page_lo, off_page_hi,
+													ps_mxoff_reconstruct,
+													base, target, "multixact offsets", false);
 		}
 		else
 		{
 			off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
 			off_page_hi = (int64) MaxMultiXactId / PS_MXOFF_PER_PAGE;
-			seeded += pagestore_seed_slru_pages(mxstage, "offsets",
-												off_page_lo, off_page_hi,
-												ps_mxoff_reconstruct,
-												base, target, "multixact offsets", false);
+			off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
+													off_page_lo, off_page_hi,
+													ps_mxoff_reconstruct,
+													base, target, "multixact offsets", false);
 			if (next_multi > FirstMultiXactId)
 			{
 				off_page_lo = (int64) FirstMultiXactId / PS_MXOFF_PER_PAGE;
 				off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
-				seeded += pagestore_seed_slru_pages(mxstage, "offsets",
-													off_page_lo, off_page_hi,
-													ps_mxoff_reconstruct,
-													base, target, "multixact offsets", false);
+				off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
+														off_page_lo, off_page_hi,
+														ps_mxoff_reconstruct,
+														base, target, "multixact offsets", false);
 			}
 		}
 	}
-	if (next_member > oldest_member)
+	if (next_member != oldest_member)
 	{
-		mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
-		mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
-		seeded += pagestore_seed_slru_pages(mxstage, "members",
-											mem_page_lo, mem_page_hi,
-											ps_mxmemb_reconstruct,
-											base, target, "multixact members", false);
+		if (oldest_member < next_member)
+		{
+			mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
+			mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
+			mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
+													mem_page_lo, mem_page_hi,
+													ps_mxmemb_reconstruct,
+													base, target, "multixact members", false);
+		}
+		else
+		{
+			mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
+			mem_page_hi = (int64) UINT32_MAX / PS_MXMEMB_PER_PAGE;
+			mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
+													mem_page_lo, mem_page_hi,
+													ps_mxmemb_reconstruct,
+													base, target, "multixact members", false);
+			if (next_member > 0)
+			{
+				mem_page_lo = 0;
+				mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
+				mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
+														mem_page_lo, mem_page_hi,
+														ps_mxmemb_reconstruct,
+														base, target, "multixact members", false);
+			}
+		}
 	}
+	if (off_seeded == 0)
+		pagestore_write_zero_slru_bootstrap_page(offdir, "multixact offsets");
+	if (mem_seeded == 0)
+		pagestore_write_zero_slru_bootstrap_page(memdir, "multixact members");
+	seeded += off_seeded + mem_seeded;
 
 	fsync_fname(mxstage, true);
 	if (access(mxdir, F_OK) == 0 && !rmtree(mxdir, true))

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2523,8 +2523,7 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 				ssize_t		written;
 
 				errno = 0;
-				written = pg_pwrite(fd, src + done, BLCKSZ - done,
-									(off_t) (p - first) * BLCKSZ + done);
+				written = write(fd, src + done, BLCKSZ - done);
 				if (written <= 0)
 				{
 					if (written == 0)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2578,7 +2578,6 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 						truncated[idx] = false;
 					}
 					commit_ts_active = true;
-					deactivated = false;
 				}
 			}
 			continue;
@@ -3013,7 +3012,7 @@ typedef bool (*SlruPageRangeReconstructFn) (char *pages, bool *present,
 					 errmsg("branch target directory path is too long"))); \
 	} while (0)
 
-static void
+static int64
 pagestore_write_zero_slru_page(const char *slru_dir, const char *label,
 							   int64 pageno)
 {
@@ -3070,6 +3069,7 @@ pagestore_write_zero_slru_page(const char *slru_dir, const char *label,
 				 errmsg("could not close branch %s bootstrap segment \"%s\": %m",
 						label, segpath)));
 	fsync_fname(slru_dir, true);
+	return pageno - first + 1;
 }
 
 static int64
@@ -3736,12 +3736,17 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 													off_page_lo, off_page_hi,
 													ps_mxoff_seed_reconstruct_range,
 													base, target, "multixact offsets", false);
-			if (next_multi > FirstMultiXactId)
+			if (next_multi >= FirstMultiXactId)
 			{
 				off_page_lo = (int64) FirstMultiXactId / PS_MXOFF_PER_PAGE;
-				off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
-				if (next_multi % PS_MXOFF_PER_PAGE == 0)
-					off_page_hi++;
+				if (next_multi == FirstMultiXactId)
+					off_page_hi = off_page_lo;
+				else
+				{
+					off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
+					if (next_multi % PS_MXOFF_PER_PAGE == 0)
+						off_page_hi++;
+				}
 				off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 													off_page_lo, off_page_hi,
 													ps_mxoff_seed_reconstruct_range,
@@ -3750,9 +3755,9 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			else
 			{
 				off_page_lo = (int64) next_multi / PS_MXOFF_PER_PAGE;
-				pagestore_write_zero_slru_page(offdir, "multixact offsets",
-											   off_page_lo);
-				off_seeded++;
+				off_seeded += pagestore_write_zero_slru_page(offdir,
+															 "multixact offsets",
+															 off_page_lo);
 			}
 		}
 	}
@@ -3764,11 +3769,12 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		 * simple-lru startup can read the page containing zero or wrap counters, and
 		 * preserve the page that tracks next_multi as the parent bootstrap state.
 		 */
-		pagestore_write_zero_slru_page(offdir, "multixact offsets",
-									   0);
-		pagestore_write_zero_slru_page(offdir, "multixact offsets",
-									   off_page_lo);
-		off_seeded += (off_page_lo == 0 ? 1 : 2);
+		off_seeded += pagestore_write_zero_slru_page(offdir,
+													 "multixact offsets", 0);
+		if (off_page_lo != 0)
+			off_seeded += pagestore_write_zero_slru_page(offdir,
+														 "multixact offsets",
+														 off_page_lo);
 	}
 	if (next_member != oldest_member)
 	{
@@ -3800,19 +3806,21 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			}
 			else
 			{
-				pagestore_write_zero_slru_page(memdir, "multixact members", 0);
-				mem_seeded++;
+				mem_seeded += pagestore_write_zero_slru_page(memdir,
+															 "multixact members",
+															 0);
 			}
 		}
 	}
 	else
 	{
 		mem_page_lo = next_member / PS_MXMEMB_PER_PAGE;
-		pagestore_write_zero_slru_page(memdir, "multixact members",
-									   0);
-		pagestore_write_zero_slru_page(memdir, "multixact members",
-									   mem_page_lo);
-		mem_seeded += (mem_page_lo == 0 ? 1 : 2);
+		mem_seeded += pagestore_write_zero_slru_page(memdir,
+													 "multixact members", 0);
+		if (mem_page_lo != 0)
+			mem_seeded += pagestore_write_zero_slru_page(memdir,
+														 "multixact members",
+														 mem_page_lo);
 	}
 	seeded += off_seeded + mem_seeded;
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2424,7 +2424,7 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 						  int64 page_lo, int64 page_hi,
 						  SlruPageReconstructFn reconstruct,
 						  XLogRecPtr base, XLogRecPtr target,
-						  const char *label)
+						  const char *label, bool publish_dir)
 {
 	char		dstdir[MAXPGPATH];
 	char		stagedir[MAXPGPATH];
@@ -2466,6 +2466,10 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 			continue;
 		}
 		present[p] = reconstruct(pages + p * BLCKSZ, pageno, base, target);
+		if (!present[p])
+			ereport(ERROR,
+					(errmsg("pagestore: requested %s page %lld was truncated before the target LSN",
+							label, (long long) pageno)));
 	}
 
 	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
@@ -2475,14 +2479,21 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 	snprintf(dstdir, sizeof(dstdir), "%s/%s", target_dir, slru_dir);
 	snprintf(stagedir, sizeof(stagedir), "%s/%s.tmp", target_dir, slru_dir);
 
-	if (access(stagedir, F_OK) == 0 && !rmtree(stagedir, true))
+	if (publish_dir)
+	{
+		if (access(stagedir, F_OK) == 0 && !rmtree(stagedir, true))
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not clear branch staging dir \"%s\"", stagedir)));
+		if (pg_mkdir_p(stagedir, pg_dir_create_mode) != 0 && errno != EEXIST)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not create branch staging dir \"%s\": %m", stagedir)));
+	}
+	else if (MakePGDirectory(dstdir) != 0 && errno != EEXIST)
 		ereport(ERROR,
 				(errcode_for_file_access(),
-				 errmsg("could not clear branch staging dir \"%s\"", stagedir)));
-	if (pg_mkdir_p(stagedir, pg_dir_create_mode) != 0 && errno != EEXIST)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not create branch staging dir \"%s\": %m", stagedir)));
+				 errmsg("could not create branch %s dir \"%s\": %m", label, dstdir)));
 
 	for (seg = seg_lo; seg <= seg_hi; seg++)
 	{
@@ -2499,7 +2510,8 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 		if (trim_last < first)
 			continue;
 
-		snprintf(segpath, sizeof(segpath), "%s/%04X", stagedir, (unsigned int) seg);
+		snprintf(segpath, sizeof(segpath), "%s/%04X",
+				 publish_dir ? stagedir : dstdir, (unsigned int) seg);
 		fd = OpenTransientFilePerm(segpath,
 								   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
 								   pg_file_create_mode);
@@ -2554,15 +2566,18 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 					 errmsg("could not close branch %s segment \"%s\": %m",
 							label, segpath)));
 	}
-	fsync_fname(stagedir, true);
-	if (access(dstdir, F_OK) == 0 && !rmtree(dstdir, true))
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not remove existing %s dir \"%s\"", label, dstdir)));
-	if (rename(stagedir, dstdir) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not publish branch %s dir \"%s\": %m", label, dstdir)));
+	fsync_fname(publish_dir ? stagedir : dstdir, true);
+	if (publish_dir)
+	{
+		if (access(dstdir, F_OK) == 0 && !rmtree(dstdir, true))
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not remove existing %s dir \"%s\"", label, dstdir)));
+		if (rename(stagedir, dstdir) != 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not publish branch %s dir \"%s\": %m", label, dstdir)));
+	}
 	fsync_fname(target_dir, true);
 
 	pfree(present);
@@ -2937,7 +2952,7 @@ pagestore_seed_commit_ts(PG_FUNCTION_ARGS)
 	PG_RETURN_INT64(pagestore_seed_slru_pages(target_dir, "pg_commit_ts",
 											 page_lo, page_hi,
 											 ps_commit_ts_reconstruct,
-											 base, target, "commit-ts"));
+											 base, target, "commit-ts", true));
 }
 
 /*
@@ -2964,7 +2979,10 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 				mem_page_lo,
 				mem_page_hi;
 	int64		seeded = 0;
-	char		mxdir[MAXPGPATH];
+	char		mxdir[MAXPGPATH],
+				mxstage[MAXPGPATH],
+				offdir[MAXPGPATH],
+				memdir[MAXPGPATH];
 
 	if (!superuser())
 		ereport(ERROR,
@@ -2977,7 +2995,8 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errmsg("target LSN precedes the base cutoff")));
 	if (!MultiXactIdIsValid(oldest_multi) || !MultiXactIdIsValid(next_multi) ||
-		oldest_multi > next_multi)
+		(oldest_multi != next_multi &&
+		 !MultiXactIdPrecedes(oldest_multi, next_multi)))
 		ereport(ERROR,
 				(errmsg("invalid fork multixact horizon [%u, %u)",
 						oldest_multi, next_multi)));
@@ -2992,31 +3011,76 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
 	snprintf(mxdir, sizeof(mxdir), "%s/pg_multixact", target_dir);
-	if (MakePGDirectory(mxdir) != 0 && errno != EEXIST)
+	snprintf(mxstage, sizeof(mxstage), "%s/pg_multixact.tmp", target_dir);
+	snprintf(offdir, sizeof(offdir), "%s/offsets", mxstage);
+	snprintf(memdir, sizeof(memdir), "%s/members", mxstage);
+	if (access(mxstage, F_OK) == 0 && !rmtree(mxstage, true))
 		ereport(ERROR,
 				(errcode_for_file_access(),
-				 errmsg("could not create branch multixact dir \"%s\": %m", mxdir)));
+				 errmsg("could not clear branch multixact staging dir \"%s\"", mxstage)));
+	if (MakePGDirectory(mxstage) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch multixact staging dir \"%s\": %m", mxstage)));
+	if (MakePGDirectory(offdir) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch multixact offsets dir \"%s\": %m", offdir)));
+	if (MakePGDirectory(memdir) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch multixact members dir \"%s\": %m", memdir)));
 
-	if (next_multi > oldest_multi)
+	if (oldest_multi != next_multi)
 	{
-		off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
-		off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
-		seeded += pagestore_seed_slru_pages(target_dir, "pg_multixact/offsets",
-											off_page_lo, off_page_hi,
-											ps_mxoff_reconstruct,
-											base, target, "multixact offsets");
+		if (oldest_multi < next_multi)
+		{
+			off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
+			off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
+			seeded += pagestore_seed_slru_pages(mxstage, "offsets",
+												off_page_lo, off_page_hi,
+												ps_mxoff_reconstruct,
+												base, target, "multixact offsets", false);
+		}
+		else
+		{
+			off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
+			off_page_hi = (int64) MaxMultiXactId / PS_MXOFF_PER_PAGE;
+			seeded += pagestore_seed_slru_pages(mxstage, "offsets",
+												off_page_lo, off_page_hi,
+												ps_mxoff_reconstruct,
+												base, target, "multixact offsets", false);
+			if (next_multi > FirstMultiXactId)
+			{
+				off_page_lo = (int64) FirstMultiXactId / PS_MXOFF_PER_PAGE;
+				off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
+				seeded += pagestore_seed_slru_pages(mxstage, "offsets",
+													off_page_lo, off_page_hi,
+													ps_mxoff_reconstruct,
+													base, target, "multixact offsets", false);
+			}
+		}
 	}
 	if (next_member > oldest_member)
 	{
 		mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
 		mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
-		seeded += pagestore_seed_slru_pages(target_dir, "pg_multixact/members",
+		seeded += pagestore_seed_slru_pages(mxstage, "members",
 											mem_page_lo, mem_page_hi,
 											ps_mxmemb_reconstruct,
-											base, target, "multixact members");
+											base, target, "multixact members", false);
 	}
 
-	fsync_fname(mxdir, true);
+	fsync_fname(mxstage, true);
+	if (access(mxdir, F_OK) == 0 && !rmtree(mxdir, true))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove existing branch multixact dir \"%s\"", mxdir)));
+	if (rename(mxstage, mxdir) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not publish branch multixact dir \"%s\": %m", mxdir)));
+	fsync_fname(target_dir, true);
 	PG_RETURN_INT64(seeded);
 }
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2439,7 +2439,6 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 	XLogRecPtr	scanned = base_lsn;
 	XLogRecPtr	readfrom;
 	int64		np = page_hi - page_lo + 1;
-	bool		deactivated = false;
 	XLogRecPtr	reached_from;
 	TransactionId xid;
 	TransactionId prepared_xid;
@@ -2563,7 +2562,6 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 				memcpy(&xlrec, XLogRecGetData(reader), sizeof(xlrec));
 				if (!xlrec.track_commit_timestamp)
 				{
-					deactivated = true;
 					commit_ts_active = false;
 				}
 				else
@@ -2621,9 +2619,6 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 		ereport(ERROR,
 				(errmsg("pagestore: WAL ends before the target LSN; cannot reconstruct commit-ts as of %X/%08X",
 						LSN_FORMAT_ARGS(target_lsn))));
-	if (deactivated)
-		ereport(ERROR,
-				(errmsg("pagestore: track_commit_timestamp was turned off in (base, target]; commit-ts reconstruction across a toggle is not supported")));
 
 check_required_pages:
 	for (int64 pageno = req_lo; pageno <= req_hi; pageno++)
@@ -2648,6 +2643,21 @@ check_required_pages:
 	pfree(zeroed);
 	pfree(base_found);
 	return true;
+}
+
+static bool
+ps_mxoff_page_precedes(int64 page1, int64 page2)
+{
+	MultiXactId multi1;
+	MultiXactId multi2;
+
+	multi1 = ((MultiXactId) page1) * PS_MXOFF_PER_PAGE;
+	multi1 += FirstMultiXactId + 1;
+	multi2 = ((MultiXactId) page2) * PS_MXOFF_PER_PAGE;
+	multi2 += FirstMultiXactId + 1;
+
+	return MultiXactIdPrecedes(multi1, multi2) &&
+		MultiXactIdPrecedes(multi1, multi2 + PS_MXOFF_PER_PAGE - 1);
 }
 
 /* Load and replay multixact offsets for all requested pages in one WAL pass, marking each
@@ -2738,7 +2748,16 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 
 			memcpy(&zp, XLogRecGetData(reader), sizeof(zp));
 			if (zp == pre_initialized_offsets_page)
+			{
+				if (zp >= page_lo && zp <= page_hi)
+				{
+					idx = zp - page_lo;
+					present[idx] = true;
+					zeroed[idx] = true;
+					truncated[idx] = false;
+				}
 				pre_initialized_offsets_page = -1;
+			}
 			else if (zp >= page_lo && zp <= page_hi)
 			{
 				idx = zp - page_lo;
@@ -2785,17 +2804,17 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 		{
 			xl_multixact_truncate xlrec;
 			MultiXactId cutoff;
-			int64		cutoff_seg;
+			int64		cutoff_page;
 
 			memcpy(&xlrec, XLogRecGetData(reader), SizeOfMultiXactTruncate);
 			cutoff = (xlrec.endTruncOff == FirstMultiXactId) ? MaxMultiXactId
 				: xlrec.endTruncOff - 1;
-			cutoff_seg = ((int64) cutoff / PS_MXOFF_PER_PAGE) / SLRU_PAGES_PER_SEGMENT;
+			cutoff_page = (int64) cutoff / PS_MXOFF_PER_PAGE;
 			for (int64 p = 0; p < np; p++)
 			{
-				int64		pageseg = (page_lo + p) / SLRU_PAGES_PER_SEGMENT;
+				int64		page = page_lo + p;
 
-				if (pageseg < cutoff_seg)
+				if (ps_mxoff_page_precedes(page, cutoff_page))
 				{
 					present[p] = false;
 					truncated[p] = true;

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2427,6 +2427,7 @@ pagestore_multixact_members_page_asof(PG_FUNCTION_ARGS)
 static bool
 ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 								   int64 page_hi, int64 req_lo, int64 req_hi,
+								   int64 horizon_lo, int64 horizon_hi,
 								   XLogRecPtr base_lsn,
 								   XLogRecPtr target_lsn)
 {
@@ -2445,6 +2446,8 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 	bool	   *base_found;
 	bool	   *zeroed;
 	bool	   *truncated;
+
+	(void) horizon_hi;
 
 	if (target_lsn < base_lsn)
 		ereport(ERROR,
@@ -2546,6 +2549,7 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 					}
 				}
 			}
+			continue;
 		}
 		else if (rmid == RM_XLOG_ID)
 		{
@@ -2556,6 +2560,14 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 				memcpy(&xlrec, XLogRecGetData(reader), sizeof(xlrec));
 				if (!xlrec.track_commit_timestamp)
 					deactivated = true;
+				else if (horizon_lo >= page_lo && horizon_lo <= page_hi)
+				{
+					idx = horizon_lo - page_lo;
+					memset(pages + idx * BLCKSZ, 0, BLCKSZ);
+					present[idx] = true;
+					zeroed[idx] = true;
+					truncated[idx] = false;
+				}
 			}
 			continue;
 		}
@@ -2617,8 +2629,10 @@ check_required_pages:
 							(long long) pageno, LSN_FORMAT_ARGS(base_lsn))));
 	}
 
-	XLogReaderFree(reader);
-	pfree(pd);
+	if (reader != NULL)
+		XLogReaderFree(reader);
+	if (pd != NULL)
+		pfree(pd);
 	pfree(truncated);
 	pfree(zeroed);
 	pfree(base_found);
@@ -2632,6 +2646,7 @@ static bool
 ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 								int64 page_lo, int64 page_hi,
 								int64 req_lo, int64 req_hi,
+								int64 horizon_lo, int64 horizon_hi,
 								XLogRecPtr base_lsn, XLogRecPtr target_lsn)
 {
 	PageStoreRelKey key;
@@ -2645,6 +2660,9 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 	bool	   *base_found;
 	bool	   *zeroed;
 	bool	   *truncated;
+
+	(void) horizon_lo;
+	(void) horizon_hi;
 
 	if (target_lsn < base_lsn)
 		ereport(ERROR,
@@ -2790,8 +2808,10 @@ check_required_pages:
 							(long long) pageno, LSN_FORMAT_ARGS(base_lsn))));
 	}
 
-	XLogReaderFree(reader);
-	pfree(pd);
+	if (reader != NULL)
+		XLogReaderFree(reader);
+	if (pd != NULL)
+		pfree(pd);
 	pfree(truncated);
 	pfree(zeroed);
 	pfree(base_found);
@@ -2805,6 +2825,7 @@ static bool
 ps_mxmemb_seed_reconstruct_range(char *pages, bool *present,
 								int64 page_lo, int64 page_hi,
 								int64 req_lo, int64 req_hi,
+								int64 horizon_lo, int64 horizon_hi,
 								XLogRecPtr base_lsn, XLogRecPtr target_lsn)
 {
 	PageStoreRelKey key;
@@ -2818,6 +2839,9 @@ ps_mxmemb_seed_reconstruct_range(char *pages, bool *present,
 	bool	   *base_found;
 	bool	   *zeroed;
 	bool	   *truncated;
+
+	(void) horizon_lo;
+	(void) horizon_hi;
 
 	if (target_lsn < base_lsn)
 		ereport(ERROR,
@@ -2952,8 +2976,10 @@ check_required_pages:
 							(long long) pageno, LSN_FORMAT_ARGS(base_lsn))));
 	}
 
-	XLogReaderFree(reader);
-	pfree(pd);
+	if (reader != NULL)
+		XLogReaderFree(reader);
+	if (pd != NULL)
+		pfree(pd);
 	pfree(truncated);
 	pfree(zeroed);
 	pfree(base_found);
@@ -2963,6 +2989,7 @@ check_required_pages:
 typedef bool (*SlruPageRangeReconstructFn) (char *pages, bool *present,
 										   int64 page_lo, int64 page_hi,
 										   int64 req_lo, int64 req_hi,
+										   int64 horizon_lo, int64 horizon_hi,
 										   XLogRecPtr base_lsn,
 										   XLogRecPtr target_lsn);
 
@@ -3042,15 +3069,12 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 {
 	char		dstdir[MAXPGPATH];
 	char		stagedir[MAXPGPATH];
-	char	   *pages;
-	bool	   *present;
 	int64		seg_lo,
 				seg_hi,
 				req_lo,
 				req_hi,
 				seg,
 				p;
-	int			np;
 	int64		seeded = 0;
 	int			pathlen;
 
@@ -3064,26 +3088,7 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 	req_lo = page_lo;
 	req_hi = page_hi;
 	seg_lo = req_lo / SLRU_PAGES_PER_SEGMENT;
-	page_lo = seg_lo * SLRU_PAGES_PER_SEGMENT;
 	seg_hi = req_hi / SLRU_PAGES_PER_SEGMENT;
-	page_hi = req_hi;
-	np = (int) (page_hi - page_lo + 1);
-
-	pages = palloc((Size) np * BLCKSZ);
-	present = palloc0(np * sizeof(bool));
-	for (p = 0; p < np; p++)
-		memset(pages + p * BLCKSZ, 0, BLCKSZ);
-	if (!reconstruct(pages, present, page_lo, page_hi, req_lo, req_hi,
-					 base, target))
-	{
-		ereport(ERROR,
-				(errmsg("pagestore: failed to reconstruct %s pages in [%lld, %lld] as of %X/%08X",
-						label, (long long) req_lo, (long long) req_hi,
-						LSN_FORMAT_ARGS(target))));
-	}
-	for (p = 0; p < np; p++)
-		if (page_lo + p < req_lo)
-			memset(pages + p * BLCKSZ, 0, BLCKSZ);
 
 	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
 		ereport(ERROR,
@@ -3115,15 +3120,47 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 		char		segpath[MAXPGPATH];
 		int64		first = seg * SLRU_PAGES_PER_SEGMENT;
 		int64		last = first + SLRU_PAGES_PER_SEGMENT - 1;
+		int64		chunk_req_lo;
+		int64		chunk_req_hi;
+		int			np;
+		char	   *pages;
+		bool	   *present;
 		int			fd;
 		int64		trim_last = last;
 
-		if (trim_last > page_hi)
-			trim_last = page_hi;
-		while (trim_last >= first && !present[trim_last - page_lo])
+		if (last > req_hi)
+			last = req_hi;
+		chunk_req_lo = Max(first, req_lo);
+		chunk_req_hi = Min(last, req_hi);
+		np = (int) (last - first + 1);
+
+		pages = palloc((Size) np * BLCKSZ);
+		present = palloc0(np * sizeof(bool));
+		for (p = 0; p < np; p++)
+			memset(pages + p * BLCKSZ, 0, BLCKSZ);
+		if (!reconstruct(pages, present, first, last,
+						 chunk_req_lo, chunk_req_hi,
+						 req_lo, req_hi, base, target))
+		{
+			ereport(ERROR,
+					(errmsg("pagestore: failed to reconstruct %s pages in [%lld, %lld] as of %X/%08X",
+							label, (long long) chunk_req_lo,
+							(long long) chunk_req_hi,
+							LSN_FORMAT_ARGS(target))));
+		}
+		for (p = 0; p < np; p++)
+			if (first + p < req_lo)
+				memset(pages + p * BLCKSZ, 0, BLCKSZ);
+
+		trim_last = last;
+		while (trim_last >= first && !present[trim_last - first])
 			trim_last--;
 		if (trim_last < first)
+		{
+			pfree(present);
+			pfree(pages);
 			continue;
+		}
 
 		pathlen = snprintf(segpath, sizeof(segpath), "%s/%04X",
 							publish_dir ? stagedir : dstdir, (unsigned int) seg);
@@ -3141,8 +3178,8 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 			const char *src;
 			char		zerobuf[BLCKSZ];
 
-			if (present[p - page_lo])
-				src = pages + (p - page_lo) * BLCKSZ;
+			if (present[p - first])
+				src = pages + (p - first) * BLCKSZ;
 			else
 			{
 				memset(zerobuf, 0, sizeof(zerobuf));
@@ -3181,6 +3218,8 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 					(errcode_for_file_access(),
 					 errmsg("could not close branch %s segment \"%s\": %m",
 							label, segpath)));
+		pfree(present);
+		pfree(pages);
 	}
 	fsync_fname(publish_dir ? stagedir : dstdir, true);
 	if (publish_dir)
@@ -3196,8 +3235,6 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 	}
 	fsync_fname(target_dir, true);
 
-	pfree(present);
-	pfree(pages);
 	return seeded;
 }
 
@@ -3721,12 +3758,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		if (oldest_member < next_member)
 		{
 			mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
-			/* include boundary page for next_member when it is the first slot on a new
-			 * members page so the branch can allocate the next multixact immediately.
-			 */
 			mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
-			if (next_member % PS_MXMEMB_PER_PAGE == 0)
-				mem_page_hi++;
 			mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 													mem_page_lo, mem_page_hi,
 													ps_mxmemb_seed_reconstruct_range,
@@ -3744,8 +3776,6 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			{
 				mem_page_lo = 0;
 				mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
-				if (next_member % PS_MXMEMB_PER_PAGE == 0)
-					mem_page_hi++;
 				mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 													mem_page_lo, mem_page_hi,
 													ps_mxmemb_seed_reconstruct_range,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2671,6 +2671,7 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 	bool	   *base_found;
 	bool	   *zeroed;
 	bool	   *truncated;
+	int64		pre_initialized_offsets_page = -1;
 
 	(void) horizon_lo;
 	(void) horizon_hi;
@@ -2736,7 +2737,9 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 			int64		idx;
 
 			memcpy(&zp, XLogRecGetData(reader), sizeof(zp));
-			if (zp >= page_lo && zp <= page_hi)
+			if (zp == pre_initialized_offsets_page)
+				pre_initialized_offsets_page = -1;
+			else if (zp >= page_lo && zp <= page_hi)
 			{
 				idx = zp - page_lo;
 				memset(pages + idx * BLCKSZ, 0, BLCKSZ);
@@ -2756,6 +2759,8 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 			if (next == 0)
 				next = 1;
 			succ = (xlrec->mid == MaxMultiXactId) ? FirstMultiXactId : xlrec->mid + 1;
+			if (pre_initialized_offsets_page != -1)
+				pre_initialized_offsets_page = -1;
 
 			mpageno = (int64) (xlrec->mid / PS_MXOFF_PER_PAGE);
 			if (mpageno >= page_lo && mpageno <= page_hi)
@@ -2773,6 +2778,8 @@ ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
 				ps_mxoff_set(pages + idx * BLCKSZ, mpageno, succ, next);
 				present[idx] = true;
 			}
+			if ((int64) (xlrec->mid / PS_MXOFF_PER_PAGE) != mpageno)
+				pre_initialized_offsets_page = mpageno;
 		}
 		else if (info == XLOG_MULTIXACT_TRUNCATE_ID)
 		{

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2446,6 +2446,7 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 	bool	   *base_found;
 	bool	   *zeroed;
 	bool	   *truncated;
+	bool		commit_ts_active = true;
 
 	(void) horizon_hi;
 
@@ -2471,6 +2472,8 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 		if (!base_found[p])
 			memset(pages + p * BLCKSZ, 0, BLCKSZ);
 	}
+	if (horizon_lo >= page_lo && horizon_lo <= page_hi)
+		commit_ts_active = base_found[horizon_lo - page_lo];
 
 	if (target_lsn == base_lsn)
 		goto check_required_pages;
@@ -2559,14 +2562,23 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 
 				memcpy(&xlrec, XLogRecGetData(reader), sizeof(xlrec));
 				if (!xlrec.track_commit_timestamp)
-					deactivated = true;
-				else if (horizon_lo >= page_lo && horizon_lo <= page_hi)
 				{
-					idx = horizon_lo - page_lo;
-					memset(pages + idx * BLCKSZ, 0, BLCKSZ);
-					present[idx] = true;
-					zeroed[idx] = true;
-					truncated[idx] = false;
+					deactivated = true;
+					commit_ts_active = false;
+				}
+				else
+				{
+					if (!commit_ts_active &&
+						horizon_lo >= page_lo && horizon_lo <= page_hi)
+					{
+						idx = horizon_lo - page_lo;
+						memset(pages + idx * BLCKSZ, 0, BLCKSZ);
+						present[idx] = true;
+						zeroed[idx] = true;
+						truncated[idx] = false;
+					}
+					commit_ts_active = true;
+					deactivated = false;
 				}
 			}
 			continue;
@@ -3595,8 +3607,13 @@ pagestore_seed_commit_ts(PG_FUNCTION_ARGS)
 		TransactionIdFollows(oldest_xid, next_xid))
 		ereport(ERROR,
 				(errmsg("invalid fork xid horizon [%u, %u)", oldest_xid, next_xid)));
-	page_lo = ((int64) oldest_xid / PS_CTS_XACTS_PER_PAGE);
-	page_hi = ((int64) (next_xid - 1)) / PS_CTS_XACTS_PER_PAGE;
+	if (oldest_xid == next_xid)
+		page_lo = page_hi = ((int64) next_xid / PS_CTS_XACTS_PER_PAGE);
+	else
+	{
+		page_lo = ((int64) oldest_xid / PS_CTS_XACTS_PER_PAGE);
+		page_hi = ((int64) (next_xid - 1)) / PS_CTS_XACTS_PER_PAGE;
+	}
 	if (page_hi < page_lo)
 		ereport(ERROR,
 				(errmsg("fork xid horizon [%u, %u) spans XID wraparound; commit-ts seeding across wrap is not supported",

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3068,7 +3068,8 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 	if (target < base)
 		ereport(ERROR,
 				(errmsg("target LSN precedes the base cutoff")));
-	if (!MultiXactIdIsValid(oldest_multi) || !MultiXactIdIsValid(next_multi) ||
+	if (!MultiXactIdIsValid(oldest_multi) ||
+		(next_multi != InvalidMultiXactId && !MultiXactIdIsValid(next_multi)) ||
 		(oldest_multi != next_multi &&
 		 !MultiXactIdPrecedes(oldest_multi, next_multi)))
 		ereport(ERROR,
@@ -3115,7 +3116,14 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		if (oldest_multi < next_multi)
 		{
 			off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
+			/* include boundary page for next_multi when it is the first entry on a new
+			 * offsets page so next allocation can safely read page_next_multi; this
+			 * page already exists in the parent and must be preserved for the branch.
+			 */
 			off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
+			if (next_multi != InvalidMultiXactId &&
+				next_multi % PS_MXOFF_PER_PAGE == 0)
+				off_page_hi++;
 			off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 													off_page_lo, off_page_hi,
 													ps_mxoff_reconstruct,
@@ -3133,6 +3141,8 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			{
 				off_page_lo = (int64) FirstMultiXactId / PS_MXOFF_PER_PAGE;
 				off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
+				if (next_multi % PS_MXOFF_PER_PAGE == 0)
+					off_page_hi++;
 				off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 														off_page_lo, off_page_hi,
 														ps_mxoff_reconstruct,
@@ -3150,16 +3160,28 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 	else
 	{
 		off_page_lo = (int64) next_multi / PS_MXOFF_PER_PAGE;
+		/*
+		 * Even when the fork has no live multixacts, bootstrap must preserve page 0 so
+		 * simple-lru startup can read the page containing zero or wrap counters, and
+		 * preserve the page that tracks next_multi as the parent bootstrap state.
+		 */
+		pagestore_write_zero_slru_page(offdir, "multixact offsets",
+									   0);
 		pagestore_write_zero_slru_page(offdir, "multixact offsets",
 									   off_page_lo);
-		off_seeded++;
+		off_seeded += (off_page_lo == 0 ? 1 : 2);
 	}
 	if (next_member != oldest_member)
 	{
 		if (oldest_member < next_member)
 		{
 			mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
+			/* include boundary page for next_member when it is the first slot on a new
+			 * members page so the branch can allocate the next multixact immediately.
+			 */
 			mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
+			if (next_member % PS_MXMEMB_PER_PAGE == 0)
+				mem_page_hi++;
 			mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 													mem_page_lo, mem_page_hi,
 													ps_mxmemb_reconstruct,
@@ -3177,6 +3199,8 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			{
 				mem_page_lo = 0;
 				mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
+				if (next_member % PS_MXMEMB_PER_PAGE == 0)
+					mem_page_hi++;
 				mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 														mem_page_lo, mem_page_hi,
 														ps_mxmemb_reconstruct,
@@ -3193,8 +3217,10 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 	{
 		mem_page_lo = next_member / PS_MXMEMB_PER_PAGE;
 		pagestore_write_zero_slru_page(memdir, "multixact members",
+									   0);
+		pagestore_write_zero_slru_page(memdir, "multixact members",
 									   mem_page_lo);
-		mem_seeded++;
+		mem_seeded += (mem_page_lo == 0 ? 1 : 2);
 	}
 	seeded += off_seeded + mem_seeded;
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2492,6 +2492,8 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 		int			fd;
 		int64		trim_last = last;
 
+		if (trim_last > page_hi)
+			trim_last = page_hi;
 		while (trim_last >= first && !present[trim_last - page_lo])
 			trim_last--;
 		if (trim_last < first)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2445,6 +2445,7 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 	bool	   *base_found;
 	bool	   *zeroed;
 	bool	   *truncated;
+	bool		deactivated = false;
 	bool		commit_ts_active = true;
 
 	(void) horizon_hi;
@@ -2562,6 +2563,7 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 				memcpy(&xlrec, XLogRecGetData(reader), sizeof(xlrec));
 				if (!xlrec.track_commit_timestamp)
 				{
+					deactivated = true;
 					commit_ts_active = false;
 				}
 				else
@@ -2619,6 +2621,9 @@ ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
 		ereport(ERROR,
 				(errmsg("pagestore: WAL ends before the target LSN; cannot reconstruct commit-ts as of %X/%08X",
 						LSN_FORMAT_ARGS(target_lsn))));
+	if (deactivated)
+		ereport(ERROR,
+				(errmsg("pagestore: track_commit_timestamp was turned off in (base, target]; commit-ts reconstruction across a toggle is not supported")));
 
 check_required_pages:
 	for (int64 pageno = req_lo; pageno <= req_hi; pageno++)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2518,14 +2518,24 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 				memset(zerobuf, 0, sizeof(zerobuf));
 				src = zerobuf;
 			}
-			if (pg_pwrite(fd, src, BLCKSZ,
-						  (off_t) (p - first) * BLCKSZ) != BLCKSZ)
+			for (int done = 0; done < BLCKSZ;)
 			{
-				CloseTransientFile(fd);
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not write branch %s segment \"%s\": %m",
-								label, segpath)));
+				ssize_t		written;
+
+				errno = 0;
+				written = pg_pwrite(fd, src + done, BLCKSZ - done,
+									(off_t) (p - first) * BLCKSZ + done);
+				if (written <= 0)
+				{
+					if (written == 0)
+						errno = ENOSPC;
+					CloseTransientFile(fd);
+					ereport(ERROR,
+							(errcode_for_file_access(),
+							 errmsg("could not write branch %s segment \"%s\": %m",
+									label, segpath)));
+				}
+				done += written;
 			}
 			seeded++;
 		}

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2415,9 +2415,464 @@ pagestore_multixact_members_page_asof(PG_FUNCTION_ARGS)
 	PG_RETURN_BYTEA_P(result);
 }
 
-typedef bool (*SlruPageReconstructFn) (char *page, int64 pageno,
-									   XLogRecPtr base_lsn,
-									   XLogRecPtr target_lsn);
+/* Load commit-ts pages in [page_lo, page_hi], replay (base, target] once, and mark each
+ * page as present when we have a known byte value for at least one slot.
+ */
+static bool
+ps_commit_ts_seed_reconstruct_range(char *pages, bool *present, int64 page_lo,
+								   int64 page_hi, XLogRecPtr base_lsn,
+								   XLogRecPtr target_lsn)
+{
+	PageStoreRelKey key;
+	ReadLocalXLogPageNoWaitPrivate *pd = NULL;
+	XLogReaderState *reader = NULL;
+	RmgrId		rmid;
+	char	   *errm = NULL;
+	XLogRecPtr	scanned = base_lsn;
+	XLogRecPtr	readfrom;
+	int64		np = page_hi - page_lo + 1;
+	bool		deactivated = false;
+	XLogRecPtr	reached_from;
+	TransactionId xid;
+	TransactionId prepared_xid;
+
+	if (target_lsn < base_lsn)
+		ereport(ERROR,
+				(errmsg("target LSN precedes the base cutoff")));
+
+	slru_obj_key(&key, "pg_commit_ts");
+	for (int64 p = 0; p < np; p++)
+	{
+		uint64		resolved = 0;
+		bool		base_found;
+
+		base_found = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
+												   (BlockNumber) (page_lo + p),
+												   (uint64) base_lsn,
+												   pages + p * BLCKSZ,
+												   &resolved) &&
+			resolved == (uint64) base_lsn;
+		present[p] = base_found;
+		if (!base_found)
+			memset(pages + p * BLCKSZ, 0, BLCKSZ);
+	}
+
+	if (target_lsn == base_lsn)
+		return true;
+
+	pd = palloc0(sizeof(*pd));
+	reader = XLogReaderAllocate(wal_segment_size, NULL,
+								XL_ROUTINE(.page_read = &read_local_xlog_page_no_wait,
+										   .segment_open = &wal_segment_open,
+										   .segment_close = &wal_segment_close),
+								pd);
+	if (reader == NULL)
+		ereport(ERROR, (errmsg("pagestore: could not allocate a WAL reader")));
+
+	{
+		XLogSegNo	segno;
+
+		XLByteToSeg(base_lsn, segno, wal_segment_size);
+		XLogSegNoOffsetToRecPtr(segno, 0, wal_segment_size, readfrom);
+	}
+	readfrom = XLogFindNextRecord(reader, readfrom);
+	reached_from = readfrom;
+	if (!XLogRecPtrIsInvalid(readfrom))
+		XLogBeginRead(reader, readfrom);
+	while (!XLogRecPtrIsInvalid(readfrom) && XLogReadRecord(reader, &errm) != NULL)
+	{
+		uint8		cinfo;
+		uint8		info;
+		int64		pageno;
+		int64		idx;
+		TimestampTz ts;
+		RepOriginId origin;
+		xl_xact_parsed_commit parsed;
+
+		if (reader->EndRecPtr > scanned)
+			scanned = reader->EndRecPtr;
+		if (reader->EndRecPtr > target_lsn)
+			break;
+		if (reader->EndRecPtr <= base_lsn)
+			continue;
+
+		rmid = XLogRecGetRmid(reader);
+		if (rmid == RM_COMMIT_TS_ID)
+		{
+			cinfo = XLogRecGetInfo(reader) & ~XLR_INFO_MASK;
+			if (cinfo == COMMIT_TS_ZEROPAGE)
+			{
+				int64		zp;
+
+				memcpy(&zp, XLogRecGetData(reader), sizeof(zp));
+				if (zp >= page_lo && zp <= page_hi)
+				{
+					idx = zp - page_lo;
+					memset(pages + idx * BLCKSZ, 0, BLCKSZ);
+					present[idx] = true;
+				}
+			}
+			else if (cinfo == COMMIT_TS_TRUNCATE)
+			{
+				xl_commit_ts_truncate xlrec;
+				int64		pageseg;
+				int64		cut_seg;
+
+				/* the record carries only SizeOfCommitTsTruncate bytes; sizeof() would
+				 * include trailing struct padding and read past the WAL payload */
+				memcpy(&xlrec, XLogRecGetData(reader), SizeOfCommitTsTruncate);
+				cut_seg = xlrec.pageno / SLRU_PAGES_PER_SEGMENT;
+				for (int64 p = 0; p < np; p++)
+				{
+					pageseg = (page_lo + p) / SLRU_PAGES_PER_SEGMENT;
+					if (pageseg < cut_seg)
+						present[p] = false;
+				}
+			}
+		}
+		else if (rmid == RM_XLOG_ID)
+		{
+			if ((XLogRecGetInfo(reader) & ~XLR_INFO_MASK) == XLOG_PARAMETER_CHANGE)
+			{
+				xl_parameter_change xlrec;
+
+				memcpy(&xlrec, XLogRecGetData(reader), sizeof(xlrec));
+				if (!xlrec.track_commit_timestamp)
+					deactivated = true;
+			}
+			continue;
+		}
+		else if (rmid != RM_XACT_ID)
+			continue;
+
+		info = XLogRecGetInfo(reader) & XLOG_XACT_OPMASK;
+		if (info != XLOG_XACT_COMMIT && info != XLOG_XACT_COMMIT_PREPARED)
+			continue;
+		ParseCommitRecord(XLogRecGetInfo(reader),
+						 (xl_xact_commit *) XLogRecGetData(reader), &parsed);
+		ts = (parsed.xinfo & XACT_XINFO_HAS_ORIGIN) ? parsed.origin_timestamp
+			: parsed.xact_time;
+		origin = XLogRecGetOrigin(reader);
+		prepared_xid = parsed.twophase_xid;
+		xid = (info == XLOG_XACT_COMMIT_PREPARED) ? prepared_xid : XLogRecGetXid(reader);
+		pageno = (int64) xid / PS_CTS_XACTS_PER_PAGE;
+		if (pageno >= page_lo && pageno <= page_hi)
+		{
+			idx = pageno - page_lo;
+			ps_commit_ts_set(pages + idx * BLCKSZ, pageno, xid, ts, origin);
+			present[idx] = true;
+		}
+		for (int i = 0; i < parsed.nsubxacts; i++)
+		{
+			xid = parsed.subxacts[i];
+			pageno = (int64) xid / PS_CTS_XACTS_PER_PAGE;
+			if (pageno >= page_lo && pageno <= page_hi)
+			{
+				idx = pageno - page_lo;
+				ps_commit_ts_set(pages + idx * BLCKSZ, pageno, xid, ts, origin);
+				present[idx] = true;
+			}
+		}
+	}
+
+	if (scanned < target_lsn && target_lsn != PG_UINT64_MAX &&
+		(XLogRecPtrIsInvalid(reached_from) || errm != NULL ||
+		 ps_local_wal_limit() < target_lsn))
+		ereport(ERROR,
+				(errmsg("pagestore: WAL ends before the target LSN; cannot reconstruct commit-ts as of %X/%08X",
+						LSN_FORMAT_ARGS(target_lsn))));
+	if (deactivated)
+		ereport(ERROR,
+				(errmsg("pagestore: track_commit_timestamp was turned off in (base, target]; commit-ts reconstruction across a toggle is not supported")));
+
+	XLogReaderFree(reader);
+	pfree(pd);
+	return true;
+}
+
+/* Load and replay multixact offsets for all requested pages in one WAL pass, marking each
+ * requested page as present when any content is known.
+ */
+static bool
+ps_mxoff_seed_reconstruct_range(char *pages, bool *present,
+								int64 page_lo, int64 page_hi,
+								XLogRecPtr base_lsn, XLogRecPtr target_lsn)
+{
+	PageStoreRelKey key;
+	ReadLocalXLogPageNoWaitPrivate *pd = NULL;
+	XLogReaderState *reader = NULL;
+	char	   *errm = NULL;
+	XLogRecPtr	scanned = base_lsn;
+	XLogRecPtr	readfrom;
+	int64		np = page_hi - page_lo + 1;
+	uint64		resolved = 0;
+
+	if (target_lsn < base_lsn)
+		ereport(ERROR,
+				(errmsg("target LSN precedes the base cutoff")));
+
+	slru_obj_key(&key, "pg_multixact/offsets");
+	for (int64 p = 0; p < np; p++)
+	{
+		bool		base_found;
+
+		base_found = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
+												   (BlockNumber) (page_lo + p),
+												   (uint64) base_lsn,
+												   pages + p * BLCKSZ,
+												   &resolved) &&
+			resolved == (uint64) base_lsn;
+		present[p] = base_found;
+		if (!base_found)
+			memset(pages + p * BLCKSZ, 0, BLCKSZ);
+	}
+	if (target_lsn == base_lsn)
+		return true;
+
+	pd = palloc0(sizeof(*pd));
+	reader = XLogReaderAllocate(wal_segment_size, NULL,
+								XL_ROUTINE(.page_read = &read_local_xlog_page_no_wait,
+										   .segment_open = &wal_segment_open,
+										   .segment_close = &wal_segment_close),
+								pd);
+	if (reader == NULL)
+		ereport(ERROR, (errmsg("pagestore: could not allocate a WAL reader")));
+
+	{
+		XLogSegNo	segno;
+
+		XLByteToSeg(base_lsn, segno, wal_segment_size);
+		XLogSegNoOffsetToRecPtr(segno, 0, wal_segment_size, readfrom);
+	}
+	readfrom = XLogFindNextRecord(reader, readfrom);
+	if (!XLogRecPtrIsInvalid(readfrom))
+		XLogBeginRead(reader, readfrom);
+	while (!XLogRecPtrIsInvalid(readfrom) && XLogReadRecord(reader, &errm) != NULL)
+	{
+		uint8		info;
+
+		if (reader->EndRecPtr > scanned)
+			scanned = reader->EndRecPtr;
+		if (reader->EndRecPtr > target_lsn)
+			break;
+		if (reader->EndRecPtr <= base_lsn)
+			continue;
+		if (XLogRecGetRmid(reader) != RM_MULTIXACT_ID)
+			continue;
+		info = XLogRecGetInfo(reader) & XLR_RMGR_INFO_MASK;
+
+		if (info == XLOG_MULTIXACT_ZERO_OFF_PAGE)
+		{
+			int64		zp;
+			int64		idx;
+
+			memcpy(&zp, XLogRecGetData(reader), sizeof(zp));
+			if (zp >= page_lo && zp <= page_hi)
+			{
+				idx = zp - page_lo;
+				memset(pages + idx * BLCKSZ, 0, BLCKSZ);
+				present[idx] = true;
+			}
+		}
+		else if (info == XLOG_MULTIXACT_CREATE_ID)
+		{
+			xl_multixact_create *xlrec =
+				(xl_multixact_create *) XLogRecGetData(reader);
+			MultiXactOffset next = xlrec->moff + xlrec->nmembers;
+			MultiXactId succ;
+			int64		mpageno;
+
+			if (next == 0)
+				next = 1;
+			succ = (xlrec->mid == MaxMultiXactId) ? FirstMultiXactId : xlrec->mid + 1;
+
+			mpageno = (int64) (xlrec->mid / PS_MXOFF_PER_PAGE);
+			if (mpageno >= page_lo && mpageno <= page_hi)
+			{
+				int64	 idx = mpageno - page_lo;
+
+				ps_mxoff_set(pages + idx * BLCKSZ, mpageno, xlrec->mid, xlrec->moff);
+				present[idx] = true;
+			}
+			mpageno = (int64) (succ / PS_MXOFF_PER_PAGE);
+			if (mpageno >= page_lo && mpageno <= page_hi)
+			{
+				int64	 idx = mpageno - page_lo;
+
+				ps_mxoff_set(pages + idx * BLCKSZ, mpageno, succ, next);
+				present[idx] = true;
+			}
+		}
+		else if (info == XLOG_MULTIXACT_TRUNCATE_ID)
+		{
+			xl_multixact_truncate xlrec;
+			MultiXactId cutoff;
+			int64		cutoff_seg;
+
+			memcpy(&xlrec, XLogRecGetData(reader), SizeOfMultiXactTruncate);
+			cutoff = (xlrec.endTruncOff == FirstMultiXactId) ? MaxMultiXactId
+				: xlrec.endTruncOff - 1;
+			cutoff_seg = ((int64) cutoff / PS_MXOFF_PER_PAGE) / SLRU_PAGES_PER_SEGMENT;
+			for (int64 p = 0; p < np; p++)
+			{
+				int64		pageseg = (page_lo + p) / SLRU_PAGES_PER_SEGMENT;
+
+				if (pageseg < cutoff_seg)
+					present[p] = false;
+			}
+		}
+	}
+
+	if (scanned < target_lsn && target_lsn != PG_UINT64_MAX &&
+		(XLogRecPtrIsInvalid(readfrom) || errm != NULL ||
+		 ps_local_wal_limit() < target_lsn))
+		ereport(ERROR,
+				(errmsg("pagestore: WAL ends before the target LSN; cannot reconstruct multixact offsets as of %X/%08X",
+						LSN_FORMAT_ARGS(target_lsn))));
+
+	XLogReaderFree(reader);
+	pfree(pd);
+	return true;
+}
+
+/* Load and replay multixact members for all requested pages in one WAL pass, marking each
+ * requested page as present when any content is known.
+ */
+static bool
+ps_mxmemb_seed_reconstruct_range(char *pages, bool *present,
+								int64 page_lo, int64 page_hi,
+								XLogRecPtr base_lsn, XLogRecPtr target_lsn)
+{
+	PageStoreRelKey key;
+	ReadLocalXLogPageNoWaitPrivate *pd = NULL;
+	XLogReaderState *reader = NULL;
+	char	   *errm = NULL;
+	XLogRecPtr	scanned = base_lsn;
+	XLogRecPtr	readfrom;
+	int64		np = page_hi - page_lo + 1;
+	uint64		resolved = 0;
+
+	if (target_lsn < base_lsn)
+		ereport(ERROR,
+				(errmsg("target LSN precedes the base cutoff")));
+
+	slru_obj_key(&key, "pg_multixact/members");
+	for (int64 p = 0; p < np; p++)
+	{
+		bool		base_found;
+
+		base_found = pagestore_localsvc_obj_read_at(PS_KLASS_SLRU, &key,
+												   (BlockNumber) (page_lo + p),
+												   (uint64) base_lsn,
+												   pages + p * BLCKSZ,
+												   &resolved) &&
+			resolved == (uint64) base_lsn;
+		present[p] = base_found;
+		if (!base_found)
+			memset(pages + p * BLCKSZ, 0, BLCKSZ);
+	}
+	if (target_lsn == base_lsn)
+		return true;
+
+	pd = palloc0(sizeof(*pd));
+	reader = XLogReaderAllocate(wal_segment_size, NULL,
+								XL_ROUTINE(.page_read = &read_local_xlog_page_no_wait,
+										   .segment_open = &wal_segment_open,
+										   .segment_close = &wal_segment_close),
+								pd);
+	if (reader == NULL)
+		ereport(ERROR, (errmsg("pagestore: could not allocate a WAL reader")));
+
+	{
+		XLogSegNo	segno;
+
+		XLByteToSeg(base_lsn, segno, wal_segment_size);
+		XLogSegNoOffsetToRecPtr(segno, 0, wal_segment_size, readfrom);
+	}
+	readfrom = XLogFindNextRecord(reader, readfrom);
+	if (!XLogRecPtrIsInvalid(readfrom))
+		XLogBeginRead(reader, readfrom);
+	while (!XLogRecPtrIsInvalid(readfrom) && XLogReadRecord(reader, &errm) != NULL)
+	{
+		uint8		info;
+
+		if (reader->EndRecPtr > scanned)
+			scanned = reader->EndRecPtr;
+		if (reader->EndRecPtr > target_lsn)
+			break;
+		if (reader->EndRecPtr <= base_lsn)
+			continue;
+		if (XLogRecGetRmid(reader) != RM_MULTIXACT_ID)
+			continue;
+		info = XLogRecGetInfo(reader) & XLR_RMGR_INFO_MASK;
+
+		if (info == XLOG_MULTIXACT_ZERO_MEM_PAGE)
+		{
+			int64		zp;
+			int64		idx;
+
+			memcpy(&zp, XLogRecGetData(reader), sizeof(zp));
+			if (zp >= page_lo && zp <= page_hi)
+			{
+				idx = zp - page_lo;
+				memset(pages + idx * BLCKSZ, 0, BLCKSZ);
+				present[idx] = true;
+			}
+		}
+		else if (info == XLOG_MULTIXACT_CREATE_ID)
+		{
+			xl_multixact_create *xlrec =
+				(xl_multixact_create *) XLogRecGetData(reader);
+
+			for (int i = 0; i < xlrec->nmembers; i++)
+			{
+				int64		pageno = (xlrec->moff + i) / PS_MXMEMB_PER_PAGE;
+
+				if (pageno >= page_lo && pageno <= page_hi)
+				{
+					int64		idx = pageno - page_lo;
+
+					ps_mxmemb_set(pages + idx * BLCKSZ, pageno,
+								  xlrec->moff + i,
+								  xlrec->members[i].xid,
+								  (uint32) xlrec->members[i].status);
+					present[idx] = true;
+				}
+			}
+		}
+		else if (info == XLOG_MULTIXACT_TRUNCATE_ID)
+		{
+			xl_multixact_truncate xlrec;
+
+			memcpy(&xlrec, XLogRecGetData(reader), SizeOfMultiXactTruncate);
+			for (int64 p = 0; p < np; p++)
+			{
+				int64		segno = (page_lo + p) / SLRU_PAGES_PER_SEGMENT;
+
+				if (ps_mxmemb_segment_truncated(segno,
+												xlrec.startTruncMemb,
+												xlrec.endTruncMemb))
+					present[p] = false;
+			}
+		}
+	}
+
+	if (scanned < target_lsn && target_lsn != PG_UINT64_MAX &&
+		(XLogRecPtrIsInvalid(readfrom) || errm != NULL ||
+		 ps_local_wal_limit() < target_lsn))
+		ereport(ERROR,
+				(errmsg("pagestore: WAL ends before the target LSN; cannot reconstruct multixact members as of %X/%08X",
+						LSN_FORMAT_ARGS(target_lsn))));
+
+	XLogReaderFree(reader);
+	pfree(pd);
+	return true;
+}
+
+typedef bool (*SlruPageRangeReconstructFn) (char *pages, bool *present,
+										   int64 page_lo, int64 page_hi,
+										   XLogRecPtr base_lsn,
+										   XLogRecPtr target_lsn);
 
 #define PS_CHECK_PATH_FORMAT(ret, buf) \
 	do { \
@@ -2489,7 +2944,7 @@ pagestore_write_zero_slru_page(const char *slru_dir, const char *label,
 static int64
 pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 						  int64 page_lo, int64 page_hi,
-						  SlruPageReconstructFn reconstruct,
+						  SlruPageRangeReconstructFn reconstruct,
 						  XLogRecPtr base, XLogRecPtr target,
 						  const char *label, bool publish_dir)
 {
@@ -2525,20 +2980,17 @@ pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 	pages = palloc((Size) np * BLCKSZ);
 	present = palloc0(np * sizeof(bool));
 	for (p = 0; p < np; p++)
+		memset(pages + p * BLCKSZ, 0, BLCKSZ);
+	if (!reconstruct(pages, present, page_lo, page_hi, base, target))
 	{
-		int64		pageno = page_lo + p;
-
-		if (pageno < req_lo)
-		{
-			memset(pages + p * BLCKSZ, 0, BLCKSZ);
-			continue;
-		}
-		present[p] = reconstruct(pages + p * BLCKSZ, pageno, base, target);
-		if (!present[p])
-			ereport(ERROR,
-					(errmsg("pagestore: requested %s page %lld was truncated before the target LSN",
-							label, (long long) pageno)));
+		ereport(ERROR,
+				(errmsg("pagestore: failed to reconstruct %s pages in [%lld, %lld] as of %X/%08X",
+						label, (long long) req_lo, (long long) req_hi,
+						LSN_FORMAT_ARGS(target))));
 	}
+	for (p = 0; p < np; p++)
+		if (page_lo + p < req_lo)
+			memset(pages + p * BLCKSZ, 0, BLCKSZ);
 
 	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
 		ereport(ERROR,
@@ -3022,7 +3474,7 @@ pagestore_seed_commit_ts(PG_FUNCTION_ARGS)
 
 	PG_RETURN_INT64(pagestore_seed_slru_pages(target_dir, "pg_commit_ts",
 											 page_lo, page_hi,
-											 ps_commit_ts_reconstruct,
+											 ps_commit_ts_seed_reconstruct_range,
 											 base, target, "commit-ts", true));
 }
 
@@ -3126,7 +3578,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 				off_page_hi++;
 			off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 													off_page_lo, off_page_hi,
-													ps_mxoff_reconstruct,
+													ps_mxoff_seed_reconstruct_range,
 													base, target, "multixact offsets", false);
 		}
 		else
@@ -3135,7 +3587,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			off_page_hi = (int64) MaxMultiXactId / PS_MXOFF_PER_PAGE;
 			off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 													off_page_lo, off_page_hi,
-													ps_mxoff_reconstruct,
+													ps_mxoff_seed_reconstruct_range,
 													base, target, "multixact offsets", false);
 			if (next_multi > FirstMultiXactId)
 			{
@@ -3144,9 +3596,9 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 				if (next_multi % PS_MXOFF_PER_PAGE == 0)
 					off_page_hi++;
 				off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
-														off_page_lo, off_page_hi,
-														ps_mxoff_reconstruct,
-														base, target, "multixact offsets", false);
+													off_page_lo, off_page_hi,
+													ps_mxoff_seed_reconstruct_range,
+													base, target, "multixact offsets", false);
 			}
 			else
 			{
@@ -3184,7 +3636,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 				mem_page_hi++;
 			mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 													mem_page_lo, mem_page_hi,
-													ps_mxmemb_reconstruct,
+													ps_mxmemb_seed_reconstruct_range,
 													base, target, "multixact members", false);
 		}
 		else
@@ -3193,7 +3645,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			mem_page_hi = (int64) UINT32_MAX / PS_MXMEMB_PER_PAGE;
 			mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 													mem_page_lo, mem_page_hi,
-													ps_mxmemb_reconstruct,
+													ps_mxmemb_seed_reconstruct_range,
 													base, target, "multixact members", false);
 			if (next_member > 0)
 			{
@@ -3202,9 +3654,9 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 				if (next_member % PS_MXMEMB_PER_PAGE == 0)
 					mem_page_hi++;
 				mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
-														mem_page_lo, mem_page_hi,
-														ps_mxmemb_reconstruct,
-														base, target, "multixact members", false);
+													mem_page_lo, mem_page_hi,
+													ps_mxmemb_seed_reconstruct_range,
+													base, target, "multixact members", false);
 			}
 			else
 			{

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -2427,59 +2427,6 @@ typedef bool (*SlruPageReconstructFn) (char *page, int64 pageno,
 					 errmsg("branch target directory path is too long"))); \
 	} while (0)
 
-static void
-pagestore_write_zero_slru_bootstrap_page(const char *slru_dir, const char *label)
-{
-	char		segpath[MAXPGPATH];
-	char		zerobuf[BLCKSZ];
-	int			pathlen;
-	int			fd;
-
-	pathlen = snprintf(segpath, sizeof(segpath), "%s/%04X", slru_dir, 0);
-	PS_CHECK_PATH_FORMAT(pathlen, segpath);
-	fd = OpenTransientFilePerm(segpath,
-							   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
-							   pg_file_create_mode);
-	if (fd < 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not create branch %s bootstrap segment \"%s\": %m",
-						label, segpath)));
-	memset(zerobuf, 0, sizeof(zerobuf));
-	for (int done = 0; done < BLCKSZ;)
-	{
-		ssize_t		written;
-
-		errno = 0;
-		written = write(fd, zerobuf + done, BLCKSZ - done);
-		if (written <= 0)
-		{
-			if (written == 0)
-				errno = ENOSPC;
-			CloseTransientFile(fd);
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not write branch %s bootstrap segment \"%s\": %m",
-							label, segpath)));
-		}
-		done += written;
-	}
-	if (pg_fsync(fd) != 0)
-	{
-		CloseTransientFile(fd);
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not fsync branch %s bootstrap segment \"%s\": %m",
-						label, segpath)));
-	}
-	if (CloseTransientFile(fd) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not close branch %s bootstrap segment \"%s\": %m",
-						label, segpath)));
-	fsync_fname(slru_dir, true);
-}
-
 static int64
 pagestore_seed_slru_pages(const char *target_dir, const char *slru_dir,
 						  int64 page_lo, int64 page_hi,
@@ -3109,7 +3056,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 		if (oldest_multi < next_multi)
 		{
 			off_page_lo = (int64) oldest_multi / PS_MXOFF_PER_PAGE;
-			off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
+			off_page_hi = (int64) next_multi / PS_MXOFF_PER_PAGE;
 			off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 													off_page_lo, off_page_hi,
 													ps_mxoff_reconstruct,
@@ -3126,20 +3073,36 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			if (next_multi > FirstMultiXactId)
 			{
 				off_page_lo = (int64) FirstMultiXactId / PS_MXOFF_PER_PAGE;
-				off_page_hi = (int64) (next_multi - 1) / PS_MXOFF_PER_PAGE;
+				off_page_hi = (int64) next_multi / PS_MXOFF_PER_PAGE;
 				off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
 														off_page_lo, off_page_hi,
 														ps_mxoff_reconstruct,
 														base, target, "multixact offsets", false);
 			}
+			else
+			{
+				off_page_lo = (int64) next_multi / PS_MXOFF_PER_PAGE;
+				off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
+														off_page_lo, off_page_lo,
+														ps_mxoff_reconstruct,
+														base, target, "multixact offsets", false);
+			}
 		}
+	}
+	else
+	{
+		off_page_lo = (int64) next_multi / PS_MXOFF_PER_PAGE;
+		off_seeded += pagestore_seed_slru_pages(mxstage, "offsets",
+												off_page_lo, off_page_lo,
+												ps_mxoff_reconstruct,
+												base, target, "multixact offsets", false);
 	}
 	if (next_member != oldest_member)
 	{
 		if (oldest_member < next_member)
 		{
 			mem_page_lo = oldest_member / PS_MXMEMB_PER_PAGE;
-			mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
+			mem_page_hi = next_member / PS_MXMEMB_PER_PAGE;
 			mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 													mem_page_lo, mem_page_hi,
 													ps_mxmemb_reconstruct,
@@ -3156,18 +3119,29 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 			if (next_member > 0)
 			{
 				mem_page_lo = 0;
-				mem_page_hi = (next_member - 1) / PS_MXMEMB_PER_PAGE;
+				mem_page_hi = next_member / PS_MXMEMB_PER_PAGE;
 				mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
 														mem_page_lo, mem_page_hi,
 														ps_mxmemb_reconstruct,
 														base, target, "multixact members", false);
 			}
+			else
+			{
+				mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
+														0, 0,
+														ps_mxmemb_reconstruct,
+														base, target, "multixact members", false);
+			}
 		}
 	}
-	if (off_seeded == 0)
-		pagestore_write_zero_slru_bootstrap_page(offdir, "multixact offsets");
-	if (mem_seeded == 0)
-		pagestore_write_zero_slru_bootstrap_page(memdir, "multixact members");
+	else
+	{
+		mem_page_lo = next_member / PS_MXMEMB_PER_PAGE;
+		mem_seeded += pagestore_seed_slru_pages(mxstage, "members",
+												mem_page_lo, mem_page_lo,
+												ps_mxmemb_reconstruct,
+												base, target, "multixact members", false);
+	}
 	seeded += off_seeded + mem_seeded;
 
 	fsync_fname(mxstage, true);


### PR DESCRIPTION
Phase 1 / M4 correctness follow-up.\n\nAdds branch-datadir seed materialization for the remaining WAL-logged SLRUs after clog:\n\n- pagestore_seed_commit_ts(target_dir, base, target, oldest_xid, next_xid)\n- pagestore_seed_multixact(target_dir, base, target, oldest_multi, next_multi, oldest_member, next_member)\n- pagestore_commit_ts_page_asof() for byte-for-byte seed verification\n\nThe integration test now verifies that commit-ts and multixact offsets/members are materialized into branch SLRU files and match the reconstructed as-of-L pages.\n\nThis advances the stage-1 branch boot path: base SLRU snapshot + WAL replay can now materialize clog, commit-ts, and both multixact SLRUs into a branch data directory.