### PR TITLE
pagestore: validate branch bootstrap manifest

### DIFF
--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -539,7 +539,9 @@ $P -c "CREATE FUNCTION pagestore_multixact_members_page_asof(int, pg_lsn, pg_lsn
        CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_seed_branch_slrus' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
-        AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;" >/dev/null
+        AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;
+       CREATE FUNCTION pagestore_validate_branch_manifest(text, int, int, pg_lsn) RETURNS bool
+        AS 'pagestore','pagestore_validate_branch_manifest' LANGUAGE C STRICT;" >/dev/null
 mOff=$mxRecon                                          # mA's first member offset (step 20)
 # MULTIXACT_MEMBERS_PER_PAGE = (block_size / MULTIXACT_MEMBERGROUP_SIZE) * members-per-group;
 # the group is 4 flag bytes + 4 TransactionIds = 20 bytes, 4 members each (block-size derived)
@@ -606,6 +608,10 @@ manifestHasTimeline=$($P -c "SELECT position('\"new_timeline\": 2' in pg_read_fi
 assert "$manifestHasTimeline" "t" "branch prepare manifest records the new timeline"
 manifestHasFork=$($P -c "SELECT position('\"fork_lsn\": ' in pg_read_file('$PREPSEED/pagestore_branch.manifest')) > 0;")
 assert "$manifestHasFork" "t" "branch prepare manifest records the fork LSN"
+assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');")" "t" \
+	"branch manifest validator accepts the prepared branch identity"
+assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 3, 0, '$mxL');")" "f" \
+	"branch manifest validator rejects the wrong branch timeline"
 prepClogMd5=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_xact/$bootClogSeg', $(( bootClogPage * bs )), $bs));")
 assert "$prepClogMd5" "$bootClogRecon" "branch prepare pg_xact page == reconstructed as-of-L page"
 prepMxOff=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_multixact/offsets/$mxSeg', $(( (mxPage % 32) * bs )), $bs));")

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -617,6 +617,21 @@ assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$
 	"branch manifest validator accepts the prepared branch identity"
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 3, 0, '$mxL');")" "f" \
 	"branch manifest validator rejects the wrong branch timeline"
+cp "$PREPSEED/pagestore_branch.manifest" "$PREPSEED/pagestore_branch.manifest.good"
+cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
+{ "wrapper": { "format": 1, "new_timeline": 2, "parent_timeline": 0, "fork_lsn": "$mxL" } }
+EOF
+assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');")" "f" \
+	"branch manifest validator rejects nested manifest fields"
+cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
+{ "format": 1, "new_timeline": 0, "parent_timeline": 0, "fork_lsn": "$mxL" }
+EOF
+assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 0, 0, '$mxL');")" "f" \
+	"branch manifest validator rejects timeline zero"
+printf '{ "format": 1, "new_timeline": 2, "parent_timeline": 0, "fork_lsn": "%s" }\\0{ "format": 2 }\\n' "$mxL" > "$PREPSEED/pagestore_branch.manifest"
+nulManifest=$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');" 2>/dev/null || echo ERROR)
+assert "$nulManifest" "ERROR" "branch manifest validator rejects embedded NUL bytes"
+mv "$PREPSEED/pagestore_branch.manifest.good" "$PREPSEED/pagestore_branch.manifest"
 prepClogMd5=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_xact/$bootClogSeg', $(( bootClogPage * bs )), $bs));")
 assert "$prepClogMd5" "$bootClogRecon" "branch prepare pg_xact page == reconstructed as-of-L page"
 prepMxOff=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_multixact/offsets/$mxSeg', $(( (mxPage % 32) * bs )), $bs));")

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -628,7 +628,7 @@ cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
 EOF
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 0, 0, '$mxL');")" "f" \
 	"branch manifest validator rejects timeline zero"
-printf '{ "format": 1, "new_timeline": 2, "parent_timeline": 0, "fork_lsn": "%s" }\\0{ "format": 2 }\\n' "$mxL" > "$PREPSEED/pagestore_branch.manifest"
+printf '{ "format": 1, "new_timeline": 2, "parent_timeline": 0, "fork_lsn": "%s" }\0{ "format": 2 }\n' "$mxL" > "$PREPSEED/pagestore_branch.manifest"
 nulManifest=$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');" 2>/dev/null || echo ERROR)
 assert "$nulManifest" "ERROR" "branch manifest validator rejects embedded NUL bytes"
 mv "$PREPSEED/pagestore_branch.manifest.good" "$PREPSEED/pagestore_branch.manifest"

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -625,6 +625,11 @@ EOF
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');")" "f" \
 	"branch manifest validator rejects nested manifest fields"
 cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
+{ "format": 1, "new_timeline": 2, "parent_timeline": 0, "fork_lsn": "$mxL", "extra": @ }
+EOF
+assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');")" "f" \
+	"branch manifest validator rejects malformed JSON"
+cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
 { "format": 1, "new_timeline": 0, "parent_timeline": 0, "fork_lsn": "$mxL" }
 EOF
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 0, 0, '$mxL');")" "f" \

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -630,6 +630,11 @@ EOF
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');")" "f" \
 	"branch manifest validator rejects malformed JSON"
 cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
+{ "format": 1, "new_timeline": 2, "new_\u0074imeline": 3, "parent_timeline": 0, "fork_lsn": "$mxL" }
+EOF
+assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');")" "f" \
+	"branch manifest validator rejects escaped duplicate keys"
+cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
 { "format": 1, "new_timeline": 0, "parent_timeline": 0, "fork_lsn": "$mxL" }
 EOF
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 0, 0, '$mxL');")" "f" \

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3266,6 +3266,8 @@ pagestore_seed_branch_slrus(PG_FUNCTION_ARGS)
 	PG_RETURN_INT64(seeded);
 }
 
+#define PAGESTORE_BRANCH_MANIFEST_MAXLEN 8192
+
 static void
 pagestore_write_branch_manifest(const char *target_dir,
 								int32 new_tl, int32 parent_tl,
@@ -3394,7 +3396,16 @@ pagestore_read_branch_manifest(const char *target_dir)
 
 	initStringInfo(&buf);
 	while ((nread = fread(tmp, 1, sizeof(tmp), file)) > 0)
+	{
+		if (buf.len + nread > PAGESTORE_BRANCH_MANIFEST_MAXLEN)
+		{
+			FreeFile(file);
+			ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					 errmsg("branch manifest \"%s\" is too large", path)));
+		}
 		appendBinaryStringInfo(&buf, tmp, nread);
+	}
 	if (ferror(file))
 	{
 		FreeFile(file);
@@ -3406,46 +3417,111 @@ pagestore_read_branch_manifest(const char *target_dir)
 	return buf.data;
 }
 
+static const char *
+pagestore_manifest_skip_ws(const char *p)
+{
+	while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+		p++;
+	return p;
+}
+
+static bool
+pagestore_manifest_value_ends(char c)
+{
+	return c == '\0' || c == ',' || c == '}' ||
+		c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+static const char *
+pagestore_manifest_find_field(const char *manifest, const char *key)
+{
+	size_t		keylen = strlen(key);
+	const char *p = manifest;
+
+	while ((p = strchr(p, '"')) != NULL)
+	{
+		const char *name = p + 1;
+		const char *end = strchr(name, '"');
+
+		if (end == NULL)
+			return NULL;
+		if ((size_t) (end - name) == keylen &&
+			strncmp(name, key, keylen) == 0)
+		{
+			p = pagestore_manifest_skip_ws(end + 1);
+			if (*p != ':')
+				return NULL;
+			return pagestore_manifest_skip_ws(p + 1);
+		}
+		p = end + 1;
+	}
+	return NULL;
+}
+
 static bool
 pagestore_manifest_has_token(const char *manifest, const char *key,
 							 const char *value)
 {
-	char		token[256];
-	int			len;
-	const char *match;
+	const char *field = pagestore_manifest_find_field(manifest, key);
+	size_t		len = strlen(value);
 
-	len = snprintf(token, sizeof(token), "\"%s\": %s", key, value);
-	if (len < 0 || len >= (int) sizeof(token))
-		ereport(ERROR,
-				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-				 errmsg("branch manifest token is too large")));
-	match = manifest;
-	while ((match = strstr(match, token)) != NULL)
-	{
-		char		next = match[len];
-
-		if (next == '\0' || next == ',' || next == '}' ||
-			next == '\n' || next == '\r' ||
-			next == ' ' || next == '\t')
-			return true;
-		match += len;
-	}
-	return false;
+	if (field == NULL)
+		return false;
+	if (*field == '"')
+		return false;
+	if (strncmp(field, value, len) != 0)
+		return false;
+	return pagestore_manifest_value_ends(field[len]);
 }
 
 static bool
 pagestore_manifest_has_string_token(const char *manifest, const char *key,
 									const char *value)
 {
-	char		quoted[128];
+	const char *field = pagestore_manifest_find_field(manifest, key);
+	size_t		len = strlen(value);
+
+	if (field == NULL)
+		return false;
+	if (*field != '"')
+		return false;
+	field++;
+	if (strncmp(field, value, len) != 0)
+		return false;
+	return field[len] == '"';
+}
+
+static bool
+pagestore_manifest_matches(const char *manifest, int32 new_tl, int32 parent_tl,
+						   XLogRecPtr fork_lsn)
+{
+	char		buf[64];
 	int			len;
 
-	len = snprintf(quoted, sizeof(quoted), "\"%s\"", value);
-	if (len < 0 || len >= (int) sizeof(quoted))
+	if (!pagestore_manifest_has_token(manifest, "format", "1"))
+		return false;
+	len = snprintf(buf, sizeof(buf), "%d", new_tl);
+	if (len < 0 || len >= (int) sizeof(buf))
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("branch manifest token is too large")));
-	return pagestore_manifest_has_token(manifest, key, quoted);
+	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+		return false;
+	len = snprintf(buf, sizeof(buf), "%d", parent_tl);
+	if (len < 0 || len >= (int) sizeof(buf))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("branch manifest token is too large")));
+	if (!pagestore_manifest_has_token(manifest, "parent_timeline", buf))
+		return false;
+	len = snprintf(buf, sizeof(buf), "%X/%08X", LSN_FORMAT_ARGS(fork_lsn));
+	if (len < 0 || len >= (int) sizeof(buf))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("branch manifest token is too large")));
+	if (!pagestore_manifest_has_string_token(manifest, "fork_lsn", buf))
+		return false;
+	return true;
 }
 
 /*
@@ -3468,7 +3544,6 @@ pagestore_validate_branch_manifest(PG_FUNCTION_ARGS)
 	int32		parent_tl = PG_GETARG_INT32(2);
 	XLogRecPtr	fork_lsn = PG_GETARG_LSN(3);
 	char	   *manifest;
-	char		buf[64];
 
 	if (!superuser())
 		ereport(ERROR,
@@ -3478,19 +3553,8 @@ pagestore_validate_branch_manifest(PG_FUNCTION_ARGS)
 	manifest = pagestore_read_branch_manifest(target_dir);
 	if (manifest == NULL)
 		PG_RETURN_BOOL(false);
-	if (!pagestore_manifest_has_token(manifest, "format", "1"))
-		PG_RETURN_BOOL(false);
-	snprintf(buf, sizeof(buf), "%d", new_tl);
-	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
-		PG_RETURN_BOOL(false);
-	snprintf(buf, sizeof(buf), "%d", parent_tl);
-	if (!pagestore_manifest_has_token(manifest, "parent_timeline", buf))
-		PG_RETURN_BOOL(false);
-	snprintf(buf, sizeof(buf), "%X/%08X", LSN_FORMAT_ARGS(fork_lsn));
-	if (!pagestore_manifest_has_string_token(manifest, "fork_lsn", buf))
-		PG_RETURN_BOOL(false);
-
-	PG_RETURN_BOOL(true);
+	PG_RETURN_BOOL(pagestore_manifest_matches(manifest, new_tl, parent_tl,
+											  fork_lsn));
 }
 
 /*

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -50,6 +50,7 @@
 #include "catalog/storage_xlog.h"
 #include "common/file_perm.h"
 #include "fmgr.h"
+#include "lib/stringinfo.h"
 #include "miscadmin.h"
 #include "pagestore_backend.h"
 #include "pagestore_ipc.h"
@@ -3364,6 +3365,114 @@ pagestore_write_branch_manifest(const char *target_dir,
 				(errcode_for_file_access(),
 				 errmsg("could not publish branch manifest \"%s\": %m", path)));
 	fsync_fname(target_dir, true);
+}
+
+static char *
+pagestore_read_branch_manifest(const char *target_dir)
+{
+	char		path[MAXPGPATH];
+	FILE	   *file;
+	StringInfoData buf;
+	char		tmp[1024];
+	size_t		nread;
+
+	if (strlen(target_dir) + sizeof("/pagestore_branch.manifest") > MAXPGPATH)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("branch target directory path is too long")));
+
+	snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
+	file = AllocateFile(path, PG_BINARY_R);
+	if (file == NULL)
+		return NULL;
+
+	initStringInfo(&buf);
+	while ((nread = fread(tmp, 1, sizeof(tmp), file)) > 0)
+		appendBinaryStringInfo(&buf, tmp, nread);
+	if (ferror(file))
+	{
+		FreeFile(file);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read branch manifest \"%s\": %m", path)));
+	}
+	FreeFile(file);
+	return buf.data;
+}
+
+static bool
+pagestore_manifest_has_token(const char *manifest, const char *key,
+							 const char *value)
+{
+	char		token[256];
+	int			len;
+
+	len = snprintf(token, sizeof(token), "\"%s\": %s", key, value);
+	if (len < 0 || len >= (int) sizeof(token))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("branch manifest token is too large")));
+	return strstr(manifest, token) != NULL;
+}
+
+static bool
+pagestore_manifest_has_string_token(const char *manifest, const char *key,
+									const char *value)
+{
+	char		quoted[128];
+	int			len;
+
+	len = snprintf(quoted, sizeof(quoted), "\"%s\"", value);
+	if (len < 0 || len >= (int) sizeof(quoted))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("branch manifest token is too large")));
+	return pagestore_manifest_has_token(manifest, key, quoted);
+}
+
+/*
+ * pagestore_validate_branch_manifest(target_dir text, new_timeline int,
+ *                                    parent_timeline int, fork_lsn pg_lsn)
+ * returns bool
+ *
+ * Bootstrap preflight for a prepared branch datadir.  It verifies that the
+ * durable manifest written by pagestore_prepare_branch() matches the timeline
+ * identity the caller is about to boot.  This intentionally does not mutate the
+ * datadir; it is a guard against pointing a compute at the wrong copied
+ * datadir or store timeline.
+ */
+PG_FUNCTION_INFO_V1(pagestore_validate_branch_manifest);
+Datum
+pagestore_validate_branch_manifest(PG_FUNCTION_ARGS)
+{
+	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	int32		new_tl = PG_GETARG_INT32(1);
+	int32		parent_tl = PG_GETARG_INT32(2);
+	XLogRecPtr	fork_lsn = PG_GETARG_LSN(3);
+	char	   *manifest;
+	char		buf[64];
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to validate a branch manifest")));
+
+	manifest = pagestore_read_branch_manifest(target_dir);
+	if (manifest == NULL)
+		PG_RETURN_BOOL(false);
+	if (!pagestore_manifest_has_token(manifest, "format", "1"))
+		PG_RETURN_BOOL(false);
+	snprintf(buf, sizeof(buf), "%d", new_tl);
+	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+		PG_RETURN_BOOL(false);
+	snprintf(buf, sizeof(buf), "%d", parent_tl);
+	if (!pagestore_manifest_has_token(manifest, "parent_timeline", buf))
+		PG_RETURN_BOOL(false);
+	snprintf(buf, sizeof(buf), "%X/%08X", LSN_FORMAT_ARGS(fork_lsn));
+	if (!pagestore_manifest_has_string_token(manifest, "fork_lsn", buf))
+		PG_RETURN_BOOL(false);
+
+	PG_RETURN_BOOL(true);
 }
 
 /*

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4353,48 +4353,221 @@ pagestore_manifest_has_string_token(const char *manifest, const char *key,
 }
 
 static bool
-pagestore_manifest_is_single_object(const char *manifest)
-{
-	const char *p = pagestore_manifest_skip_ws(manifest);
-	int			depth = 0;
+pagestore_manifest_parse_value(const char **pp);
 
-	if (*p != '{')
+static bool
+pagestore_manifest_parse_string(const char **pp)
+{
+	const char *p = *pp;
+	int			i;
+
+	if (*p != '"')
 		return false;
+	p++;
 	while (*p != '\0')
 	{
+		if ((unsigned char) *p < 0x20)
+			return false;
 		if (*p == '"')
 		{
-			p++;
-			while (*p != '\0')
-			{
-				if (*p == '\\' && p[1] != '\0')
-				{
-					p += 2;
-					continue;
-				}
-				if (*p == '"')
-					break;
-				p++;
-			}
-			if (*p == '\0')
-				return false;
+			*pp = p + 1;
+			return true;
 		}
-		else if (*p == '{' || *p == '[')
-			depth++;
-		else if (*p == '}' || *p == ']')
+		if (*p == '\\')
 		{
-			depth--;
-			if (depth == 0)
+			p++;
+			if (*p == '"' || *p == '\\' || *p == '/' ||
+				*p == 'b' || *p == 'f' || *p == 'n' ||
+				*p == 'r' || *p == 't')
 			{
-				p = pagestore_manifest_skip_ws(p + 1);
-				return *p == '\0';
+				p++;
+				continue;
 			}
-			if (depth < 0)
-				return false;
+			if (*p == 'u')
+			{
+				for (i = 0; i < 4; i++)
+				{
+					p++;
+					if (!((*p >= '0' && *p <= '9') ||
+						  (*p >= 'a' && *p <= 'f') ||
+						  (*p >= 'A' && *p <= 'F')))
+						return false;
+				}
+				p++;
+				continue;
+			}
+			return false;
 		}
 		p++;
 	}
 	return false;
+}
+
+static bool
+pagestore_manifest_parse_number(const char **pp)
+{
+	const char *p = *pp;
+
+	if (*p == '-')
+		p++;
+	if (*p == '0')
+		p++;
+	else
+	{
+		if (*p < '1' || *p > '9')
+			return false;
+		while (*p >= '0' && *p <= '9')
+			p++;
+	}
+	if (*p == '.')
+	{
+		p++;
+		if (*p < '0' || *p > '9')
+			return false;
+		while (*p >= '0' && *p <= '9')
+			p++;
+	}
+	if (*p == 'e' || *p == 'E')
+	{
+		p++;
+		if (*p == '+' || *p == '-')
+			p++;
+		if (*p < '0' || *p > '9')
+			return false;
+		while (*p >= '0' && *p <= '9')
+			p++;
+	}
+	*pp = p;
+	return true;
+}
+
+static bool
+pagestore_manifest_parse_literal(const char **pp, const char *literal)
+{
+	size_t		len = strlen(literal);
+
+	if (strncmp(*pp, literal, len) != 0)
+		return false;
+	*pp += len;
+	return true;
+}
+
+static bool
+pagestore_manifest_parse_array(const char **pp)
+{
+	const char *p = pagestore_manifest_skip_ws(*pp + 1);
+
+	if (*p == ']')
+	{
+		*pp = p + 1;
+		return true;
+	}
+	for (;;)
+	{
+		if (!pagestore_manifest_parse_value(&p))
+			return false;
+		p = pagestore_manifest_skip_ws(p);
+		if (*p == ']')
+		{
+			*pp = p + 1;
+			return true;
+		}
+		if (*p != ',')
+			return false;
+		p = pagestore_manifest_skip_ws(p + 1);
+	}
+}
+
+static bool
+pagestore_manifest_parse_object(const char **pp)
+{
+	const char *p = pagestore_manifest_skip_ws(*pp + 1);
+
+	if (*p == '}')
+	{
+		*pp = p + 1;
+		return true;
+	}
+	for (;;)
+	{
+		if (!pagestore_manifest_parse_string(&p))
+			return false;
+		p = pagestore_manifest_skip_ws(p);
+		if (*p != ':')
+			return false;
+		p = pagestore_manifest_skip_ws(p + 1);
+		if (!pagestore_manifest_parse_value(&p))
+			return false;
+		p = pagestore_manifest_skip_ws(p);
+		if (*p == '}')
+		{
+			*pp = p + 1;
+			return true;
+		}
+		if (*p != ',')
+			return false;
+		p = pagestore_manifest_skip_ws(p + 1);
+	}
+}
+
+static bool
+pagestore_manifest_parse_value(const char **pp)
+{
+	const char *p = pagestore_manifest_skip_ws(*pp);
+
+	if (*p == '"')
+	{
+		if (!pagestore_manifest_parse_string(&p))
+			return false;
+	}
+	else if (*p == '{')
+	{
+		if (!pagestore_manifest_parse_object(&p))
+			return false;
+	}
+	else if (*p == '[')
+	{
+		if (!pagestore_manifest_parse_array(&p))
+			return false;
+	}
+	else if (*p == '-' || (*p >= '0' && *p <= '9'))
+	{
+		if (!pagestore_manifest_parse_number(&p))
+			return false;
+	}
+	else if (*p == 't')
+	{
+		if (!pagestore_manifest_parse_literal(&p, "true"))
+			return false;
+	}
+	else if (*p == 'f')
+	{
+		if (!pagestore_manifest_parse_literal(&p, "false"))
+			return false;
+	}
+	else if (*p == 'n')
+	{
+		if (!pagestore_manifest_parse_literal(&p, "null"))
+			return false;
+	}
+	else
+		return false;
+
+	*pp = p;
+	return true;
+}
+
+static bool
+pagestore_manifest_is_single_object(const char *manifest)
+{
+	const char *p = pagestore_manifest_skip_ws(manifest);
+
+	if (*p != '{')
+		return false;
+	if (!pagestore_manifest_parse_object(&p))
+		return false;
+	p = pagestore_manifest_skip_ws(p);
+	return *p == '\0';
 }
 
 static bool

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3377,6 +3377,7 @@ pagestore_read_branch_manifest(const char *target_dir)
 	StringInfoData buf;
 	char		tmp[1024];
 	size_t		nread;
+	long		manifest_size;
 
 	if (strlen(target_dir) + sizeof("/pagestore_branch.manifest") > MAXPGPATH)
 		ereport(ERROR,
@@ -3392,6 +3393,28 @@ pagestore_read_branch_manifest(const char *target_dir)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not open branch manifest \"%s\": %m", path)));
+	}
+	if (fseek(file, 0L, SEEK_END) != 0)
+	{
+		FreeFile(file);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read branch manifest \"%s\": %m", path)));
+	}
+	manifest_size = ftell(file);
+	if (manifest_size < 0 || manifest_size > PAGESTORE_BRANCH_MANIFEST_MAXLEN)
+	{
+		FreeFile(file);
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("branch manifest \"%s\" is too large", path)));
+	}
+	if (fseek(file, 0L, SEEK_SET) != 0)
+	{
+		FreeFile(file);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read branch manifest \"%s\": %m", path)));
 	}
 
 	initStringInfo(&buf);

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3384,7 +3384,13 @@ pagestore_read_branch_manifest(const char *target_dir)
 	snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
 	file = AllocateFile(path, PG_BINARY_R);
 	if (file == NULL)
-		return NULL;
+	{
+		if (errno == ENOENT)
+			return NULL;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open branch manifest \"%s\": %m", path)));
+	}
 
 	initStringInfo(&buf);
 	while ((nread = fread(tmp, 1, sizeof(tmp), file)) > 0)
@@ -3406,13 +3412,25 @@ pagestore_manifest_has_token(const char *manifest, const char *key,
 {
 	char		token[256];
 	int			len;
+	const char *match;
 
 	len = snprintf(token, sizeof(token), "\"%s\": %s", key, value);
 	if (len < 0 || len >= (int) sizeof(token))
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("branch manifest token is too large")));
-	return strstr(manifest, token) != NULL;
+	match = manifest;
+	while ((match = strstr(match, token)) != NULL)
+	{
+		char		next = match[len];
+
+		if (next == '\0' || next == ',' || next == '}' ||
+			next == '\n' || next == '\r' ||
+			next == ' ' || next == '\t')
+			return true;
+		match += len;
+	}
+	return false;
 }
 
 static bool

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4252,25 +4252,60 @@ pagestore_manifest_find_unique_field(const char *manifest, const char *key)
 	size_t		keylen = strlen(key);
 	const char *p = manifest;
 	const char *field = NULL;
+	int			depth = 0;
 
-	while ((p = strchr(p, '"')) != NULL)
+	while (*p != '\0')
 	{
-		const char *name = p + 1;
-		const char *end = strchr(name, '"');
-
-		if (end == NULL)
-			return NULL;
-		if ((size_t) (end - name) == keylen &&
-			strncmp(name, key, keylen) == 0)
+		if (*p == '{' || *p == '[')
 		{
-			p = pagestore_manifest_skip_ws(end + 1);
-			if (*p != ':')
-				return NULL;
-			if (field != NULL)
-				return NULL;
-			field = pagestore_manifest_skip_ws(p + 1);
+			depth++;
+			p++;
+			continue;
 		}
-		p = end + 1;
+		if (*p == '}' || *p == ']')
+		{
+			if (depth > 0)
+				depth--;
+			p++;
+			continue;
+		}
+		if (*p == '"')
+		{
+			const char *name = p + 1;
+			const char *end = name;
+
+			while (*end != '\0')
+			{
+				if (*end == '\\' && end[1] != '\0')
+				{
+					end += 2;
+					continue;
+				}
+				if (*end == '"')
+					break;
+				end++;
+			}
+			if (*end == '\0')
+				return NULL;
+
+			if (depth == 1)
+			{
+				const char *value = pagestore_manifest_skip_ws(end + 1);
+
+				if (*value == ':' &&
+					(size_t) (end - name) == keylen &&
+					strncmp(name, key, keylen) == 0)
+				{
+					if (field != NULL)
+						return NULL;
+					field = pagestore_manifest_skip_ws(value + 1);
+				}
+			}
+			p = end + 1;
+			continue;
+		}
+
+		p++;
 	}
 	return field;
 }
@@ -4386,6 +4421,8 @@ pagestore_validate_branch_manifest(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser to validate a branch manifest")));
+	if (new_tl <= 0 || parent_tl < 0)
+		PG_RETURN_BOOL(false);
 
 	manifest = pagestore_read_branch_manifest(target_dir);
 	if (manifest == NULL)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4353,21 +4353,60 @@ pagestore_manifest_has_string_token(const char *manifest, const char *key,
 }
 
 static bool
+pagestore_manifest_is_single_object(const char *manifest)
+{
+	const char *p = pagestore_manifest_skip_ws(manifest);
+	int			depth = 0;
+
+	if (*p != '{')
+		return false;
+	while (*p != '\0')
+	{
+		if (*p == '"')
+		{
+			p++;
+			while (*p != '\0')
+			{
+				if (*p == '\\' && p[1] != '\0')
+				{
+					p += 2;
+					continue;
+				}
+				if (*p == '"')
+					break;
+				p++;
+			}
+			if (*p == '\0')
+				return false;
+		}
+		else if (*p == '{' || *p == '[')
+			depth++;
+		else if (*p == '}' || *p == ']')
+		{
+			depth--;
+			if (depth == 0)
+			{
+				p = pagestore_manifest_skip_ws(p + 1);
+				return *p == '\0';
+			}
+			if (depth < 0)
+				return false;
+		}
+		p++;
+	}
+	return false;
+}
+
+static bool
 pagestore_manifest_matches(const char *manifest, int32 new_tl, int32 parent_tl,
 						   XLogRecPtr fork_lsn)
 {
 	char		buf[64];
 	int			len;
-	const char *p;
 
-	p = pagestore_manifest_skip_ws(manifest);
-	if (*p != '{')
+	if (new_tl <= 0 || parent_tl < 0)
 		return false;
-	p += strlen(p);
-	while (p > manifest &&
-		   (p[-1] == ' ' || p[-1] == '\t' || p[-1] == '\n' || p[-1] == '\r'))
-		p--;
-	if (p == manifest || p[-1] != '}')
+	if (!pagestore_manifest_is_single_object(manifest))
 		return false;
 
 	if (!pagestore_manifest_has_token(manifest, "format", "1"))

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4657,6 +4657,7 @@ pagestore_existing_branch_manifest_matches(const char *target_dir,
 	char	   *seeded_end;
 	long long	seeded;
 	int			len;
+	volatile bool read_failed = false;
 
 #define CHECK_MANIFEST_LINE(...) \
 	do { \
@@ -4666,7 +4667,18 @@ pagestore_existing_branch_manifest_matches(const char *target_dir,
 			return false; \
 	} while (0)
 
-	manifest = pagestore_read_branch_manifest(target_dir);
+	PG_TRY();
+	{
+		manifest = pagestore_read_branch_manifest(target_dir);
+	}
+	PG_CATCH();
+	{
+		FlushErrorState();
+		read_failed = true;
+	}
+	PG_END_TRY();
+	if (read_failed)
+		return false;
 	if (manifest == NULL)
 		return false;
 	if (!pagestore_manifest_matches(manifest, new_tl, parent_tl, target))

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4313,6 +4313,8 @@ pagestore_manifest_find_unique_field(const char *manifest, const char *key)
 			{
 				const char *value = pagestore_manifest_skip_ws(end + 1);
 
+				if (memchr(name, '\\', end - name) != NULL)
+					return NULL;
 				if (*value == ':' &&
 					(size_t) (end - name) == keylen &&
 					strncmp(name, key, keylen) == 0)


### PR DESCRIPTION
## Summary
- add pagestore_validate_branch_manifest() as a server-side bootstrap preflight guard
- read the prepared branch manifest and verify format, new timeline, parent timeline, and fork LSN
- extend the integration test to accept the prepared branch identity and reject a wrong timeline

## Stack
- stacked on #72 / feat/pagestore-branch-bootstrap-manifest
- #72 is stacked on #71, which is stacked on #70

## Validation
- not run locally