### PR TITLE
pagestore: add branch prepare manifest

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -530,6 +530,24 @@ pagestore_localsvc_read_at(const PageStoreRelKey *key, BlockNumber blocknum,
  * for the pagestore_create_branch() SQL function.
  */
 void
+pagestore_localsvc_check_branch(uint32 new_tl, uint32 parent_tl,
+								uint64 branch_lsn)
+{
+	PsChannel  *ch = ls_chan();
+
+	ch->opcode = PS_OP_CHECK_BRANCH;
+	ch->timeline = new_tl;
+	ch->parent_timeline = parent_tl;
+	ch->req_lsn = branch_lsn;
+	ls_exec(ch);
+}
+
+/*
+ * Create a branch (new timeline) forking from parent_tl at branch_lsn.  This is
+ * an O(1) metadata operation in the daemon -- no page data is copied.  Exposed
+ * for the pagestore_create_branch() SQL function.
+ */
+void
 pagestore_localsvc_create_branch(uint32 new_tl, uint32 parent_tl,
 								 uint64 branch_lsn)
 {

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -537,7 +537,9 @@ $P -c "CREATE FUNCTION pagestore_multixact_members_page_asof(int, pg_lsn, pg_lsn
        CREATE FUNCTION pagestore_seed_multixact(text, pg_lsn, pg_lsn, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_seed_multixact' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
-        AS 'pagestore','pagestore_seed_branch_slrus' LANGUAGE C STRICT;" >/dev/null
+        AS 'pagestore','pagestore_seed_branch_slrus' LANGUAGE C STRICT;
+       CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
+        AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;" >/dev/null
 mOff=$mxRecon                                          # mA's first member offset (step 20)
 # MULTIXACT_MEMBERS_PER_PAGE = (block_size / MULTIXACT_MEMBERGROUP_SIZE) * members-per-group;
 # the group is 4 flag bytes + 4 TransactionIds = 20 bytes, 4 members each (block-size derived)
@@ -589,6 +591,28 @@ bootMxMem=$($P -c "SELECT md5(pg_read_binary_file('$BOOTSEED/pg_multixact/member
 assert "$bootMxOff" "$mxRP" "branch bootstrap seed multixact offsets page == reconstructed as-of-L page"
 assert "$bootMxMem" "$mbRecon" "branch bootstrap seed multixact members page == reconstructed as-of-L page"
 rm -rf "$BOOTSEED"
+
+# --- 23. branch prepare control-plane entrypoint: seed + fork timeline + manifest -------
+# The next layer up should call one control-plane function, not independently remember to
+# seed SLRUs, create the store timeline, and persist fork metadata.  Preparing a branch
+# must leave a durable manifest next to the seeded SLRUs; that manifest is the handoff
+# artifact for the later pg_control/bootstrap step.
+PREPSEED=$(mktemp -d)
+prepSeeded=$($P -c "SELECT pagestore_prepare_branch('$PREPSEED', 2, 0, '$mxC', '$mxL',
+	'3'::xid, '$bootNext'::xid, '$mA'::xid, '$mxNext'::xid, $mOff, $((mOff + mxMembers)));")
+assert "$([ "${prepSeeded:-0}" -ge 3 ] && echo ok || echo no)" "ok" \
+	"branch prepare seeded all bootstrap SLRUs and forked a store timeline ($prepSeeded page(s))"
+manifestHasTimeline=$($P -c "SELECT position('\"new_timeline\": 2' in pg_read_file('$PREPSEED/pagestore_branch.manifest')) > 0;")
+assert "$manifestHasTimeline" "t" "branch prepare manifest records the new timeline"
+manifestHasFork=$($P -c "SELECT position('\"fork_lsn\": ' in pg_read_file('$PREPSEED/pagestore_branch.manifest')) > 0;")
+assert "$manifestHasFork" "t" "branch prepare manifest records the fork LSN"
+prepClogMd5=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_xact/$bootClogSeg', $(( bootClogPage * bs )), $bs));")
+assert "$prepClogMd5" "$bootClogRecon" "branch prepare pg_xact page == reconstructed as-of-L page"
+prepMxOff=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_multixact/offsets/$mxSeg', $(( (mxPage % 32) * bs )), $bs));")
+prepMxMem=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_multixact/members/$mbSeg', $(( (mPage % 32) * bs )), $bs));")
+assert "$prepMxOff" "$mxRP" "branch prepare multixact offsets page == reconstructed as-of-L page"
+assert "$prepMxMem" "$mbRecon" "branch prepare multixact members page == reconstructed as-of-L page"
+rm -rf "$PREPSEED"
 
 echo "----"
 [ "$fail" = 0 ] && echo "integration test: PASS" || echo "integration test: FAIL"

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -536,9 +536,9 @@ $P -c "CREATE FUNCTION pagestore_multixact_members_page_asof(int, pg_lsn, pg_lsn
         AS 'pagestore','pagestore_multixact_members_page_asof' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_seed_multixact(text, pg_lsn, pg_lsn, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_seed_multixact' LANGUAGE C STRICT;
-       CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
+       CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_seed_branch_slrus' LANGUAGE C STRICT;
-       CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
+       CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;" >/dev/null
 mOff=$mxRecon                                          # mA's first member offset (step 20)
 # MULTIXACT_MEMBERS_PER_PAGE = (block_size / MULTIXACT_MEMBERGROUP_SIZE) * members-per-group;
@@ -575,7 +575,7 @@ rm -rf "$MXSEED"
 BOOTSEED=$(mktemp -d)
 bootNext=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
 bootSeeded=$($P -c "SELECT pagestore_seed_branch_slrus('$BOOTSEED', '$mxC', '$mxL',
-	'3'::xid, '$bootNext'::xid, '$mA'::xid, '$mxNext'::xid, $mOff, $((mOff + mxMembers)));")
+	'3'::xid, '$bootNext'::xid, '$ctsA'::xid, '$cts_next'::text::xid, '$mA'::xid, '$mxNext'::xid, $mOff, $((mOff + mxMembers)));")
 assert "$([ "${bootSeeded:-0}" -ge 3 ] && echo ok || echo no)" "ok" \
 	"branch bootstrap seed materialized pg_xact, pg_commit_ts, and pg_multixact ($bootSeeded page(s))"
 bootClogSeg=$(printf '%04X' $(( (ctsA / cxpp) / 32 )))
@@ -599,7 +599,7 @@ rm -rf "$BOOTSEED"
 # artifact for the later pg_control/bootstrap step.
 PREPSEED=$(mktemp -d)
 prepSeeded=$($P -c "SELECT pagestore_prepare_branch('$PREPSEED', 2, 0, '$mxC', '$mxL',
-	'3'::xid, '$bootNext'::xid, '$mA'::xid, '$mxNext'::xid, $mOff, $((mOff + mxMembers)));")
+	'3'::xid, '$bootNext'::xid, '$ctsA'::xid, '$cts_next'::text::xid, '$mA'::xid, '$mxNext'::xid, $mOff, $((mOff + mxMembers)));")
 assert "$([ "${prepSeeded:-0}" -ge 3 ] && echo ok || echo no)" "ok" \
 	"branch prepare seeded all bootstrap SLRUs and forked a store timeline ($prepSeeded page(s))"
 manifestHasTimeline=$($P -c "SELECT position('\"new_timeline\": 2' in pg_read_file('$PREPSEED/pagestore_branch.manifest')) > 0;")

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3265,6 +3265,170 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 	PG_RETURN_INT64(seeded);
 }
 
+static void
+pagestore_write_branch_manifest(const char *target_dir,
+								int32 new_tl, int32 parent_tl,
+								XLogRecPtr base, XLogRecPtr target,
+								TransactionId oldest_xid,
+								TransactionId next_xid,
+								MultiXactId oldest_multi,
+								MultiXactId next_multi,
+								int64 oldest_member,
+								int64 next_member,
+								int64 seeded_pages)
+{
+	char		path[MAXPGPATH];
+	char		tmppath[MAXPGPATH];
+	char		manifest[2048];
+	int			len;
+	int			fd;
+	int			done = 0;
+
+	if (strlen(target_dir) + sizeof("/pagestore_branch.manifest.tmp") > MAXPGPATH)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("branch target directory path is too long")));
+
+	len = snprintf(manifest, sizeof(manifest),
+				   "{\n"
+				   "  \"format\": 1,\n"
+				   "  \"new_timeline\": %d,\n"
+				   "  \"parent_timeline\": %d,\n"
+				   "  \"base_lsn\": \"%X/%08X\",\n"
+				   "  \"fork_lsn\": \"%X/%08X\",\n"
+				   "  \"oldest_xid\": \"%u\",\n"
+				   "  \"next_xid\": \"%u\",\n"
+				   "  \"oldest_multi\": \"%u\",\n"
+				   "  \"next_multi\": \"%u\",\n"
+				   "  \"oldest_member\": \"%lld\",\n"
+				   "  \"next_member\": \"%lld\",\n"
+				   "  \"seeded_slru_pages\": \"%lld\"\n"
+				   "}\n",
+				   new_tl, parent_tl,
+				   LSN_FORMAT_ARGS(base),
+				   LSN_FORMAT_ARGS(target),
+				   oldest_xid, next_xid,
+				   oldest_multi, next_multi,
+				   (long long) oldest_member,
+				   (long long) next_member,
+				   (long long) seeded_pages);
+	if (len < 0 || len >= (int) sizeof(manifest))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("branch manifest is too large")));
+
+	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
+
+	snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
+	snprintf(tmppath, sizeof(tmppath), "%s/pagestore_branch.manifest.tmp", target_dir);
+	fd = OpenTransientFilePerm(tmppath,
+							   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
+							   pg_file_create_mode);
+	if (fd < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch manifest \"%s\": %m", tmppath)));
+	while (done < len)
+	{
+		ssize_t		written;
+
+		errno = 0;
+		written = write(fd, manifest + done, len - done);
+		if (written <= 0)
+		{
+			if (written == 0)
+				errno = ENOSPC;
+			CloseTransientFile(fd);
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not write branch manifest \"%s\": %m", tmppath)));
+		}
+		done += written;
+	}
+	if (pg_fsync(fd) != 0)
+	{
+		CloseTransientFile(fd);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not fsync branch manifest \"%s\": %m", tmppath)));
+	}
+	if (CloseTransientFile(fd) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not close branch manifest \"%s\": %m", tmppath)));
+	if (rename(tmppath, path) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not publish branch manifest \"%s\": %m", path)));
+	fsync_fname(target_dir, true);
+}
+
+/*
+ * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
+ *                          base pg_lsn, target pg_lsn,
+ *                          oldest_xid xid, next_xid xid,
+ *                          oldest_multi xid, next_multi xid,
+ *                          oldest_member bigint, next_member bigint)
+ * returns bigint
+ *
+ * Control-plane bootstrap entrypoint for a branch-capable compute: materialize
+ * branch SLRUs, fork the store timeline, and durably record the fork metadata in
+ * the target datadir.  This is still intentionally pg_control-adjacent rather
+ * than pg_control-editing: the manifest gives later bootstrap code one durable
+ * protocol artifact to consume.
+ */
+PG_FUNCTION_INFO_V1(pagestore_prepare_branch);
+Datum
+pagestore_prepare_branch(PG_FUNCTION_ARGS)
+{
+	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	int32		new_tl = PG_GETARG_INT32(1);
+	int32		parent_tl = PG_GETARG_INT32(2);
+	XLogRecPtr	base = PG_GETARG_LSN(3);
+	XLogRecPtr	target = PG_GETARG_LSN(4);
+	TransactionId oldest_xid = PG_GETARG_TRANSACTIONID(5);
+	TransactionId next_xid = PG_GETARG_TRANSACTIONID(6);
+	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(7);
+	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(8);
+	int64		oldest_member = PG_GETARG_INT64(9);
+	int64		next_member = PG_GETARG_INT64(10);
+	int64		seeded;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to prepare a branch")));
+	if (new_tl <= 0)
+		ereport(ERROR,
+				(errmsg("pagestore branch timeline must be > 0 (0 is the main timeline)")));
+	if (target < base)
+		ereport(ERROR,
+				(errmsg("target LSN precedes the base cutoff")));
+
+	seeded = DatumGetInt64(DirectFunctionCall9(pagestore_seed_branch_slrus,
+											   CStringGetTextDatum(target_dir),
+											   LSNGetDatum(base),
+											   LSNGetDatum(target),
+											   TransactionIdGetDatum(oldest_xid),
+											   TransactionIdGetDatum(next_xid),
+											   TransactionIdGetDatum(oldest_multi),
+											   TransactionIdGetDatum(next_multi),
+											   Int64GetDatum(oldest_member),
+											   Int64GetDatum(next_member)));
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) target);
+	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl, base, target,
+									oldest_xid, next_xid,
+									oldest_multi, next_multi,
+									oldest_member, next_member,
+									seeded);
+
+	PG_RETURN_INT64(seeded);
+}
+
 void
 _PG_init(void)
 {

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3214,6 +3214,7 @@ pagestore_seed_multixact(PG_FUNCTION_ARGS)
 /*
  * pagestore_seed_branch_slrus(target_dir text, base pg_lsn, target pg_lsn,
  *                             oldest_xid xid, next_xid xid,
+ *                             oldest_commit_ts_xid xid, next_commit_ts_xid xid,
  *                             oldest_multi xid, next_multi xid,
  *                             oldest_member bigint, next_member bigint)
  * returns bigint
@@ -3234,10 +3235,12 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 	XLogRecPtr	target = PG_GETARG_LSN(2);
 	TransactionId oldest_xid = PG_GETARG_TRANSACTIONID(3);
 	TransactionId next_xid = PG_GETARG_TRANSACTIONID(4);
-	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(5);
-	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(6);
-	int64		oldest_member = PG_GETARG_INT64(7);
-	int64		next_member = PG_GETARG_INT64(8);
+	TransactionId oldest_commit_ts_xid = PG_GETARG_TRANSACTIONID(5);
+	TransactionId next_commit_ts_xid = PG_GETARG_TRANSACTIONID(6);
+	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(7);
+	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(8);
+	int64		oldest_member = PG_GETARG_INT64(9);
+	int64		next_member = PG_GETARG_INT64(10);
 	Datum		target_dir_datum = CStringGetTextDatum(target_dir);
 	int64		seeded = 0;
 
@@ -3247,12 +3250,19 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 												LSNGetDatum(target),
 												TransactionIdGetDatum(oldest_xid),
 												TransactionIdGetDatum(next_xid)));
-	seeded += DatumGetInt64(DirectFunctionCall5(pagestore_seed_commit_ts,
-												target_dir_datum,
-												LSNGetDatum(base),
-												LSNGetDatum(target),
-												TransactionIdGetDatum(oldest_xid),
-												TransactionIdGetDatum(next_xid)));
+	if (TransactionIdIsNormal(oldest_commit_ts_xid) &&
+		TransactionIdIsNormal(next_commit_ts_xid))
+		seeded += DatumGetInt64(DirectFunctionCall5(pagestore_seed_commit_ts,
+													target_dir_datum,
+													LSNGetDatum(base),
+													LSNGetDatum(target),
+													TransactionIdGetDatum(oldest_commit_ts_xid),
+													TransactionIdGetDatum(next_commit_ts_xid)));
+	else if (TransactionIdIsNormal(oldest_commit_ts_xid) ||
+			 TransactionIdIsNormal(next_commit_ts_xid))
+		ereport(ERROR,
+				(errmsg("invalid commit-ts horizon [%u, %u)",
+						oldest_commit_ts_xid, next_commit_ts_xid)));
 	seeded += DatumGetInt64(DirectFunctionCall7(pagestore_seed_multixact,
 												target_dir_datum,
 												LSNGetDatum(base),
@@ -3271,6 +3281,8 @@ pagestore_write_branch_manifest(const char *target_dir,
 								XLogRecPtr base, XLogRecPtr target,
 								TransactionId oldest_xid,
 								TransactionId next_xid,
+								TransactionId oldest_commit_ts_xid,
+								TransactionId next_commit_ts_xid,
 								MultiXactId oldest_multi,
 								MultiXactId next_multi,
 								int64 oldest_member,
@@ -3298,6 +3310,8 @@ pagestore_write_branch_manifest(const char *target_dir,
 				   "  \"fork_lsn\": \"%X/%08X\",\n"
 				   "  \"oldest_xid\": \"%u\",\n"
 				   "  \"next_xid\": \"%u\",\n"
+				   "  \"oldest_commit_ts_xid\": \"%u\",\n"
+				   "  \"next_commit_ts_xid\": \"%u\",\n"
 				   "  \"oldest_multi\": \"%u\",\n"
 				   "  \"next_multi\": \"%u\",\n"
 				   "  \"oldest_member\": \"%lld\",\n"
@@ -3308,6 +3322,7 @@ pagestore_write_branch_manifest(const char *target_dir,
 				   LSN_FORMAT_ARGS(base),
 				   LSN_FORMAT_ARGS(target),
 				   oldest_xid, next_xid,
+				   oldest_commit_ts_xid, next_commit_ts_xid,
 				   oldest_multi, next_multi,
 				   (long long) oldest_member,
 				   (long long) next_member,
@@ -3370,6 +3385,7 @@ pagestore_write_branch_manifest(const char *target_dir,
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,
  *                          oldest_xid xid, next_xid xid,
+ *                          oldest_commit_ts_xid xid, next_commit_ts_xid xid,
  *                          oldest_multi xid, next_multi xid,
  *                          oldest_member bigint, next_member bigint)
  * returns bigint
@@ -3391,10 +3407,12 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 	XLogRecPtr	target = PG_GETARG_LSN(4);
 	TransactionId oldest_xid = PG_GETARG_TRANSACTIONID(5);
 	TransactionId next_xid = PG_GETARG_TRANSACTIONID(6);
-	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(7);
-	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(8);
-	int64		oldest_member = PG_GETARG_INT64(9);
-	int64		next_member = PG_GETARG_INT64(10);
+	TransactionId oldest_commit_ts_xid = PG_GETARG_TRANSACTIONID(7);
+	TransactionId next_commit_ts_xid = PG_GETARG_TRANSACTIONID(8);
+	MultiXactId oldest_multi = PG_GETARG_TRANSACTIONID(9);
+	MultiXactId next_multi = PG_GETARG_TRANSACTIONID(10);
+	int64		oldest_member = PG_GETARG_INT64(11);
+	int64		next_member = PG_GETARG_INT64(12);
 	int64		seeded;
 
 	if (!superuser())
@@ -3404,27 +3422,35 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 	if (new_tl <= 0)
 		ereport(ERROR,
 				(errmsg("pagestore branch timeline must be > 0 (0 is the main timeline)")));
+	if (parent_tl < 0)
+		ereport(ERROR,
+				(errmsg("pagestore parent timeline must be >= 0")));
 	if (target < base)
 		ereport(ERROR,
 				(errmsg("target LSN precedes the base cutoff")));
 
-	seeded = DatumGetInt64(DirectFunctionCall9(pagestore_seed_branch_slrus,
-											   CStringGetTextDatum(target_dir),
-											   LSNGetDatum(base),
-											   LSNGetDatum(target),
-											   TransactionIdGetDatum(oldest_xid),
-											   TransactionIdGetDatum(next_xid),
-											   TransactionIdGetDatum(oldest_multi),
-											   TransactionIdGetDatum(next_multi),
-											   Int64GetDatum(oldest_member),
-											   Int64GetDatum(next_member)));
-	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-									 (uint64) target);
+	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
+									(uint64) target);
+	seeded = DatumGetInt64(DirectFunctionCall11(pagestore_seed_branch_slrus,
+												CStringGetTextDatum(target_dir),
+												LSNGetDatum(base),
+												LSNGetDatum(target),
+												TransactionIdGetDatum(oldest_xid),
+												TransactionIdGetDatum(next_xid),
+												TransactionIdGetDatum(oldest_commit_ts_xid),
+												TransactionIdGetDatum(next_commit_ts_xid),
+												TransactionIdGetDatum(oldest_multi),
+												TransactionIdGetDatum(next_multi),
+												Int64GetDatum(oldest_member),
+												Int64GetDatum(next_member)));
 	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl, base, target,
 									oldest_xid, next_xid,
+									oldest_commit_ts_xid, next_commit_ts_xid,
 									oldest_multi, next_multi,
 									oldest_member, next_member,
 									seeded);
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) target);
 
 	PG_RETURN_INT64(seeded);
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4159,14 +4159,21 @@ pagestore_write_branch_manifest(const char *target_dir,
 				(errcode_for_file_access(),
 				 errmsg("could not close branch manifest \"%s\": %m", tmppath)));
 	}
-	if (rename(tmppath, path) != 0)
+	/*
+	 * The manifest is the marker that this dir is consumable, so if any part
+	 * of the durable publish (rename + directory fsync) fails it must not
+	 * stay visible while the caller reports the prepare as failed.  The
+	 * unlinks are best-effort: if the directory fsync itself is failing
+	 * there is no stronger rollback available.
+	 */
+	if (durable_rename(tmppath, path, LOG) != 0)
 	{
 		(void) unlink(tmppath);
+		(void) unlink(path);
 		ereport(ERROR,
 				(errcode_for_file_access(),
-				 errmsg("could not publish branch manifest \"%s\": %m", path)));
+				 errmsg("could not durably publish branch manifest \"%s\"", path)));
 	}
-	fsync_fname(target_dir, true);
 }
 
 /*

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -31,6 +31,7 @@
 #include "postgres.h"
 
 #include <fcntl.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "access/clog.h"
@@ -4176,6 +4177,102 @@ pagestore_write_branch_manifest(const char *target_dir,
 	}
 }
 
+static bool
+pagestore_manifest_has_line(const char *manifest, const char *line)
+{
+	return strstr(manifest, line) != NULL;
+}
+
+static bool
+pagestore_existing_branch_manifest_matches(const char *target_dir,
+										   int32 new_tl, int32 parent_tl,
+										   XLogRecPtr base, XLogRecPtr target,
+										   TransactionId oldest_xid,
+										   TransactionId next_xid,
+										   TransactionId oldest_commit_ts_xid,
+										   TransactionId next_commit_ts_xid,
+										   MultiXactId oldest_multi,
+										   MultiXactId next_multi,
+										   int64 oldest_member,
+										   int64 next_member,
+										   int64 *seeded_pages)
+{
+	char		path[MAXPGPATH];
+	char		manifest[4096];
+	char		line[128];
+	char	   *seeded_start;
+	char	   *seeded_end;
+	long long	seeded;
+	FILE	   *file;
+	size_t		nread;
+	int			len;
+
+#define CHECK_MANIFEST_LINE(...) \
+	do { \
+		len = snprintf(line, sizeof(line), __VA_ARGS__); \
+		if (len < 0 || len >= (int) sizeof(line) || \
+			!pagestore_manifest_has_line(manifest, line)) \
+			return false; \
+	} while (0)
+
+	len = snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
+	PS_CHECK_PATH_FORMAT(len, path);
+	file = AllocateFile(path, PG_BINARY_R);
+	if (file == NULL)
+	{
+		if (errno == ENOENT)
+			return false;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open branch manifest \"%s\": %m", path)));
+	}
+	nread = fread(manifest, 1, sizeof(manifest) - 1, file);
+	if (ferror(file))
+	{
+		FreeFile(file);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read branch manifest \"%s\": %m", path)));
+	}
+	if (!feof(file))
+	{
+		FreeFile(file);
+		return false;
+	}
+	FreeFile(file);
+	if (memchr(manifest, '\0', nread) != NULL)
+		return false;
+	manifest[nread] = '\0';
+
+	CHECK_MANIFEST_LINE("  \"format\": 1,\n");
+	CHECK_MANIFEST_LINE("  \"new_timeline\": %d,\n", new_tl);
+	CHECK_MANIFEST_LINE("  \"parent_timeline\": %d,\n", parent_tl);
+	CHECK_MANIFEST_LINE("  \"base_lsn\": \"%X/%08X\",\n", LSN_FORMAT_ARGS(base));
+	CHECK_MANIFEST_LINE("  \"fork_lsn\": \"%X/%08X\",\n", LSN_FORMAT_ARGS(target));
+	CHECK_MANIFEST_LINE("  \"oldest_xid\": \"%u\",\n", oldest_xid);
+	CHECK_MANIFEST_LINE("  \"next_xid\": \"%u\",\n", next_xid);
+	CHECK_MANIFEST_LINE("  \"oldest_commit_ts_xid\": \"%u\",\n", oldest_commit_ts_xid);
+	CHECK_MANIFEST_LINE("  \"next_commit_ts_xid\": \"%u\",\n", next_commit_ts_xid);
+	CHECK_MANIFEST_LINE("  \"oldest_multi\": \"%u\",\n", oldest_multi);
+	CHECK_MANIFEST_LINE("  \"next_multi\": \"%u\",\n", next_multi);
+	CHECK_MANIFEST_LINE("  \"oldest_member\": \"%lld\",\n", (long long) oldest_member);
+	CHECK_MANIFEST_LINE("  \"next_member\": \"%lld\",\n", (long long) next_member);
+
+	seeded_start = strstr(manifest, "  \"seeded_slru_pages\": \"");
+	if (seeded_start == NULL)
+		return false;
+	seeded_start += strlen("  \"seeded_slru_pages\": \"");
+	errno = 0;
+	seeded = strtoll(seeded_start, &seeded_end, 10);
+	if (errno != 0 || seeded_end == seeded_start || seeded < 0 ||
+		strncmp(seeded_end, "\"\n", 2) != 0)
+		return false;
+	*seeded_pages = (int64) seeded;
+	return true;
+
+#undef CHECK_MANIFEST_LINE
+}
+
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,
@@ -4232,6 +4329,20 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 
 	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
 									(uint64) target);
+
+	if (pagestore_existing_branch_manifest_matches(target_dir, new_tl, parent_tl,
+												   base, target,
+												   oldest_xid, next_xid,
+												   oldest_commit_ts_xid,
+												   next_commit_ts_xid,
+												   oldest_multi, next_multi,
+												   oldest_member, next_member,
+												   &seeded))
+	{
+		pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+										 (uint64) target);
+		PG_RETURN_INT64(seeded);
+	}
 
 	/*
 	 * From here until the new manifest is published the target's SLRUs may

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4229,6 +4229,18 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 											  next_commit_ts_xid,
 											  oldest_multi, next_multi,
 											  oldest_member, next_member);
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) target);
+
+	/*
+	 * Publish the manifest only after the store-side timeline exists: the
+	 * manifest is the durable handoff artifact for later bootstrap, so it must
+	 * never advertise a branch that CREATE_BRANCH refused (e.g. the same
+	 * timeline raced into existence with different ancestry during seeding).
+	 * The reverse window is retry-safe: if the manifest write fails here, the
+	 * timeline already exists and a retried prepare passes CHECK_BRANCH and
+	 * re-runs CREATE_BRANCH idempotently.
+	 */
 	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl,
 									base, target,
 									oldest_xid, next_xid,
@@ -4237,8 +4249,6 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 									oldest_multi, next_multi,
 									oldest_member, next_member,
 									seeded);
-	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-									 (uint64) target);
 
 	PG_RETURN_INT64(seeded);
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4071,11 +4071,6 @@ pagestore_write_branch_manifest(const char *target_dir,
 	int			fd;
 	int			done = 0;
 
-	if (strlen(target_dir) + sizeof("/pagestore_branch.manifest.tmp") > MAXPGPATH)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("branch target directory path is too long")));
-
 	len = snprintf(manifest, sizeof(manifest),
 				   "{\n"
 				   "  \"format\": 1,\n"
@@ -4112,10 +4107,14 @@ pagestore_write_branch_manifest(const char *target_dir,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
 
-	snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
-	snprintf(tmppath, sizeof(tmppath), "%s/pagestore_branch.manifest.tmp", target_dir);
+	len = snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
+	PS_CHECK_PATH_FORMAT(len, path);
+	len = snprintf(tmppath, sizeof(tmppath),
+				   "%s/pagestore_branch.manifest.tmp.%ld",
+				   target_dir, (long) MyProcPid);
+	PS_CHECK_PATH_FORMAT(len, tmppath);
 	fd = OpenTransientFilePerm(tmppath,
-							   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
+							   O_WRONLY | O_CREAT | O_EXCL | PG_BINARY,
 							   pg_file_create_mode);
 	if (fd < 0)
 		ereport(ERROR,
@@ -4200,20 +4199,24 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 	if (parent_tl < 0)
 		ereport(ERROR,
 				(errmsg("pagestore parent timeline must be >= 0")));
+	if ((uint32) parent_tl != pagestore_localsvc_timeline())
+		ereport(ERROR,
+				(errmsg("pagestore parent timeline %d is not the active localsvc timeline %u",
+						parent_tl, pagestore_localsvc_timeline())));
 	if (target < base)
 		ereport(ERROR,
 				(errmsg("target LSN precedes the base cutoff")));
 
 	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
 									(uint64) target);
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) target);
 	seeded = pagestore_seed_branch_slrus_impl(target_dir, base, target,
 											  oldest_xid, next_xid,
 											  oldest_commit_ts_xid,
 											  next_commit_ts_xid,
 											  oldest_multi, next_multi,
 											  oldest_member, next_member);
-	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-									 (uint64) target);
 	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl, base, target,
 									oldest_xid, next_xid,
 									oldest_commit_ts_xid, next_commit_ts_xid,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4202,6 +4202,8 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 	int64		oldest_member = PG_GETARG_INT64(11);
 	int64		next_member = PG_GETARG_INT64(12);
 	int64		seeded;
+	char		manifest_path[MAXPGPATH];
+	int			pathlen;
 
 	if (!superuser())
 		ereport(ERROR,
@@ -4223,6 +4225,27 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 
 	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
 									(uint64) target);
+
+	/*
+	 * From here until the new manifest is published the target's SLRUs may
+	 * not match any manifest, so durably invalidate a manifest left by a
+	 * previous prepare before touching them.  The manifest is what marks a
+	 * prepared dir as consumable, so every failure below -- SLRU seeding,
+	 * CREATE_BRANCH being refused after the store raced ahead, the manifest
+	 * write itself -- leaves the dir inert instead of advertising stale or
+	 * half-updated contents.
+	 */
+	pathlen = snprintf(manifest_path, sizeof(manifest_path),
+					   "%s/pagestore_branch.manifest", target_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, manifest_path);
+	if (unlink(manifest_path) == 0)
+		fsync_fname(target_dir, true);
+	else if (errno != ENOENT)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove stale branch manifest \"%s\": %m",
+						manifest_path)));
+
 	seeded = pagestore_seed_branch_slrus_impl(target_dir, base, target,
 											  oldest_xid, next_xid,
 											  oldest_commit_ts_xid,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4068,36 +4068,37 @@ pagestore_write_branch_manifest(const char *target_dir,
 	char		tmppath[MAXPGPATH];
 	char		manifest[2048];
 	int			len;
+	int			manifest_len;
 	int			fd;
 	int			done = 0;
 
-	len = snprintf(manifest, sizeof(manifest),
-				   "{\n"
-				   "  \"format\": 1,\n"
-				   "  \"new_timeline\": %d,\n"
-				   "  \"parent_timeline\": %d,\n"
-				   "  \"base_lsn\": \"%X/%08X\",\n"
-				   "  \"fork_lsn\": \"%X/%08X\",\n"
-				   "  \"oldest_xid\": \"%u\",\n"
-				   "  \"next_xid\": \"%u\",\n"
-				   "  \"oldest_commit_ts_xid\": \"%u\",\n"
-				   "  \"next_commit_ts_xid\": \"%u\",\n"
-				   "  \"oldest_multi\": \"%u\",\n"
-				   "  \"next_multi\": \"%u\",\n"
-				   "  \"oldest_member\": \"%lld\",\n"
-				   "  \"next_member\": \"%lld\",\n"
-				   "  \"seeded_slru_pages\": \"%lld\"\n"
-				   "}\n",
-				   new_tl, parent_tl,
-				   LSN_FORMAT_ARGS(base),
-				   LSN_FORMAT_ARGS(target),
-				   oldest_xid, next_xid,
-				   oldest_commit_ts_xid, next_commit_ts_xid,
-				   oldest_multi, next_multi,
-				   (long long) oldest_member,
-				   (long long) next_member,
-				   (long long) seeded_pages);
-	if (len < 0 || len >= (int) sizeof(manifest))
+	manifest_len = snprintf(manifest, sizeof(manifest),
+							"{\n"
+							"  \"format\": 1,\n"
+							"  \"new_timeline\": %d,\n"
+							"  \"parent_timeline\": %d,\n"
+							"  \"base_lsn\": \"%X/%08X\",\n"
+							"  \"fork_lsn\": \"%X/%08X\",\n"
+							"  \"oldest_xid\": \"%u\",\n"
+							"  \"next_xid\": \"%u\",\n"
+							"  \"oldest_commit_ts_xid\": \"%u\",\n"
+							"  \"next_commit_ts_xid\": \"%u\",\n"
+							"  \"oldest_multi\": \"%u\",\n"
+							"  \"next_multi\": \"%u\",\n"
+							"  \"oldest_member\": \"%lld\",\n"
+							"  \"next_member\": \"%lld\",\n"
+							"  \"seeded_slru_pages\": \"%lld\"\n"
+							"}\n",
+							new_tl, parent_tl,
+							LSN_FORMAT_ARGS(base),
+							LSN_FORMAT_ARGS(target),
+							oldest_xid, next_xid,
+							oldest_commit_ts_xid, next_commit_ts_xid,
+							oldest_multi, next_multi,
+							(long long) oldest_member,
+							(long long) next_member,
+							(long long) seeded_pages);
+	if (manifest_len < 0 || manifest_len >= (int) sizeof(manifest))
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("branch manifest is too large")));
@@ -4120,12 +4121,12 @@ pagestore_write_branch_manifest(const char *target_dir,
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch manifest \"%s\": %m", tmppath)));
-	while (done < len)
+	while (done < manifest_len)
 	{
 		ssize_t		written;
 
 		errno = 0;
-		written = write(fd, manifest + done, len - done);
+		written = write(fd, manifest + done, manifest_len - done);
 		if (written <= 0)
 		{
 			if (written == 0)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4114,6 +4114,11 @@ pagestore_write_branch_manifest(const char *target_dir,
 				   "%s/pagestore_branch.manifest.tmp.%ld",
 				   target_dir, (long) MyProcPid);
 	PS_CHECK_PATH_FORMAT(len, tmppath);
+	if (access(tmppath, F_OK) == 0 && unlink(tmppath) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not clear stale branch manifest temp file \"%s\": %m",
+						tmppath)));
 	fd = OpenTransientFilePerm(tmppath,
 							   O_WRONLY | O_CREAT | O_EXCL | PG_BINARY,
 							   pg_file_create_mode);
@@ -4132,6 +4137,7 @@ pagestore_write_branch_manifest(const char *target_dir,
 			if (written == 0)
 				errno = ENOSPC;
 			CloseTransientFile(fd);
+			(void) unlink(tmppath);
 			ereport(ERROR,
 					(errcode_for_file_access(),
 					 errmsg("could not write branch manifest \"%s\": %m", tmppath)));
@@ -4141,19 +4147,62 @@ pagestore_write_branch_manifest(const char *target_dir,
 	if (pg_fsync(fd) != 0)
 	{
 		CloseTransientFile(fd);
+		(void) unlink(tmppath);
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not fsync branch manifest \"%s\": %m", tmppath)));
 	}
 	if (CloseTransientFile(fd) != 0)
+	{
+		(void) unlink(tmppath);
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not close branch manifest \"%s\": %m", tmppath)));
+	}
 	if (rename(tmppath, path) != 0)
+	{
+		(void) unlink(tmppath);
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not publish branch manifest \"%s\": %m", path)));
+	}
 	fsync_fname(target_dir, true);
+}
+
+static void
+pagestore_cleanup_prepared_branch_output(const char *target_dir)
+{
+	const char *artifacts[] = {
+		"pg_multixact",
+		"pg_commit_ts",
+		"pg_xact",
+		"pagestore_branch.manifest",
+	};
+	char		path[MAXPGPATH];
+
+	for (int i = 0; i < lengthof(artifacts); i++)
+	{
+		int			len;
+
+		len = snprintf(path, sizeof(path), "%s/%s", target_dir,
+					   artifacts[i]);
+		PS_CHECK_PATH_FORMAT(len, path);
+		if (access(path, F_OK) != 0)
+			continue;
+		if (strcmp(artifacts[i], "pagestore_branch.manifest") == 0)
+		{
+			if (unlink(path) != 0)
+				ereport(WARNING,
+						(errcode_for_file_access(),
+						 errmsg("could not remove branch prepare artifact \"%s\": %m",
+								path)));
+		}
+		else if (!rmtree(path, true))
+			ereport(WARNING,
+					(errcode_for_file_access(),
+					 errmsg("could not remove branch prepare artifact \"%s\"",
+							path)));
+	}
 }
 
 /*
@@ -4210,20 +4259,31 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 
 	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
 									(uint64) target);
-	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-									 (uint64) target);
 	seeded = pagestore_seed_branch_slrus_impl(target_dir, base, target,
 											  oldest_xid, next_xid,
 											  oldest_commit_ts_xid,
 											  next_commit_ts_xid,
 											  oldest_multi, next_multi,
 											  oldest_member, next_member);
-	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl, base, target,
-									oldest_xid, next_xid,
-									oldest_commit_ts_xid, next_commit_ts_xid,
-									oldest_multi, next_multi,
-									oldest_member, next_member,
-									seeded);
+	PG_TRY();
+	{
+		pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+										 (uint64) target);
+		pagestore_write_branch_manifest(target_dir, new_tl, parent_tl,
+										base, target,
+										oldest_xid, next_xid,
+										oldest_commit_ts_xid,
+										next_commit_ts_xid,
+										oldest_multi, next_multi,
+										oldest_member, next_member,
+										seeded);
+	}
+	PG_CATCH();
+	{
+		pagestore_cleanup_prepared_branch_output(target_dir);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	PG_RETURN_INT64(seeded);
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4169,42 +4169,6 @@ pagestore_write_branch_manifest(const char *target_dir,
 	fsync_fname(target_dir, true);
 }
 
-static void
-pagestore_cleanup_prepared_branch_output(const char *target_dir)
-{
-	const char *artifacts[] = {
-		"pg_multixact",
-		"pg_commit_ts",
-		"pg_xact",
-		"pagestore_branch.manifest",
-	};
-	char		path[MAXPGPATH];
-
-	for (int i = 0; i < lengthof(artifacts); i++)
-	{
-		int			len;
-
-		len = snprintf(path, sizeof(path), "%s/%s", target_dir,
-					   artifacts[i]);
-		PS_CHECK_PATH_FORMAT(len, path);
-		if (access(path, F_OK) != 0)
-			continue;
-		if (strcmp(artifacts[i], "pagestore_branch.manifest") == 0)
-		{
-			if (unlink(path) != 0)
-				ereport(WARNING,
-						(errcode_for_file_access(),
-						 errmsg("could not remove branch prepare artifact \"%s\": %m",
-								path)));
-		}
-		else if (!rmtree(path, true))
-			ereport(WARNING,
-					(errcode_for_file_access(),
-					 errmsg("could not remove branch prepare artifact \"%s\"",
-							path)));
-	}
-}
-
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,
@@ -4265,25 +4229,16 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 											  next_commit_ts_xid,
 											  oldest_multi, next_multi,
 											  oldest_member, next_member);
-	PG_TRY();
-	{
-		pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-										 (uint64) target);
-		pagestore_write_branch_manifest(target_dir, new_tl, parent_tl,
-										base, target,
-										oldest_xid, next_xid,
-										oldest_commit_ts_xid,
-										next_commit_ts_xid,
-										oldest_multi, next_multi,
-										oldest_member, next_member,
-										seeded);
-	}
-	PG_CATCH();
-	{
-		pagestore_cleanup_prepared_branch_output(target_dir);
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
+	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl,
+									base, target,
+									oldest_xid, next_xid,
+									oldest_commit_ts_xid,
+									next_commit_ts_xid,
+									oldest_multi, next_multi,
+									oldest_member, next_member,
+									seeded);
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) target);
 
 	PG_RETURN_INT64(seeded);
 }

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -145,6 +145,8 @@ extern const PageStoreBackend PageStoreBackendLocalSvc;
 extern void pagestore_localsvc_init(void);
 extern void pagestore_localsvc_read_at(const PageStoreRelKey *key,
 									   BlockNumber blocknum, uint64 lsn, void *out);
+extern void pagestore_localsvc_check_branch(uint32 new_tl, uint32 parent_tl,
+										   uint64 branch_lsn);
 extern void pagestore_localsvc_create_branch(uint32 new_tl, uint32 parent_tl,
 											 uint64 branch_lsn);
 extern void pagestore_localsvc_wal_append(uint64 start_lsn, const void *data,

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -757,21 +757,26 @@ tl_walk_next(TlWalk *w)
  * Validate a branch-creation request before it is recorded.  read_through() and
  * the fork-size walks follow the parent chain assuming it is finite and well
  * formed, so a bad CREATE_BRANCH must be rejected rather than persisted.  Refuse:
- *	- a new id that is out of range, the root (0), or already defined (otherwise
- *	  re-creating an id silently rewrites an existing branch's ancestry);
+ *	- a new id that is out of range, or an already-defined id with mismatched
+ *	  ancestry metadata (unless it exactly matches for idempotent retry);
  *	- a parent that is out of range or not yet defined (the requested parent must
  *	  actually exist, else the branch silently inherits from nothing);
  *	- a parent whose ancestry already reaches the new id, which would turn the
  *	  parent walk into an infinite loop (e.g. new == parent, or A->B->A).
- * Returns 1 if (new_tl, parent) is safe to define.
+ * Returns 1 if (new_tl, parent, branch_lsn) can be used for CREATE_BRANCH.
  */
 static int
-branch_request_ok(uint32_t new_tl, int parent)
+branch_request_ok(uint32_t new_tl, int parent, uint64_t branch_lsn)
 {
-	if (new_tl == 0 || new_tl >= MAX_TIMELINES || timelines[new_tl].defined)
+	/* Exact matches to an existing definition are idempotent retries. */
+	if (new_tl < MAX_TIMELINES && timelines[new_tl].defined)
+		return timelines[new_tl].parent == parent &&
+			timelines[new_tl].branch_lsn == branch_lsn;
+
+	if (new_tl == 0 || new_tl >= MAX_TIMELINES || parent < 0 ||
+		parent >= MAX_TIMELINES || !timelines[parent].defined)
 		return 0;
-	if (parent < 0 || parent >= MAX_TIMELINES || !timelines[parent].defined)
-		return 0;
+
 	for (int t = parent; t >= 0 && t < MAX_TIMELINES; t = timelines[t].parent)
 	{
 		if ((uint32_t) t == new_tl)
@@ -860,12 +865,12 @@ typedef struct TimelineRec
 	uint64_t	branch_lsn;
 } TimelineRec;
 
-static void
+static int
 timeline_persist(uint32_t id, int parent, uint64_t branch_lsn)
 {
 	TimelineRec rec = {id, (int32_t) parent, branch_lsn};
 
-	ps_storage->meta_append(&rec, sizeof(rec));		/* best-effort */
+	return ps_storage->meta_append(&rec, sizeof(rec));
 }
 
 static void
@@ -884,7 +889,7 @@ load_timelines(void)
 	 */
 	while (ps_storage->meta_read(off, &rec, sizeof(rec)) == (int) sizeof(rec))
 	{
-		if (branch_request_ok(rec.id, rec.parent))
+		if (branch_request_ok(rec.id, rec.parent, rec.branch_lsn))
 			timeline_define(rec.id, rec.parent, rec.branch_lsn);
 		else
 			fprintf(stderr, "pagestore: skipping invalid timeline record "
@@ -1485,12 +1490,31 @@ ps_handle_meta(PsChannel *ch)
 			 * copied -- the branch shares the parent's pages by read-through
 			 * until it writes (copy-on-write).
 			 */
-			if (branch_request_ok(ch->timeline, (int) ch->parent_timeline))
+			if (branch_request_ok(ch->timeline, (int) ch->parent_timeline,
+								 ch->req_lsn))
 			{
-				timeline_define(ch->timeline, (int) ch->parent_timeline,
-								ch->req_lsn);
-				timeline_persist(ch->timeline, (int) ch->parent_timeline,
-								 ch->req_lsn);
+				if (timelines[ch->timeline].defined)
+					break;
+				if (timeline_persist(ch->timeline, (int) ch->parent_timeline,
+								 ch->req_lsn) == 0)
+					timeline_define(ch->timeline, (int) ch->parent_timeline,
+									ch->req_lsn);
+				else
+					ch->status = PS_STATUS_ERROR;
+			}
+			else
+				ch->status = PS_STATUS_ERROR;
+			break;
+		case PS_OP_CHECK_BRANCH:
+			/*
+			 * Validate a branch request without mutating timeline metadata.
+			 * This keeps prepare/retry paths deterministic: invalid requests are
+			 * rejected in-place before any SLRU directory mutation.
+			 */
+			if (branch_request_ok(ch->timeline, (int) ch->parent_timeline,
+								 ch->req_lsn))
+			{
+				/* valid */
 			}
 			else
 				ch->status = PS_STATUS_ERROR;

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -534,7 +534,7 @@ static TimelineMeta timelines[MAX_TIMELINES];
 
 /*
  * Branch-local usage marker: set once a timeline acquires any local state (a
- * page version or fork entry here; shipped WAL is tracked by wal_end[]).  An
+ * page version, fork entry, WAL-index entry, or shipped WAL).  An
  * exact-match duplicate CREATE_BRANCH is accepted only while the timeline is
  * still unused: that keeps a prepare retry idempotent (retries happen before
  * a compute ever boots on the branch), while reusing the id of a live branch
@@ -561,6 +561,30 @@ timeline_is_used(uint32_t timeline)
 
 /* highest end LSN (start+len) of shipped WAL received per timeline */
 static uint64_t wal_end[MAX_TIMELINES];
+
+static inline uint64_t
+wal_end_read(uint32_t timeline)
+{
+	if (timeline >= MAX_TIMELINES)
+		return 0;
+	return __atomic_load_n(&wal_end[timeline], __ATOMIC_ACQUIRE);
+}
+
+static inline void
+wal_end_advance(uint32_t timeline, uint64_t end_lsn)
+{
+	uint64_t	old_end;
+
+	if (timeline >= MAX_TIMELINES)
+		return;
+	old_end = __atomic_load_n(&wal_end[timeline], __ATOMIC_RELAXED);
+	while (end_lsn > old_end &&
+		   !__atomic_compare_exchange_n(&wal_end[timeline], &old_end,
+										end_lsn, false,
+										__ATOMIC_RELEASE,
+										__ATOMIC_RELAXED))
+		;
+}
 
 /* FNV-1a hash over a byte range (used to hash keys into buckets). */
 
@@ -806,11 +830,11 @@ branch_request_ok(uint32_t new_tl, int parent, uint64_t branch_lsn)
 	 * only while the timeline has no branch-local state yet.  Once it has
 	 * pages, forks or shipped WAL, the duplicate is timeline-id reuse, not a
 	 * retry, and accepting it would hand the caller the old branch's data.
-		 */
+	 */
 	if (new_tl < MAX_TIMELINES && timelines[new_tl].defined)
 		return timelines[new_tl].parent == parent &&
 			timelines[new_tl].branch_lsn == branch_lsn &&
-			!timeline_is_used(new_tl) && wal_end[new_tl] == 0;
+			!timeline_is_used(new_tl) && wal_end_read(new_tl) == 0;
 
 	if (new_tl == 0 || new_tl >= MAX_TIMELINES || parent < 0 ||
 		parent >= MAX_TIMELINES || !timelines[parent].defined)
@@ -964,14 +988,14 @@ wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,
 	if (tl >= MAX_TIMELINES)
 		return -1;
 
+	timeline_mark_used(tl);
 	h.magic = WAL_MAGIC;
 	h.len = len;
 	h.start_lsn = start_lsn;
 	if (ps_storage->wal_append(tl, &h, sizeof(h), data, len) != 0)
 		return -1;
 
-	if (start_lsn + len > wal_end[tl])
-		wal_end[tl] = start_lsn + len;
+	wal_end_advance(tl, start_lsn + len);
 	return 0;
 }
 
@@ -1028,8 +1052,11 @@ wal_recover_one(uint32_t tl)
 	while (ps_storage->wal_read(tl, off, &h, sizeof(h)) == (int) sizeof(h) &&
 		   h.magic == WAL_MAGIC)
 	{
-		if (h.start_lsn + h.len > wal_end[tl])
-			wal_end[tl] = h.start_lsn + h.len;
+		if (h.start_lsn + h.len > wal_end_read(tl))
+		{
+			timeline_mark_used(tl);
+			wal_end_advance(tl, h.start_lsn + h.len);
+		}
 		off += sizeof(h) + h.len;
 	}
 }
@@ -1564,7 +1591,7 @@ ps_handle_meta(PsChannel *ch)
 			break;
 
 		case PS_OP_WAL_SIZE:
-			ch->req_lsn = wal_end[tl];	/* output: end LSN of this timeline's WAL */
+			ch->req_lsn = wal_end_read(tl);	/* output: end LSN of this timeline's WAL */
 			break;
 
 		case PS_OP_WAL_READ:

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -532,6 +532,24 @@ typedef struct TimelineMeta
 
 static TimelineMeta timelines[MAX_TIMELINES];
 
+/*
+ * Branch-local usage marker: set once a timeline acquires any local state (a
+ * page version or fork entry here; shipped WAL is tracked by wal_end[]).  An
+ * exact-match duplicate CREATE_BRANCH is accepted only while the timeline is
+ * still unused: that keeps a prepare retry idempotent (retries happen before
+ * a compute ever boots on the branch), while reusing the id of a live branch
+ * is refused -- read_through() resolves timeline-local versions before the
+ * parent snapshot, so a "fresh" branch recreated over a written timeline
+ * would silently serve the previous branch's pages.  Plain ints, not
+ * atomics: every writer stores 1, and a duplicate create racing the
+ * timeline's very first write is indistinguishable from that write landing
+ * just after an accepted create.
+ */
+static int timeline_used[MAX_TIMELINES];
+
+/* highest end LSN (start+len) of shipped WAL received per timeline */
+static uint64_t wal_end[MAX_TIMELINES];
+
 /* FNV-1a hash over a byte range (used to hash keys into buckets). */
 
 static uint32_t
@@ -592,6 +610,8 @@ page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
 	Shard	   *s = shard_for(key);
 	PageEnt    *e = page_find(timeline, key, block);
 
+	if (timeline < MAX_TIMELINES)
+		timeline_used[timeline] = 1;
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
@@ -651,6 +671,8 @@ fork_get_or_create(uint32_t timeline, const PsKey *key)
 	Shard	   *s = shard_for(key);
 	ForkEnt    *e = fork_find(timeline, key);
 
+	if (timeline < MAX_TIMELINES)
+		timeline_used[timeline] = 1;
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
@@ -758,7 +780,8 @@ tl_walk_next(TlWalk *w)
  * the fork-size walks follow the parent chain assuming it is finite and well
  * formed, so a bad CREATE_BRANCH must be rejected rather than persisted.  Refuse:
  *	- a new id that is out of range, or an already-defined id with mismatched
- *	  ancestry metadata (unless it exactly matches for idempotent retry);
+ *	  ancestry metadata (an exact match is an idempotent retry, but only while
+ *	  the timeline is still unused -- see timeline_used[]);
  *	- a parent that is out of range or not yet defined (the requested parent must
  *	  actually exist, else the branch silently inherits from nothing);
  *	- a parent whose ancestry already reaches the new id, which would turn the
@@ -768,10 +791,16 @@ tl_walk_next(TlWalk *w)
 static int
 branch_request_ok(uint32_t new_tl, int parent, uint64_t branch_lsn)
 {
-	/* Exact matches to an existing definition are idempotent retries. */
+	/*
+	 * Exact matches to an existing definition are idempotent retries -- but
+	 * only while the timeline has no branch-local state yet.  Once it has
+	 * pages, forks or shipped WAL, the duplicate is timeline-id reuse, not a
+	 * retry, and accepting it would hand the caller the old branch's data.
+	 */
 	if (new_tl < MAX_TIMELINES && timelines[new_tl].defined)
 		return timelines[new_tl].parent == parent &&
-			timelines[new_tl].branch_lsn == branch_lsn;
+			timelines[new_tl].branch_lsn == branch_lsn &&
+			!timeline_used[new_tl] && wal_end[new_tl] == 0;
 
 	if (new_tl == 0 || new_tl >= MAX_TIMELINES || parent < 0 ||
 		parent >= MAX_TIMELINES || !timelines[parent].defined)
@@ -915,9 +944,6 @@ typedef struct WalRecHdr
 	uint32_t	len;			/* WAL bytes following the header */
 	uint64_t	start_lsn;		/* LSN of the first byte */
 } WalRecHdr;
-
-/* highest end LSN (start+len) received per timeline */
-static uint64_t wal_end[MAX_TIMELINES];
 
 static int
 wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -303,7 +303,7 @@ gc_resume(void)
 		 * write error may have torn the manifest tail; stop so that record stays
 		 * the recoverable tail instead of becoming interior corruption, and the
 		 * next start retries from the last valid manifest state.
-		 */
+	 */
 		if (ps_layer_store->delete_local_layer(&dead[k]) != 0)
 			continue;
 		if (ps_manifest_remove_layer(dead[k].layer_id) != 0)
@@ -540,12 +540,24 @@ static TimelineMeta timelines[MAX_TIMELINES];
  * a compute ever boots on the branch), while reusing the id of a live branch
  * is refused -- read_through() resolves timeline-local versions before the
  * parent snapshot, so a "fresh" branch recreated over a written timeline
- * would silently serve the previous branch's pages.  Plain ints, not
- * atomics: every writer stores 1, and a duplicate create racing the
- * timeline's very first write is indistinguishable from that write landing
- * just after an accepted create.
+ * would silently serve the previous branch's pages.
  */
 static int timeline_used[MAX_TIMELINES];
+
+static inline void
+timeline_mark_used(uint32_t timeline)
+{
+	if (timeline < MAX_TIMELINES)
+		__atomic_store_n(&timeline_used[timeline], 1, __ATOMIC_RELEASE);
+}
+
+static inline int
+timeline_is_used(uint32_t timeline)
+{
+	if (timeline >= MAX_TIMELINES)
+		return 0;
+	return __atomic_load_n(&timeline_used[timeline], __ATOMIC_ACQUIRE);
+}
 
 /* highest end LSN (start+len) of shipped WAL received per timeline */
 static uint64_t wal_end[MAX_TIMELINES];
@@ -610,8 +622,7 @@ page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
 	Shard	   *s = shard_for(key);
 	PageEnt    *e = page_find(timeline, key, block);
 
-	if (timeline < MAX_TIMELINES)
-		timeline_used[timeline] = 1;
+	timeline_mark_used(timeline);
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
@@ -671,8 +682,7 @@ fork_get_or_create(uint32_t timeline, const PsKey *key)
 	Shard	   *s = shard_for(key);
 	ForkEnt    *e = fork_find(timeline, key);
 
-	if (timeline < MAX_TIMELINES)
-		timeline_used[timeline] = 1;
+	timeline_mark_used(timeline);
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
@@ -796,11 +806,11 @@ branch_request_ok(uint32_t new_tl, int parent, uint64_t branch_lsn)
 	 * only while the timeline has no branch-local state yet.  Once it has
 	 * pages, forks or shipped WAL, the duplicate is timeline-id reuse, not a
 	 * retry, and accepting it would hand the caller the old branch's data.
-	 */
+		 */
 	if (new_tl < MAX_TIMELINES && timelines[new_tl].defined)
 		return timelines[new_tl].parent == parent &&
 			timelines[new_tl].branch_lsn == branch_lsn &&
-			!timeline_used[new_tl] && wal_end[new_tl] == 0;
+			!timeline_is_used(new_tl) && wal_end[new_tl] == 0;
 
 	if (new_tl == 0 || new_tl >= MAX_TIMELINES || parent < 0 ||
 		parent >= MAX_TIMELINES || !timelines[parent].defined)
@@ -1052,6 +1062,8 @@ walidx_add(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 	uint32_t	h = page_hash(tl, key, block);
 	Shard	   *s = shard_for(key);
 	WalIdxEnt  *e;
+
+	timeline_mark_used(tl);
 
 	for (e = s->walidx[h & IDX_MASK]; e; e = e->next)
 		if (e->timeline == tl && e->block == block && key_eq(&e->key, key))

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -166,7 +166,7 @@ run_request(PsChannel *ch)
 	 * alone (no shard lock), so it serializes against map readers/writers but
 	 * not against per-shard work on unrelated shards.
 	 */
-	if (op == PS_OP_CREATE_BRANCH)
+	if (op == PS_OP_CREATE_BRANCH || op == PS_OP_CHECK_BRANCH)
 	{
 		ps_lock_map_wr();
 		handle_request(ch);

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -111,6 +111,7 @@ request_is_write(PsOpcode opcode)
 		case PS_OP_TRUNCATE:
 		case PS_OP_ZEROEXTEND:
 		case PS_OP_CREATE_BRANCH:
+		case PS_OP_CHECK_BRANCH:
 		case PS_OP_EXTEND:
 		case PS_OP_WRITEV:
 		case PS_OP_WAL_APPEND:

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -66,6 +66,7 @@ typedef enum PsOpcode
 	PS_OP_READV,				/* read nblocks pages at blocknum into data */
 	PS_OP_IMMEDSYNC,
 	PS_OP_READ_AT,				/* read 1 page at blocknum as-of req_lsn (COW) */
+	PS_OP_CHECK_BRANCH,			/* validate timeline creation request, no mutation */
 	PS_OP_CREATE_BRANCH,		/* create timeline from parent_timeline @ req_lsn */
 	PS_OP_WAL_APPEND,			/* append datalen WAL bytes at LSN req_lsn (timeline) */
 	PS_OP_WAL_SIZE,				/* return end LSN of the timeline's WAL in req_lsn */

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -359,6 +359,19 @@ op_create_branch_status(uint32_t new_tl, uint32_t parent_tl, uint64_t branch_lsn
 	return cl_exec()->status;
 }
 
+/* Like op_create_branch but only validates the request (no metadata mutation). */
+static int
+op_check_branch_status(uint32_t new_tl, uint32_t parent_tl, uint64_t branch_lsn)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	ch->opcode = PS_OP_CHECK_BRANCH;
+	ch->timeline = new_tl;
+	ch->parent_timeline = parent_tl;
+	ch->req_lsn = branch_lsn;
+	return cl_exec()->status;
+}
+
 /* Write one page on a specific timeline. */
 static void
 op_write_tl(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
@@ -811,6 +824,10 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 
 	/* CREATE_BRANCH validation: reject requests that would corrupt the parent
 	 * walk (timelines 0,1,2 are defined here) */
+	check(op_check_branch_status(1, 0, 1500) == PS_STATUS_OK,
+		  "CHECK_BRANCH accepts idempotent retry metadata");
+	check(op_check_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
+		  "CHECK_BRANCH rejects mismatched ancestry for existing timeline");
 	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_ERROR,
 		  "reject re-creating an existing timeline id");
 	check(op_create_branch_status(9, 900, 1500) == PS_STATUS_ERROR,

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -828,8 +828,10 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 		  "CHECK_BRANCH accepts idempotent retry metadata");
 	check(op_check_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
 		  "CHECK_BRANCH rejects mismatched ancestry for existing timeline");
-	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_ERROR,
-		  "reject re-creating an existing timeline id");
+	check(op_create_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
+		  "CREATE_BRANCH rejects re-creating existing timeline with mismatched ancestry");
+	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_OK,
+		  "re-create existing timeline id with identical ancestry is idempotent");
 	check(op_create_branch_status(9, 900, 1500) == PS_STATUS_ERROR,
 		  "reject branch off an undefined parent");
 	check(op_create_branch_status(9, 9, 1500) == PS_STATUS_ERROR,

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -824,14 +824,14 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 
 	/* CREATE_BRANCH validation: reject requests that would corrupt the parent
 	 * walk (timelines 0,1,2 are defined here) */
-	check(op_check_branch_status(1, 0, 1500) == PS_STATUS_OK,
-		  "CHECK_BRANCH accepts idempotent retry metadata");
+	check(op_check_branch_status(1, 0, 1500) == PS_STATUS_ERROR,
+		  "CHECK_BRANCH rejects retry of a timeline with branch-local writes");
 	check(op_check_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
 		  "CHECK_BRANCH rejects mismatched ancestry for existing timeline");
 	check(op_create_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
 		  "CREATE_BRANCH rejects re-creating existing timeline with mismatched ancestry");
-	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_OK,
-		  "re-create existing timeline id with identical ancestry is idempotent");
+	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_ERROR,
+		  "re-create of a written timeline id is rejected (would expose its pages)");
 	check(op_create_branch_status(9, 900, 1500) == PS_STATUS_ERROR,
 		  "reject branch off an undefined parent");
 	check(op_create_branch_status(9, 9, 1500) == PS_STATUS_ERROR,
@@ -842,6 +842,18 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 		  "valid branch off a defined branch still accepted");
 	op_read_tl(7, REL_B, FORK0, 0, rb);
 	check(page_has_tag(rb, ps, 11), "new valid branch reads through to root");
+
+	/* the idempotent-retry window: an unused timeline may be re-created (a
+	 * prepare retry), but the first branch-local write closes it -- reads on
+	 * the timeline do not */
+	check(op_check_branch_status(7, 2, 1500) == PS_STATUS_OK,
+		  "CHECK_BRANCH accepts retry of an unused timeline after reads");
+	check(op_create_branch_status(7, 2, 1500) == PS_STATUS_OK,
+		  "re-create of an unused timeline with identical ancestry is idempotent");
+	fill_page(p, ps, 4000, 77);
+	op_write_tl(7, REL_B, FORK0, 0, p);
+	check(op_create_branch_status(7, 2, 1500) == PS_STATUS_ERROR,
+		  "the timeline's first write closes the idempotent-retry window");
 
 	client_detach();
 	stop_daemon(dpid);
@@ -913,6 +925,8 @@ run_wal_suite(const char *daemon_path, const char *tmpbase)
 	client_attach(shm, ps);
 	check(op_wal_size(0) == 2000, "main WAL end LSN survives daemon restart");
 	check(op_wal_size(1) == 2300, "branch WAL end LSN survives daemon restart");
+	check(op_create_branch_status(1, 0, 2000) == PS_STATUS_ERROR,
+		  "shipped WAL also closes the idempotent re-create window (post-restart)");
 
 	client_detach();
 	stop_daemon(dpid);

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -327,6 +327,25 @@ posix_truncate_best_effort(int fd, off_t old_size)
 	}
 }
 
+static void
+posix_fsync_dir_best_effort(void)
+{
+	int		fd = open(posix_dir, O_RDONLY | O_DIRECTORY);
+
+	if (fd >= 0)
+	{
+		(void) fsync(fd);
+		close(fd);
+	}
+}
+
+static void
+posix_unlink_created_meta(const char *path)
+{
+	if (unlink(path) == 0)
+		posix_fsync_dir_best_effort();
+}
+
 /*
  * Roll back an append whose record may already be durable in the metadata
  * log: reopen the log, truncate it back to old_size, and push the truncate
@@ -347,7 +366,7 @@ posix_meta_rollback(const char *path, off_t old_size, int created)
 		close(fd);
 	}
 	if (created && old_size == 0)
-		(void) unlink(path);
+		posix_unlink_created_meta(path);
 }
 
 static int
@@ -368,7 +387,7 @@ posix_meta_append(const void *buf, uint32_t len)
 	{
 		close(fd);
 		if (created)
-			(void) unlink(path);
+			posix_unlink_created_meta(path);
 		return -1;
 	}
 
@@ -384,7 +403,7 @@ posix_meta_append(const void *buf, uint32_t len)
 		posix_truncate_best_effort(fd, old_size);
 		close(fd);
 		if (created)
-			(void) unlink(path);
+			posix_unlink_created_meta(path);
 		return -1;
 	}
 	if (fsync(fd) != 0)
@@ -393,7 +412,7 @@ posix_meta_append(const void *buf, uint32_t len)
 		(void) fsync(fd);
 		close(fd);
 		if (created)
-			(void) unlink(path);
+			posix_unlink_created_meta(path);
 		return -1;
 	}
 	if (close(fd) != 0)

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -319,24 +319,43 @@ posix_meta_append(const void *buf, uint32_t len)
 	char		path[4096];
 	int		fd;
 	int		created;
+	off_t		old_size;
 
 	snprintf(path, sizeof(path), "%s/timelines", posix_dir);
 	created = access(path, F_OK) != 0;
 	fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
 	if (fd < 0)
 		return -1;
+	old_size = lseek(fd, 0, SEEK_END);
+	if (old_size < 0)
+	{
+		close(fd);
+		return -1;
+	}
 	if (write(fd, buf, len) != (ssize_t) len)
 	{
+		(void) ftruncate(fd, old_size);
 		close(fd);
 		return -1;
 	}
 	if (fsync(fd) != 0)
 	{
+		(void) ftruncate(fd, old_size);
+		(void) fsync(fd);
 		close(fd);
 		return -1;
 	}
 	if (close(fd) != 0)
+	{
+		fd = open(path, O_WRONLY);
+		if (fd >= 0)
+		{
+			(void) ftruncate(fd, old_size);
+			(void) fsync(fd);
+			close(fd);
+		}
 		return -1;
+	}
 	if (created)
 	{
 		fd = open(posix_dir, O_RDONLY | O_DIRECTORY);
@@ -345,10 +364,30 @@ posix_meta_append(const void *buf, uint32_t len)
 		if (fsync(fd) != 0)
 		{
 			close(fd);
+			fd = open(path, O_WRONLY);
+			if (fd >= 0)
+			{
+				(void) ftruncate(fd, old_size);
+				(void) fsync(fd);
+				close(fd);
+			}
+			if (old_size == 0)
+				(void) unlink(path);
 			return -1;
 		}
 		if (close(fd) != 0)
+		{
+			fd = open(path, O_WRONLY);
+			if (fd >= 0)
+			{
+				(void) ftruncate(fd, old_size);
+				(void) fsync(fd);
+				close(fd);
+			}
+			if (old_size == 0)
+				(void) unlink(path);
 			return -1;
+		}
 	}
 	return 0;
 }

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -367,12 +367,24 @@ posix_meta_append(const void *buf, uint32_t len)
 	if (old_size < 0)
 	{
 		close(fd);
+		if (created)
+			(void) unlink(path);
 		return -1;
 	}
+
+	/*
+	 * Every failure below must also remove a file this append created (not
+	 * just truncate it): if an empty log lingered, the next successful append
+	 * would see the file as pre-existing and skip the directory fsync, so its
+	 * directory entry would never be made durable and a crash could drop an
+	 * acknowledged record with it.
+	 */
 	if (write(fd, buf, len) != (ssize_t) len)
 	{
 		posix_truncate_best_effort(fd, old_size);
 		close(fd);
+		if (created)
+			(void) unlink(path);
 		return -1;
 	}
 	if (fsync(fd) != 0)
@@ -380,6 +392,8 @@ posix_meta_append(const void *buf, uint32_t len)
 		posix_truncate_best_effort(fd, old_size);
 		(void) fsync(fd);
 		close(fd);
+		if (created)
+			(void) unlink(path);
 		return -1;
 	}
 	if (close(fd) != 0)

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -327,6 +327,29 @@ posix_truncate_best_effort(int fd, off_t old_size)
 	}
 }
 
+/*
+ * Roll back an append whose record may already be durable in the metadata
+ * log: reopen the log, truncate it back to old_size, and push the truncate
+ * out.  If this append created the file, remove it again -- otherwise a
+ * failed append is reported as an error yet a daemon restart would replay
+ * the record from the log and resurrect it.  Best-effort, like
+ * posix_truncate_best_effort().
+ */
+static void
+posix_meta_rollback(const char *path, off_t old_size, int created)
+{
+	int		fd = open(path, O_WRONLY);
+
+	if (fd >= 0)
+	{
+		posix_truncate_best_effort(fd, old_size);
+		(void) fsync(fd);
+		close(fd);
+	}
+	if (created && old_size == 0)
+		(void) unlink(path);
+}
+
 static int
 posix_meta_append(const void *buf, uint32_t len)
 {
@@ -361,45 +384,26 @@ posix_meta_append(const void *buf, uint32_t len)
 	}
 	if (close(fd) != 0)
 	{
-		fd = open(path, O_WRONLY);
-		if (fd >= 0)
-		{
-			posix_truncate_best_effort(fd, old_size);
-			(void) fsync(fd);
-			close(fd);
-		}
+		posix_meta_rollback(path, old_size, created);
 		return -1;
 	}
 	if (created)
 	{
 		fd = open(posix_dir, O_RDONLY | O_DIRECTORY);
 		if (fd < 0)
+		{
+			posix_meta_rollback(path, old_size, created);
 			return -1;
+		}
 		if (fsync(fd) != 0)
 		{
 			close(fd);
-			fd = open(path, O_WRONLY);
-			if (fd >= 0)
-			{
-				posix_truncate_best_effort(fd, old_size);
-				(void) fsync(fd);
-				close(fd);
-			}
-			if (old_size == 0)
-				(void) unlink(path);
+			posix_meta_rollback(path, old_size, created);
 			return -1;
 		}
 		if (close(fd) != 0)
 		{
-			fd = open(path, O_WRONLY);
-			if (fd >= 0)
-			{
-				posix_truncate_best_effort(fd, old_size);
-				(void) fsync(fd);
-				close(fd);
-			}
-			if (old_size == 0)
-				(void) unlink(path);
+			posix_meta_rollback(path, old_size, created);
 			return -1;
 		}
 	}

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -313,6 +313,20 @@ posix_wal_read(uint32_t tl, uint64_t off, void *buf, uint32_t len)
 	return (int) n;
 }
 
+/*
+ * Truncate fd back to old_size on an error path.  Best-effort: the caller
+ * is already returning an error and cannot act on a rollback failure; the
+ * torn tail is detected and discarded on the next meta read.
+ */
+static void
+posix_truncate_best_effort(int fd, off_t old_size)
+{
+	if (ftruncate(fd, old_size) != 0)
+	{
+		/* nothing we can do; see above */
+	}
+}
+
 static int
 posix_meta_append(const void *buf, uint32_t len)
 {
@@ -334,13 +348,13 @@ posix_meta_append(const void *buf, uint32_t len)
 	}
 	if (write(fd, buf, len) != (ssize_t) len)
 	{
-		(void) ftruncate(fd, old_size);
+		posix_truncate_best_effort(fd, old_size);
 		close(fd);
 		return -1;
 	}
 	if (fsync(fd) != 0)
 	{
-		(void) ftruncate(fd, old_size);
+		posix_truncate_best_effort(fd, old_size);
 		(void) fsync(fd);
 		close(fd);
 		return -1;
@@ -350,7 +364,7 @@ posix_meta_append(const void *buf, uint32_t len)
 		fd = open(path, O_WRONLY);
 		if (fd >= 0)
 		{
-			(void) ftruncate(fd, old_size);
+			posix_truncate_best_effort(fd, old_size);
 			(void) fsync(fd);
 			close(fd);
 		}
@@ -367,7 +381,7 @@ posix_meta_append(const void *buf, uint32_t len)
 			fd = open(path, O_WRONLY);
 			if (fd >= 0)
 			{
-				(void) ftruncate(fd, old_size);
+				posix_truncate_best_effort(fd, old_size);
 				(void) fsync(fd);
 				close(fd);
 			}
@@ -380,7 +394,7 @@ posix_meta_append(const void *buf, uint32_t len)
 			fd = open(path, O_WRONLY);
 			if (fd >= 0)
 			{
-				(void) ftruncate(fd, old_size);
+				posix_truncate_best_effort(fd, old_size);
 				(void) fsync(fd);
 				close(fd);
 			}

--- a/contrib/pagestore/wal_only_redo_demo.sh
+++ b/contrib/pagestore/wal_only_redo_demo.sh
@@ -26,7 +26,7 @@ WALRESTORE="$BUILD/contrib/pagestore/pagestore_walrestore"
 D=$(mktemp -d)/pgdata
 S=$(mktemp -d)/store
 SHM=/pswonly_$$
-PORT=54480
+PORT=$((54000 + ($$ % 1000)))
 P="$BIN/psql -h 127.0.0.1 -p $PORT -U postgres -tA"
 
 cleanup() {
@@ -58,6 +58,11 @@ port = $PORT
 EOF
 
 "$BIN/pg_ctl" -D "$D" -l "$D/w.log" -w start >/dev/null 2>&1
+if ! $P -c "SELECT 1;" >/dev/null 2>&1; then
+	echo "FAIL - writer did not accept connections on port $PORT; log:"
+	tail -20 "$D/w.log" 2>/dev/null
+	exit 1
+fi
 # base backup right at the start (recovery start point), before any user table
 "$BIN/psql" -h 127.0.0.1 -p $PORT -U postgres >/dev/null <<SQL
 SELECT pg_backup_start('b', fast => true);

--- a/contrib/pagestore/wal_only_redo_demo.sh
+++ b/contrib/pagestore/wal_only_redo_demo.sh
@@ -26,7 +26,7 @@ WALRESTORE="$BUILD/contrib/pagestore/pagestore_walrestore"
 D=$(mktemp -d)/pgdata
 S=$(mktemp -d)/store
 SHM=/pswonly_$$
-PORT=$((54000 + ($$ % 1000)))
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
 P="$BIN/psql -h 127.0.0.1 -p $PORT -U postgres -tA"
 
 cleanup() {
@@ -54,6 +54,7 @@ io_method = sync
 recovery_prefetch = off
 archive_mode = on
 archive_library = 'pagestore'
+listen_addresses = '127.0.0.1'
 port = $PORT
 EOF
 


### PR DESCRIPTION
## Summary
- add pagestore_prepare_branch() as a control-plane bootstrap entrypoint
- prepare a branch by seeding all bootstrap SLRUs, forking the store timeline, and atomically writing a pagestore_branch.manifest file
- extend the integration test to verify the manifest and seeded pg_xact/pg_multixact pages

## Stack
- stacked on #71 / feat/pagestore-branch-bootstrap-slrus
- #71 is stacked on #70

## Validation
- not run locally