### PR TITLE
pagestore: add branch bootstrap SLRU seeder

### DIFF
--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -486,6 +486,8 @@ $P -c "CREATE FUNCTION pagestore_multixact_offset_asof(xid, pg_lsn, pg_lsn) RETU
 $P -c "CREATE TABLE mx(id int primary key, note text) TABLESPACE ts; INSERT INTO mx VALUES (1,'a');" >/dev/null
 $P -c "CHECKPOINT;" >/dev/null
 mxC=$($P -c "SELECT pg_current_wal_lsn();")                       # base cutoff C
+$P -c "SELECT pagestore_ship_slru_snapshot('pg_xact', '$mxC');" >/dev/null
+$P -c "SELECT pagestore_ship_slru_snapshot('pg_commit_ts', '$mxC');" >/dev/null
 $P -c "SELECT pagestore_ship_slru_snapshot('pg_multixact/offsets', '$mxC');" >/dev/null
 $P -c "SELECT pagestore_ship_slru_snapshot('pg_multixact/members', '$mxC');" >/dev/null
 # session A holds a FOR SHARE lock across the second locker
@@ -533,7 +535,9 @@ assert "$mxRP" "$mxLP" "multixact offsets: reconstructed page as-of L == the par
 $P -c "CREATE FUNCTION pagestore_multixact_members_page_asof(int, pg_lsn, pg_lsn) RETURNS bytea
         AS 'pagestore','pagestore_multixact_members_page_asof' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_seed_multixact(text, pg_lsn, pg_lsn, xid, xid, bigint, bigint) RETURNS bigint
-        AS 'pagestore','pagestore_seed_multixact' LANGUAGE C STRICT;" >/dev/null
+        AS 'pagestore','pagestore_seed_multixact' LANGUAGE C STRICT;
+       CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
+        AS 'pagestore','pagestore_seed_branch_slrus' LANGUAGE C STRICT;" >/dev/null
 mOff=$mxRecon                                          # mA's first member offset (step 20)
 # MULTIXACT_MEMBERS_PER_PAGE = (block_size / MULTIXACT_MEMBERGROUP_SIZE) * members-per-group;
 # the group is 4 flag bytes + 4 TransactionIds = 20 bytes, 4 members each (block-size derived)
@@ -560,6 +564,31 @@ mxSeedMem=$($P -c "SELECT md5(pg_read_binary_file('$MXSEED/pg_multixact/members/
 assert "$mxSeedOff" "$mxRP" "multixact seed offsets page == reconstructed as-of-L page"
 assert "$mxSeedMem" "$mbRecon" "multixact seed members page == reconstructed as-of-L page"
 rm -rf "$MXSEED"
+
+# --- 22. branch bootstrap SLRU seeder: one fail-closed entrypoint for all SLRUs --------
+# A branch-control-plane caller should not hand-roll separate seed calls for pg_xact,
+# pg_commit_ts, and pg_multixact.  Seed them through a single bootstrap helper using one
+# fork window and one set of horizons, then require each published SLRU page to match its
+# existing per-SLRU reconstruction helper.
+BOOTSEED=$(mktemp -d)
+bootNext=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
+bootSeeded=$($P -c "SELECT pagestore_seed_branch_slrus('$BOOTSEED', '$mxC', '$mxL',
+	'3'::xid, '$bootNext'::xid, '$mA'::xid, '$mxNext'::xid, $mOff, $((mOff + mxMembers)));")
+assert "$([ "${bootSeeded:-0}" -ge 3 ] && echo ok || echo no)" "ok" \
+	"branch bootstrap seed materialized pg_xact, pg_commit_ts, and pg_multixact ($bootSeeded page(s))"
+bootClogSeg=$(printf '%04X' $(( (ctsA / cxpp) / 32 )))
+bootClogPage=$(( (ctsA / cxpp) % 32 ))
+bootClogMd5=$($P -c "SELECT md5(pg_read_binary_file('$BOOTSEED/pg_xact/$bootClogSeg', $(( bootClogPage * bs )), $bs));")
+bootClogRecon=$($P -c "SELECT md5(pagestore_clog_page_asof($(( ctsA / cxpp )), '$mxC', '$mxL'));")
+assert "$bootClogMd5" "$bootClogRecon" "branch bootstrap seed pg_xact page == reconstructed as-of-L page"
+bootCtsMd5=$($P -c "SELECT md5(pg_read_binary_file('$BOOTSEED/pg_commit_ts/$ctsSeg', $(( (ctsPage % 32) * bs )), $bs));")
+bootCtsRecon=$($P -c "SELECT md5(pagestore_commit_ts_page_asof($ctsPage, '$mxC', '$mxL'));")
+assert "$bootCtsMd5" "$bootCtsRecon" "branch bootstrap seed pg_commit_ts page == reconstructed as-of-L page"
+bootMxOff=$($P -c "SELECT md5(pg_read_binary_file('$BOOTSEED/pg_multixact/offsets/$mxSeg', $(( (mxPage % 32) * bs )), $bs));")
+bootMxMem=$($P -c "SELECT md5(pg_read_binary_file('$BOOTSEED/pg_multixact/members/$mbSeg', $(( (mPage % 32) * bs )), $bs));")
+assert "$bootMxOff" "$mxRP" "branch bootstrap seed multixact offsets page == reconstructed as-of-L page"
+assert "$bootMxMem" "$mbRecon" "branch bootstrap seed multixact members page == reconstructed as-of-L page"
+rm -rf "$BOOTSEED"
 
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -506,6 +506,7 @@ $P -c "BEGIN; SELECT id FROM mx WHERE id=1 FOR SHARE; COMMIT;" >/dev/null
 mA=$($P -c "SELECT xmax FROM mx WHERE id=1;")                     # the row's xmax is the multixact id
 $P -c "CHECKPOINT;" >/dev/null
 mxL=$($P -c "SELECT pg_current_wal_lsn();")                       # fork LSN L (after mA)
+bootNext=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
 wait "$mxlocker"		# only the locker; a bare wait would also block on the daemon
 # confirm mA really is a multixact (its two FOR SHARE members), not a plain xid
 mxMembers=$($P -c "SELECT count(*) FROM pg_get_multixact_members('$mA');" 2>/dev/null)
@@ -536,7 +537,8 @@ $P -c "CREATE FUNCTION pagestore_multixact_members_page_asof(int, pg_lsn, pg_lsn
         AS 'pagestore','pagestore_multixact_members_page_asof' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_seed_multixact(text, pg_lsn, pg_lsn, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_seed_multixact' LANGUAGE C STRICT;
-       CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
+       CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid,
+        xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_seed_branch_slrus' LANGUAGE C STRICT;" >/dev/null
 mOff=$mxRecon                                          # mA's first member offset (step 20)
 # MULTIXACT_MEMBERS_PER_PAGE = (block_size / MULTIXACT_MEMBERGROUP_SIZE) * members-per-group;
@@ -571,9 +573,12 @@ rm -rf "$MXSEED"
 # fork window and one set of horizons, then require each published SLRU page to match its
 # existing per-SLRU reconstruction helper.
 BOOTSEED=$(mktemp -d)
-bootNext=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
+read -r ctsOldest ctsNext <<< "$($P -c "SELECT oldest_commit_ts_xid::text || ' ' || newest_commit_ts_xid::text FROM pg_control_checkpoint();")"
 bootSeeded=$($P -c "SELECT pagestore_seed_branch_slrus('$BOOTSEED', '$mxC', '$mxL',
-	'3'::xid, '$bootNext'::xid, '$mA'::xid, '$mxNext'::xid, $mOff, $((mOff + mxMembers)));")
+	'3'::xid, '$bootNext'::xid,
+	'$ctsOldest'::xid, '$ctsNext'::xid,
+	'$mA'::xid, '$mxNext'::xid,
+	$mOff, $((mOff + mxMembers)));")
 assert "$([ "${bootSeeded:-0}" -ge 3 ] && echo ok || echo no)" "ok" \
 	"branch bootstrap seed materialized pg_xact, pg_commit_ts, and pg_multixact ($bootSeeded page(s))"
 bootClogSeg=$(printf '%04X' $(( (ctsA / cxpp) / 32 )))

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -575,6 +575,7 @@ rm -rf "$MXSEED"
 BOOTSEED=$(mktemp -d)
 read -r ctsOldest ctsNewest <<< "$($P -c "SELECT oldest_commit_ts_xid::text || ' ' || newest_commit_ts_xid::text FROM pg_control_checkpoint();")"
 ctsNext=$(( (ctsNewest + 1) & 4294967295 ))
+if [ "$ctsNext" -lt 3 ]; then ctsNext=3; fi
 bootSeeded=$($P -c "SELECT pagestore_seed_branch_slrus('$BOOTSEED', '$mxC', '$mxL',
 	'3'::xid, '$bootNext'::xid,
 	'$ctsOldest'::xid, '$ctsNext'::xid,

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -573,7 +573,8 @@ rm -rf "$MXSEED"
 # fork window and one set of horizons, then require each published SLRU page to match its
 # existing per-SLRU reconstruction helper.
 BOOTSEED=$(mktemp -d)
-read -r ctsOldest ctsNext <<< "$($P -c "SELECT oldest_commit_ts_xid::text || ' ' || newest_commit_ts_xid::text FROM pg_control_checkpoint();")"
+read -r ctsOldest ctsNewest <<< "$($P -c "SELECT oldest_commit_ts_xid::text || ' ' || newest_commit_ts_xid::text FROM pg_control_checkpoint();")"
+ctsNext=$(( (ctsNewest + 1) & 4294967295 ))
 bootSeeded=$($P -c "SELECT pagestore_seed_branch_slrus('$BOOTSEED', '$mxC', '$mxL',
 	'3'::xid, '$bootNext'::xid,
 	'$ctsOldest'::xid, '$ctsNext'::xid,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3882,9 +3882,9 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 		char		staging_root[MAXPGPATH];
 		char		backup_root[MAXPGPATH];
 		bool		seed_commit_ts;
-		bool		published_xact = false,
-					published_commit_ts = false,
-					published_multixact = false;
+		volatile bool published_xact = false;
+		volatile bool published_commit_ts = false;
+		volatile bool published_multixact = false;
 		int64		seeded = 0;
 		int			pathlen;
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3211,6 +3211,60 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 	PG_RETURN_INT64(seeded);
 }
 
+/*
+ * pagestore_seed_branch_slrus(target_dir text, base pg_lsn, target pg_lsn,
+ *                             oldest_xid xid, next_xid xid,
+ *                             oldest_multi xid, next_multi xid,
+ *                             oldest_member bigint, next_member bigint)
+ * returns bigint
+ *
+ * Branch bootstrap convenience entrypoint: materialize every SLRU class needed
+ * for a branch datadir to boot at target.  This intentionally centralizes the
+ * ordering and fail-closed behavior that tests previously had to spell out as
+ * separate seed_clog/seed_commit_ts/seed_multixact calls.  A later pg_control
+ * bootstrap helper can derive these horizons from the fork manifest and call
+ * this single function.
+ */
+PG_FUNCTION_INFO_V1(pagestore_seed_branch_slrus);
+Datum
+pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
+{
+	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	XLogRecPtr	base = PG_GETARG_LSN(1);
+	XLogRecPtr	target = PG_GETARG_LSN(2);
+	TransactionId oldest_xid = PG_GETARG_TRANSACTIONID(3);
+	TransactionId next_xid = PG_GETARG_TRANSACTIONID(4);
+	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(5);
+	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(6);
+	int64		oldest_member = PG_GETARG_INT64(7);
+	int64		next_member = PG_GETARG_INT64(8);
+	Datum		target_dir_datum = CStringGetTextDatum(target_dir);
+	int64		seeded = 0;
+
+	seeded += DatumGetInt64(DirectFunctionCall5(pagestore_seed_clog,
+												target_dir_datum,
+												LSNGetDatum(base),
+												LSNGetDatum(target),
+												TransactionIdGetDatum(oldest_xid),
+												TransactionIdGetDatum(next_xid)));
+	seeded += DatumGetInt64(DirectFunctionCall5(pagestore_seed_commit_ts,
+												target_dir_datum,
+												LSNGetDatum(base),
+												LSNGetDatum(target),
+												TransactionIdGetDatum(oldest_xid),
+												TransactionIdGetDatum(next_xid)));
+	seeded += DatumGetInt64(DirectFunctionCall7(pagestore_seed_multixact,
+												target_dir_datum,
+												LSNGetDatum(base),
+												LSNGetDatum(target),
+												TransactionIdGetDatum(oldest_multi),
+												TransactionIdGetDatum(next_multi),
+												Int64GetDatum(oldest_member),
+												Int64GetDatum(next_member)));
+
+	PG_RETURN_INT64(seeded);
+}
+
 void
 _PG_init(void)
 {

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3211,9 +3211,36 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 	PG_RETURN_INT64(seeded);
 }
 
+/* Publish one staged SLRU directory into the final target branch directory,
+ * replacing any prior target version.  Missing staged directories (for skipped
+ * optional SLRUs) are treated as a no-op.
+ */
+static void
+publish_seeded_slru_dir(const char *staging_root, const char *target_root,
+					const char *slru_name)
+{
+	char		stagedir[MAXPGPATH];
+	char		targetdir[MAXPGPATH];
+
+	snprintf(stagedir, sizeof(stagedir), "%s/%s", staging_root, slru_name);
+	snprintf(targetdir, sizeof(targetdir), "%s/%s", target_root, slru_name);
+
+	if (access(stagedir, F_OK) != 0)
+		return;
+	if (access(targetdir, F_OK) == 0 && !rmtree(targetdir, true))
+		ereport(ERROR,
+			(errcode_for_file_access(),
+			 errmsg("could not remove existing branch %s dir \"%s\"", slru_name, targetdir)));
+	if (rename(stagedir, targetdir) != 0)
+		ereport(ERROR,
+			(errcode_for_file_access(),
+			 errmsg("could not publish branch %s dir \"%s\"", slru_name, targetdir)));
+}
+
 /*
  * pagestore_seed_branch_slrus(target_dir text, base pg_lsn, target pg_lsn,
  *                             oldest_xid xid, next_xid xid,
+ *                             oldest_commit_ts_xid xid, next_commit_ts_xid xid,
  *                             oldest_multi xid, next_multi xid,
  *                             oldest_member bigint, next_member bigint)
  * returns bigint
@@ -3234,33 +3261,97 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 	XLogRecPtr	target = PG_GETARG_LSN(2);
 	TransactionId oldest_xid = PG_GETARG_TRANSACTIONID(3);
 	TransactionId next_xid = PG_GETARG_TRANSACTIONID(4);
-	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(5);
-	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(6);
-	int64		oldest_member = PG_GETARG_INT64(7);
-	int64		next_member = PG_GETARG_INT64(8);
-	Datum		target_dir_datum = CStringGetTextDatum(target_dir);
+	TransactionId oldest_commit_ts_xid = PG_GETARG_TRANSACTIONID(5);
+	TransactionId next_commit_ts_xid = PG_GETARG_TRANSACTIONID(6);
+	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(7);
+	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(8);
+	int64		oldest_member = PG_GETARG_INT64(9);
+	int64		next_member = PG_GETARG_INT64(10);
+	Datum		staging_dir_datum;
+	char		staging_root[MAXPGPATH];
+	bool		seed_commit_ts;
 	int64		seeded = 0;
 
-	seeded += DatumGetInt64(DirectFunctionCall5(pagestore_seed_clog,
-												target_dir_datum,
-												LSNGetDatum(base),
-												LSNGetDatum(target),
-												TransactionIdGetDatum(oldest_xid),
-												TransactionIdGetDatum(next_xid)));
-	seeded += DatumGetInt64(DirectFunctionCall5(pagestore_seed_commit_ts,
-												target_dir_datum,
-												LSNGetDatum(base),
-												LSNGetDatum(target),
-												TransactionIdGetDatum(oldest_xid),
-												TransactionIdGetDatum(next_xid)));
-	seeded += DatumGetInt64(DirectFunctionCall7(pagestore_seed_multixact,
-												target_dir_datum,
-												LSNGetDatum(base),
-												LSNGetDatum(target),
-												TransactionIdGetDatum(oldest_multi),
-												TransactionIdGetDatum(next_multi),
-												Int64GetDatum(oldest_member),
-												Int64GetDatum(next_member)));
+	snprintf(staging_root, sizeof(staging_root), "%s/.pagestore-branch-seed.%ld",
+			target_dir, (long) MyProcPid);
+	if (access(staging_root, F_OK) == 0 && !rmtree(staging_root, true))
+		ereport(ERROR,
+			(errcode_for_file_access(),
+			 errmsg("could not clear previous branch seeding staging area \"%s\"", staging_root)));
+	if (MakePGDirectory(staging_root) != 0)
+		ereport(ERROR,
+			(errcode_for_file_access(),
+			 errmsg("could not create branch seeding staging area \"%s\"", staging_root)));
+	staging_dir_datum = CStringGetTextDatum(staging_root);
+	if (!TransactionIdIsNormal(oldest_commit_ts_xid) &&
+		!TransactionIdIsNormal(next_commit_ts_xid))
+		seed_commit_ts = false;
+	else if (!TransactionIdIsNormal(oldest_commit_ts_xid) ||
+			!TransactionIdIsNormal(next_commit_ts_xid))
+		ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("invalid commit-ts horizon [%u, %u)",
+				 oldest_commit_ts_xid, next_commit_ts_xid)));
+	else
+		seed_commit_ts = true;
+
+	PG_TRY();
+	{
+		seeded += DatumGetInt64(DirectFunctionCall5(pagestore_seed_clog,
+									  staging_dir_datum,
+									  LSNGetDatum(base),
+									  LSNGetDatum(target),
+									  TransactionIdGetDatum(oldest_xid),
+									  TransactionIdGetDatum(next_xid)));
+
+		if (seed_commit_ts)
+			seeded += DatumGetInt64(DirectFunctionCall5(pagestore_seed_commit_ts,
+											  staging_dir_datum,
+											  LSNGetDatum(base),
+											  LSNGetDatum(target),
+											  TransactionIdGetDatum(oldest_commit_ts_xid),
+											  TransactionIdGetDatum(next_commit_ts_xid)));
+
+		seeded += DatumGetInt64(DirectFunctionCall7(pagestore_seed_multixact,
+										  staging_dir_datum,
+										  LSNGetDatum(base),
+										  LSNGetDatum(target),
+										  MultiXactIdGetDatum(oldest_multi),
+										  MultiXactIdGetDatum(next_multi),
+										  Int64GetDatum(oldest_member),
+										  Int64GetDatum(next_member)));
+	}
+	PG_CATCH();
+	{
+		if (!rmtree(staging_root, true))
+			ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove branch seeding staging area after seed failure \"%s\"", staging_root)));
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	PG_TRY();
+	{
+		publish_seeded_slru_dir(staging_root, target_dir, "pg_xact");
+		if (seed_commit_ts)
+			publish_seeded_slru_dir(staging_root, target_dir, "pg_commit_ts");
+		publish_seeded_slru_dir(staging_root, target_dir, "pg_multixact");
+		fsync_fname(target_dir, true);
+		if (!rmtree(staging_root, true))
+			ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove branch seeding staging area \"%s\"", staging_root)));
+	}
+	PG_CATCH();
+	{
+		if (!rmtree(staging_root, true))
+			ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove branch seeding staging area after publish failure \"%s\"", staging_root)));
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	PG_RETURN_INT64(seeded);
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3786,26 +3786,66 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
  * replacing any prior target version.  Missing staged directories (for skipped
  * optional SLRUs) are treated as a no-op.
  */
-static void
+static bool
 publish_seeded_slru_dir(const char *staging_root, const char *target_root,
-					const char *slru_name)
+						const char *backup_root, const char *slru_name)
 {
 	char		stagedir[MAXPGPATH];
 	char		targetdir[MAXPGPATH];
+	char		backupdir[MAXPGPATH];
+	int			pathlen;
 
-	snprintf(stagedir, sizeof(stagedir), "%s/%s", staging_root, slru_name);
-	snprintf(targetdir, sizeof(targetdir), "%s/%s", target_root, slru_name);
+	pathlen = snprintf(stagedir, sizeof(stagedir), "%s/%s", staging_root,
+					   slru_name);
+	PS_CHECK_PATH_FORMAT(pathlen, stagedir);
+	pathlen = snprintf(targetdir, sizeof(targetdir), "%s/%s", target_root,
+					   slru_name);
+	PS_CHECK_PATH_FORMAT(pathlen, targetdir);
+	pathlen = snprintf(backupdir, sizeof(backupdir), "%s/%s", backup_root,
+					   slru_name);
+	PS_CHECK_PATH_FORMAT(pathlen, backupdir);
 
 	if (access(stagedir, F_OK) != 0)
-		return;
-	if (access(targetdir, F_OK) == 0 && !rmtree(targetdir, true))
+		return false;
+	if (access(targetdir, F_OK) == 0 && rename(targetdir, backupdir) != 0)
 		ereport(ERROR,
-			(errcode_for_file_access(),
-			 errmsg("could not remove existing branch %s dir \"%s\"", slru_name, targetdir)));
+				(errcode_for_file_access(),
+				 errmsg("could not move existing branch %s dir \"%s\" aside: %m",
+						slru_name, targetdir)));
 	if (rename(stagedir, targetdir) != 0)
 		ereport(ERROR,
-			(errcode_for_file_access(),
-			 errmsg("could not publish branch %s dir \"%s\"", slru_name, targetdir)));
+				(errcode_for_file_access(),
+				 errmsg("could not publish branch %s dir \"%s\"", slru_name, targetdir)));
+	return true;
+}
+
+static void
+rollback_seeded_slru_dir(const char *target_root, const char *backup_root,
+						 const char *slru_name, bool published)
+{
+	char		targetdir[MAXPGPATH];
+	char		backupdir[MAXPGPATH];
+	int			pathlen;
+
+	pathlen = snprintf(targetdir, sizeof(targetdir), "%s/%s", target_root,
+					   slru_name);
+	PS_CHECK_PATH_FORMAT(pathlen, targetdir);
+	pathlen = snprintf(backupdir, sizeof(backupdir), "%s/%s", backup_root,
+					   slru_name);
+	PS_CHECK_PATH_FORMAT(pathlen, backupdir);
+
+	if (!published && access(backupdir, F_OK) != 0)
+		return;
+	if (published && access(targetdir, F_OK) == 0 && !rmtree(targetdir, true))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove partly-published branch %s dir \"%s\"",
+						slru_name, targetdir)));
+	if (access(backupdir, F_OK) == 0 && rename(backupdir, targetdir) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not restore previous branch %s dir \"%s\": %m",
+						slru_name, targetdir)));
 }
 
 /*
@@ -3833,38 +3873,83 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 	TransactionId oldest_xid = PG_GETARG_TRANSACTIONID(3);
 	TransactionId next_xid = PG_GETARG_TRANSACTIONID(4);
 	TransactionId oldest_commit_ts_xid = PG_GETARG_TRANSACTIONID(5);
-	TransactionId next_commit_ts_xid = PG_GETARG_TRANSACTIONID(6);
-	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(7);
-	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(8);
-	int64		oldest_member = PG_GETARG_INT64(9);
-	int64		next_member = PG_GETARG_INT64(10);
-	Datum		staging_dir_datum;
-	char		staging_root[MAXPGPATH];
-	bool		seed_commit_ts;
-	int64		seeded = 0;
+		TransactionId next_commit_ts_xid = PG_GETARG_TRANSACTIONID(6);
+		MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(7);
+		MultiXactId next_multi = PG_GETARG_TRANSACTIONID(8);
+		int64		oldest_member = PG_GETARG_INT64(9);
+		int64		next_member = PG_GETARG_INT64(10);
+		Datum		staging_dir_datum;
+		char		staging_root[MAXPGPATH];
+		char		backup_root[MAXPGPATH];
+		bool		seed_commit_ts;
+		bool		published_xact = false,
+					published_commit_ts = false,
+					published_multixact = false;
+		int64		seeded = 0;
+		int			pathlen;
 
-	snprintf(staging_root, sizeof(staging_root), "%s/.pagestore-branch-seed.%ld",
-			target_dir, (long) MyProcPid);
-	if (access(staging_root, F_OK) == 0 && !rmtree(staging_root, true))
-		ereport(ERROR,
-			(errcode_for_file_access(),
-			 errmsg("could not clear previous branch seeding staging area \"%s\"", staging_root)));
-	if (MakePGDirectory(staging_root) != 0)
-		ereport(ERROR,
-			(errcode_for_file_access(),
-			 errmsg("could not create branch seeding staging area \"%s\"", staging_root)));
-	staging_dir_datum = CStringGetTextDatum(staging_root);
-	if (!TransactionIdIsNormal(oldest_commit_ts_xid) &&
-		!TransactionIdIsNormal(next_commit_ts_xid))
-		seed_commit_ts = false;
-	else if (!TransactionIdIsNormal(oldest_commit_ts_xid) ||
+		if (!superuser())
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("must be superuser to seed branch SLRUs")));
+		if (strcmp(pagestore_backend_name ? pagestore_backend_name : "", "localsvc") != 0)
+			ereport(ERROR,
+					(errmsg("pagestore.backend must be 'localsvc'")));
+		if (target < base)
+			ereport(ERROR,
+					(errmsg("target LSN precedes the base cutoff")));
+		if (!TransactionIdIsNormal(oldest_xid) || !TransactionIdIsNormal(next_xid) ||
+			TransactionIdFollows(oldest_xid, next_xid))
+			ereport(ERROR,
+					(errmsg("invalid fork xid horizon [%u, %u)", oldest_xid, next_xid)));
+		if (!TransactionIdIsNormal(oldest_commit_ts_xid) &&
 			!TransactionIdIsNormal(next_commit_ts_xid))
-		ereport(ERROR,
-			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			 errmsg("invalid commit-ts horizon [%u, %u)",
-				 oldest_commit_ts_xid, next_commit_ts_xid)));
-	else
-		seed_commit_ts = true;
+			seed_commit_ts = false;
+		else if (!TransactionIdIsNormal(oldest_commit_ts_xid) ||
+				 !TransactionIdIsNormal(next_commit_ts_xid) ||
+				 TransactionIdFollows(oldest_commit_ts_xid, next_commit_ts_xid))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid commit-ts horizon [%u, %u)",
+							oldest_commit_ts_xid, next_commit_ts_xid)));
+		else
+			seed_commit_ts = true;
+		if (!MultiXactIdIsValid(oldest_multi) ||
+			(next_multi != InvalidMultiXactId && !MultiXactIdIsValid(next_multi)) ||
+			(oldest_multi != next_multi &&
+			 !MultiXactIdPrecedes(oldest_multi, next_multi)))
+			ereport(ERROR,
+					(errmsg("invalid fork multixact horizon [%u, %u)",
+							oldest_multi, next_multi)));
+		if (oldest_member < 0 || next_member < 0 ||
+			oldest_member > UINT32_MAX ||
+			next_member > UINT32_MAX)
+			ereport(ERROR,
+					(errmsg("invalid fork multixact member horizon [%lld, %lld)",
+							(long long) oldest_member, (long long) next_member)));
+
+		pathlen = snprintf(staging_root, sizeof(staging_root),
+						   "%s/.pagestore-branch-seed.%ld",
+						   target_dir, (long) MyProcPid);
+		PS_CHECK_PATH_FORMAT(pathlen, staging_root);
+		pathlen = snprintf(backup_root, sizeof(backup_root),
+						   "%s/.pagestore-branch-backup.%ld",
+						   target_dir, (long) MyProcPid);
+		PS_CHECK_PATH_FORMAT(pathlen, backup_root);
+		staging_dir_datum = CStringGetTextDatum(staging_root);
+
+		if (access(staging_root, F_OK) == 0 && !rmtree(staging_root, true))
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not clear previous branch seeding staging area \"%s\"", staging_root)));
+		if (access(backup_root, F_OK) == 0 && !rmtree(backup_root, true))
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not clear previous branch seeding backup area \"%s\"", backup_root)));
+		if (MakePGDirectory(staging_root) != 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not create branch seeding staging area \"%s\"", staging_root)));
 
 	PG_TRY();
 	{
@@ -3904,22 +3989,46 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 
 	PG_TRY();
 	{
-		publish_seeded_slru_dir(staging_root, target_dir, "pg_xact");
+		if (MakePGDirectory(backup_root) != 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not create branch seeding backup area \"%s\"", backup_root)));
+		published_xact = publish_seeded_slru_dir(staging_root, target_dir,
+												 backup_root, "pg_xact");
 		if (seed_commit_ts)
-			publish_seeded_slru_dir(staging_root, target_dir, "pg_commit_ts");
-		publish_seeded_slru_dir(staging_root, target_dir, "pg_multixact");
+			published_commit_ts = publish_seeded_slru_dir(staging_root, target_dir,
+														  backup_root,
+														  "pg_commit_ts");
+		published_multixact = publish_seeded_slru_dir(staging_root, target_dir,
+													  backup_root,
+													  "pg_multixact");
 		fsync_fname(target_dir, true);
 		if (!rmtree(staging_root, true))
 			ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not remove branch seeding staging area \"%s\"", staging_root)));
+					(errcode_for_file_access(),
+					 errmsg("could not remove branch seeding staging area \"%s\"", staging_root)));
+		if (!rmtree(backup_root, true))
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not remove branch seeding backup area \"%s\"", backup_root)));
 	}
 	PG_CATCH();
 	{
+		rollback_seeded_slru_dir(target_dir, backup_root, "pg_multixact",
+								 published_multixact);
+		if (seed_commit_ts)
+			rollback_seeded_slru_dir(target_dir, backup_root, "pg_commit_ts",
+									 published_commit_ts);
+		rollback_seeded_slru_dir(target_dir, backup_root, "pg_xact",
+								 published_xact);
 		if (!rmtree(staging_root, true))
 			ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not remove branch seeding staging area after publish failure \"%s\"", staging_root)));
+					(errcode_for_file_access(),
+					 errmsg("could not remove branch seeding staging area after publish failure \"%s\"", staging_root)));
+		if (access(backup_root, F_OK) == 0 && !rmtree(backup_root, true))
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not remove branch seeding backup area after publish failure \"%s\"", backup_root)));
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4004,11 +4004,11 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 													  "pg_multixact");
 		fsync_fname(target_dir, true);
 		if (!rmtree(staging_root, true))
-			ereport(ERROR,
+			ereport(WARNING,
 					(errcode_for_file_access(),
 					 errmsg("could not remove branch seeding staging area \"%s\"", staging_root)));
 		if (!rmtree(backup_root, true))
-			ereport(ERROR,
+			ereport(WARNING,
 					(errcode_for_file_access(),
 					 errmsg("could not remove branch seeding backup area \"%s\"", backup_root)));
 	}


### PR DESCRIPTION
## Summary
- add pagestore_seed_branch_slrus() as one fail-closed entrypoint for branch bootstrap SLRU materialization
- reuse the existing pg_xact, pg_commit_ts, and pg_multixact seeders instead of duplicating reconstruction logic
- extend the integration test to seed all branch SLRUs from one fork window and compare each output page to its reconstruction helper

## Stack
- stacked on #70 / feat/pagestore-branch-slru-seed

## Validation
- not run locally