### PR TITLE
pagestore: enforce branch manifest timeline

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -76,6 +76,12 @@ ls_detach(int code, Datum arg)
 	}
 }
 
+void
+pagestore_localsvc_detach(void)
+{
+	ls_detach(0, (Datum) 0);
+}
+
 static void
 ls_attach(void)
 {
@@ -536,6 +542,19 @@ pagestore_localsvc_check_branch(uint32 new_tl, uint32 parent_tl,
 	PsChannel  *ch = ls_chan();
 
 	ch->opcode = PS_OP_CHECK_BRANCH;
+	ch->timeline = new_tl;
+	ch->parent_timeline = parent_tl;
+	ch->req_lsn = branch_lsn;
+	ls_exec(ch);
+}
+
+void
+pagestore_localsvc_require_branch(uint32 new_tl, uint32 parent_tl,
+								  uint64 branch_lsn)
+{
+	PsChannel  *ch = ls_chan();
+
+	ch->opcode = PS_OP_REQUIRE_BRANCH;
 	ch->timeline = new_tl;
 	ch->parent_timeline = parent_tl;
 	ch->req_lsn = branch_lsn;

--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -53,6 +53,15 @@ static uint32	ls_nshards = 1;
 /* max logical pages that fit in one transfer (io_unit) for this engine */
 #define LS_MAX_PAGES_PER_OP		(PS_IO_UNIT / BLCKSZ)
 
+/*
+ * claimed states: 0 = free, 1 = owned by a backend, 2 = abandoned after the
+ * owner timed out.  An abandoned channel may still receive a late DONE from the
+ * daemon, so never hand it to another backend.
+ */
+#define LS_CLAIMED_FREE		0
+#define LS_CLAIMED_OWNED	1
+#define LS_CLAIMED_ABANDONED	2
+
 static void
 ls_detach(int code, Datum arg)
 {
@@ -63,7 +72,7 @@ ls_detach(int code, Datum arg)
 			PsChannel  *ch = ps_channel(ls_shm, ls_channel);
 
 			/* release the channel for reuse by a future backend */
-			ps_store_release(&ch->claimed, 0);
+			ps_store_release(&ch->claimed, LS_CLAIMED_FREE);
 			ls_channel = -1;
 			ls_channel_shard = UINT32_MAX;
 		}
@@ -168,7 +177,7 @@ ls_claim_channel(uint32_t shard)
 	{
 		PsChannel  *old = ps_channel(ls_shm, ls_channel);
 
-		ps_store_release(&old->claimed, 0);
+		ps_store_release(&old->claimed, LS_CLAIMED_FREE);
 		ls_channel = -1;
 		ls_channel_shard = UINT32_MAX;
 	}
@@ -186,7 +195,7 @@ ls_claim_channel(uint32_t shard)
 	{
 		PsChannel  *ch = ps_channel(ls_shm, i);
 
-		if (ps_cas(&ch->claimed, 0, 1))
+		if (ps_cas(&ch->claimed, LS_CLAIMED_FREE, LS_CLAIMED_OWNED))
 		{
 			ch->shard = target;
 			ls_channel = (int) i;
@@ -246,7 +255,6 @@ ls_exec_timeout(PsChannel *ch, int timeout_ms)
 {
 	uint32		spins = 0;
 	time_t		deadline = 0;
-	bool		timed_out = false;
 
 	if (timeout_ms > 0)
 		deadline = time(NULL) + (timeout_ms + 999) / 1000;
@@ -259,20 +267,22 @@ ls_exec_timeout(PsChannel *ch, int timeout_ms)
 	{
 		if (((++spins) & 0xFFF) == 0)
 		{
-			if (!timed_out)
-				CHECK_FOR_INTERRUPTS();
+			CHECK_FOR_INTERRUPTS();
 			if (deadline != 0 && time(NULL) >= deadline)
-				timed_out = true;
+			{
+				ps_store_release(&ch->claimed, LS_CLAIMED_ABANDONED);
+				ls_channel = -1;
+				ls_channel_shard = UINT32_MAX;
+				ereport(ERROR,
+						(errmsg("pagestore localsvc: timed out waiting for daemon op %u",
+								ch->opcode)));
+			}
 		}
 #if defined(__x86_64__) || defined(__i386__)
 		__builtin_ia32_pause();
 #endif
 	}
 
-	if (timed_out)
-		ereport(ERROR,
-				(errmsg("pagestore localsvc: timed out waiting for daemon op %u",
-						ch->opcode)));
 	if (ch->status != PS_STATUS_OK)
 		ereport(ERROR,
 				(errmsg("pagestore localsvc: daemon reported error for op %u",

--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -246,6 +246,7 @@ ls_exec_timeout(PsChannel *ch, int timeout_ms)
 {
 	uint32		spins = 0;
 	time_t		deadline = 0;
+	bool		timed_out = false;
 
 	if (timeout_ms > 0)
 		deadline = time(NULL) + (timeout_ms + 999) / 1000;
@@ -258,17 +259,20 @@ ls_exec_timeout(PsChannel *ch, int timeout_ms)
 	{
 		if (((++spins) & 0xFFF) == 0)
 		{
-			CHECK_FOR_INTERRUPTS();
+			if (!timed_out)
+				CHECK_FOR_INTERRUPTS();
 			if (deadline != 0 && time(NULL) >= deadline)
-				ereport(ERROR,
-						(errmsg("pagestore localsvc: timed out waiting for daemon op %u",
-								ch->opcode)));
+				timed_out = true;
 		}
 #if defined(__x86_64__) || defined(__i386__)
 		__builtin_ia32_pause();
 #endif
 	}
 
+	if (timed_out)
+		ereport(ERROR,
+				(errmsg("pagestore localsvc: timed out waiting for daemon op %u",
+						ch->opcode)));
 	if (ch->status != PS_STATUS_OK)
 		ereport(ERROR,
 				(errmsg("pagestore localsvc: daemon reported error for op %u",

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -612,6 +612,24 @@ assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$
 	"branch manifest validator accepts the prepared branch identity"
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 3, 0, '$mxL');")" "f" \
 	"branch manifest validator rejects the wrong branch timeline"
+cp "$PREPSEED/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
+if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
+	echo "FAIL - branch startup rejected a manifest/timeline mismatch"
+	fail=1
+	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1 || true
+else
+	echo "ok   - branch startup rejects a manifest/timeline mismatch"
+fi
+cat >> "$BRANCHDATA/postgresql.conf" <<EOF
+pagestore.timeline = 2
+EOF
+if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
+	echo "ok   - branch startup accepts a manifest/timeline match"
+	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1
+else
+	echo "FAIL - branch startup did not accept a manifest/timeline match"
+	fail=1
+fi
 prepClogMd5=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_xact/$bootClogSeg', $(( bootClogPage * bs )), $bs));")
 assert "$prepClogMd5" "$bootClogRecon" "branch prepare pg_xact page == reconstructed as-of-L page"
 prepMxOff=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_multixact/offsets/$mxSeg', $(( (mxPage % 32) * bs )), $bs));")

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -644,22 +644,15 @@ nulManifest=$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0
 assert "$nulManifest" "ERROR" "branch manifest validator rejects embedded NUL bytes"
 mv "$PREPSEED/pagestore_branch.manifest.good" "$PREPSEED/pagestore_branch.manifest"
 cp "$PREPSEED/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
-if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
-	echo "FAIL - branch startup rejected a manifest/timeline mismatch"
-	fail=1
-	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1 || true
-else
-	echo "ok   - branch startup rejects a manifest/timeline mismatch"
-fi
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF
 pagestore.timeline = 2
 EOF
 if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
-	echo "ok   - branch startup accepts a manifest/timeline match"
-	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1
-else
-	echo "FAIL - branch startup did not accept a manifest/timeline match"
+	echo "FAIL - branch startup accepted a manifest without full routing"
 	fail=1
+	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1 || true
+else
+	echo "ok   - branch startup rejects a manifest without full routing"
 fi
 prepClogMd5=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_xact/$bootClogSeg', $(( bootClogPage * bs )), $bs));")
 assert "$prepClogMd5" "$bootClogRecon" "branch prepare pg_xact page == reconstructed as-of-L page"

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -644,9 +644,6 @@ nulManifest=$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0
 assert "$nulManifest" "ERROR" "branch manifest validator rejects embedded NUL bytes"
 mv "$PREPSEED/pagestore_branch.manifest.good" "$PREPSEED/pagestore_branch.manifest"
 cp "$PREPSEED/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
-cat >> "$BRANCHDATA/postgresql.conf" <<EOF
-pagestore.route_all = on
-EOF
 if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
 	echo "FAIL - branch startup rejected a manifest/timeline mismatch"
 	fail=1

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -644,6 +644,9 @@ nulManifest=$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0
 assert "$nulManifest" "ERROR" "branch manifest validator rejects embedded NUL bytes"
 mv "$PREPSEED/pagestore_branch.manifest.good" "$PREPSEED/pagestore_branch.manifest"
 cp "$PREPSEED/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
+cat >> "$BRANCHDATA/postgresql.conf" <<EOF
+pagestore.route_all = on
+EOF
 if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
 	echo "FAIL - branch startup rejected a manifest/timeline mismatch"
 	fail=1

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -58,6 +58,7 @@
 #include "storage/aio.h"
 #include "storage/bufpage.h"
 #include "storage/fd.h"
+#include "storage/ipc.h"
 #include "storage/md.h"
 #include "storage/smgr.h"
 #include "utils/builtins.h"
@@ -76,6 +77,7 @@ static bool pagestore_route_user_tablespaces = false;
 static char *pagestore_backend_name = NULL;
 static char *pagestore_walredo_datadir = NULL;
 static bool pagestore_redo_wal_from_store = false;
+static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 /* "which" index assigned to our smgr implementation by smgr_register() */
 static int	pagestore_smgr_which = -1;
@@ -3557,6 +3559,31 @@ pagestore_validate_branch_manifest(PG_FUNCTION_ARGS)
 											  fork_lsn));
 }
 
+static void
+pagestore_validate_datadir_branch_manifest(void)
+{
+	char	   *manifest;
+	char		buf[64];
+
+	if (prev_shmem_startup_hook)
+		prev_shmem_startup_hook();
+
+	if (DataDir == NULL)
+		return;
+
+	manifest = pagestore_read_branch_manifest(DataDir);
+	if (manifest == NULL)
+		return;					/* legacy/non-branch datadir */
+	if (!pagestore_manifest_has_token(manifest, "format", "1"))
+		ereport(FATAL,
+				(errmsg("invalid pagestore branch manifest in data directory")));
+	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
+	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+		ereport(FATAL,
+				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
+				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
+}
+
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,
@@ -3689,4 +3716,7 @@ _PG_init(void)
 	/* register our smgr implementation and claim relations via the hook */
 	pagestore_smgr_which = smgr_register(&pagestore_smgr);
 	smgr_which_hook = pagestore_which;
+
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = pagestore_validate_datadir_branch_manifest;
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3594,6 +3594,7 @@ static void
 pagestore_validate_datadir_branch_manifest(void)
 {
 	char	   *manifest;
+	char		path[MAXPGPATH];
 	char		buf[64];
 
 	if (prev_shmem_startup_hook)
@@ -3607,7 +3608,18 @@ pagestore_validate_datadir_branch_manifest(void)
 
 	manifest = pagestore_read_branch_manifest(DataDir);
 	if (manifest == NULL)
+	{
+		snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", DataDir);
+		if (access(path, R_OK) == 0)
+			ereport(FATAL,
+					(errcode_for_file_access(),
+					 errmsg("could not read branch manifest \"%s\": permission denied", path)));
+		if (errno != ENOENT)
+			ereport(FATAL,
+					(errcode_for_file_access(),
+					 errmsg("could not open branch manifest \"%s\": %m", path)));
 		return;					/* legacy/non-branch datadir */
+	}
 	if (!pagestore_manifest_has_uint_token(manifest, "format", 1))
 		ereport(FATAL,
 				(errmsg("invalid pagestore branch manifest in data directory")));

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3390,7 +3390,10 @@ pagestore_read_branch_manifest(const char *target_dir)
 	if (file == NULL)
 	{
 		if (errno == ENOENT)
+		{
+			/* No manifest means this is a legacy/non-branch datadir. */
 			return NULL;
+		}
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not open branch manifest \"%s\": %m", path)));
@@ -3477,6 +3480,25 @@ pagestore_manifest_has_token(const char *manifest, const char *key,
 }
 
 static bool
+pagestore_manifest_has_uint_token(const char *manifest, const char *key,
+							 uint32_t value)
+{
+	const char *field = pagestore_manifest_find_field(manifest, key);
+	char	   *endptr;
+	unsigned long long parsed;
+
+	if (field == NULL || *field == '"')
+		return false;
+	errno = 0;
+	parsed = strtoull(field, &endptr, 10);
+	if (errno != 0 || endptr == field)
+		return false;
+	if (parsed != (unsigned long long) value)
+		return false;
+	return pagestore_manifest_value_ends(*endptr);
+}
+
+static bool
 pagestore_manifest_has_string_token(const char *manifest, const char *key,
 									const char *value)
 {
@@ -3500,21 +3522,21 @@ pagestore_manifest_matches(const char *manifest, int32 new_tl, int32 parent_tl,
 	char		buf[64];
 	int			len;
 
-	if (!pagestore_manifest_has_token(manifest, "format", "1"))
+	if (!pagestore_manifest_has_uint_token(manifest, "format", 1))
 		return false;
-	len = snprintf(buf, sizeof(buf), "%d", new_tl);
+	len = snprintf(buf, sizeof(buf), "%u", new_tl);
 	if (len < 0 || len >= (int) sizeof(buf))
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("branch manifest token is too large")));
-	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+	if (!pagestore_manifest_has_uint_token(manifest, "new_timeline", new_tl))
 		return false;
-	len = snprintf(buf, sizeof(buf), "%d", parent_tl);
+	len = snprintf(buf, sizeof(buf), "%u", parent_tl);
 	if (len < 0 || len >= (int) sizeof(buf))
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("branch manifest token is too large")));
-	if (!pagestore_manifest_has_token(manifest, "parent_timeline", buf))
+	if (!pagestore_manifest_has_uint_token(manifest, "parent_timeline", parent_tl))
 		return false;
 	len = snprintf(buf, sizeof(buf), "%X/%08X", LSN_FORMAT_ARGS(fork_lsn));
 	if (len < 0 || len >= (int) sizeof(buf))
@@ -3586,11 +3608,11 @@ pagestore_validate_datadir_branch_manifest(void)
 	manifest = pagestore_read_branch_manifest(DataDir);
 	if (manifest == NULL)
 		return;					/* legacy/non-branch datadir */
-	if (!pagestore_manifest_has_token(manifest, "format", "1"))
+	if (!pagestore_manifest_has_uint_token(manifest, "format", 1))
 		ereport(FATAL,
 				(errmsg("invalid pagestore branch manifest in data directory")));
-	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
-	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+	if (!pagestore_manifest_has_uint_token(manifest, "new_timeline",
+										  pagestore_localsvc_timeline()))
 		ereport(FATAL,
 				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
 				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3526,6 +3526,12 @@ pagestore_manifest_matches(const char *manifest, int32 new_tl, int32 parent_tl,
 	return true;
 }
 
+static inline bool
+pagestore_branch_backend_active(void)
+{
+	return pagestore_active_backend == &PageStoreBackendLocalSvc;
+}
+
 /*
  * pagestore_validate_branch_manifest(target_dir text, new_timeline int,
  *                                    parent_timeline int, fork_lsn pg_lsn)
@@ -3551,6 +3557,9 @@ pagestore_validate_branch_manifest(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser to validate a branch manifest")));
+	if (!pagestore_branch_backend_active())
+		ereport(ERROR,
+				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
 
 	manifest = pagestore_read_branch_manifest(target_dir);
 	if (manifest == NULL)
@@ -3570,6 +3579,9 @@ pagestore_validate_datadir_branch_manifest(void)
 
 	if (DataDir == NULL)
 		return;
+	if (!pagestore_branch_backend_active())
+		ereport(FATAL,
+				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
 
 	manifest = pagestore_read_branch_manifest(DataDir);
 	if (manifest == NULL)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4288,30 +4288,16 @@ pagestore_manifest_value_delimited(const char *p)
 }
 
 static bool
-pagestore_manifest_has_token(const char *manifest, const char *key,
-							 const char *value)
+pagestore_manifest_has_uint_token(const char *manifest, const char *key,
+								 uint32_t value)
 {
 	const char *field = pagestore_manifest_find_unique_field(manifest, key);
-	size_t		len = strlen(value);
-
-	if (field == NULL)
-		return false;
-	if (*field == '"')
-		return false;
-	if (strncmp(field, value, len) != 0)
-		return false;
-	return pagestore_manifest_value_delimited(field + len);
-}
-
-static bool
-pagestore_manifest_has_uint_token(const char *manifest, const char *key,
-							 uint32_t value)
-{
-	const char *field = pagestore_manifest_find_field(manifest, key);
 	char	   *endptr;
 	unsigned long long parsed;
 
 	if (field == NULL || *field == '"')
+		return false;
+	if (*field < '0' || *field > '9')
 		return false;
 	errno = 0;
 	parsed = strtoull(field, &endptr, 10);
@@ -4319,7 +4305,7 @@ pagestore_manifest_has_uint_token(const char *manifest, const char *key,
 		return false;
 	if (parsed != (unsigned long long) value)
 		return false;
-	return pagestore_manifest_value_ends(*endptr);
+	return pagestore_manifest_value_delimited(endptr);
 }
 
 static bool
@@ -4431,32 +4417,19 @@ static void
 pagestore_validate_datadir_branch_manifest(void)
 {
 	char	   *manifest;
-	char		path[MAXPGPATH];
-	char		buf[64];
 
 	if (prev_shmem_startup_hook)
 		prev_shmem_startup_hook();
 
 	if (DataDir == NULL)
 		return;
-	if (!pagestore_branch_backend_active())
-		ereport(FATAL,
-				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
 
 	manifest = pagestore_read_branch_manifest(DataDir);
 	if (manifest == NULL)
-	{
-		snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", DataDir);
-		if (access(path, R_OK) == 0)
-			ereport(FATAL,
-					(errcode_for_file_access(),
-					 errmsg("could not read branch manifest \"%s\": permission denied", path)));
-		if (errno != ENOENT)
-			ereport(FATAL,
-					(errcode_for_file_access(),
-					 errmsg("could not open branch manifest \"%s\": %m", path)));
 		return;					/* legacy/non-branch datadir */
-	}
+	if (!pagestore_branch_backend_active())
+		ereport(FATAL,
+				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
 	if (!pagestore_manifest_has_uint_token(manifest, "format", 1))
 		ereport(FATAL,
 				(errmsg("invalid pagestore branch manifest in data directory")));

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4451,6 +4451,32 @@ pagestore_manifest_matches(const char *manifest, int32 new_tl, int32 parent_tl,
 	return true;
 }
 
+static bool
+pagestore_manifest_get_branch_identity(const char *manifest, uint32_t *new_tl,
+									   uint32_t *parent_tl,
+									   XLogRecPtr *fork_lsn)
+{
+	uint32_t	format;
+	const char *p;
+
+	p = pagestore_manifest_skip_ws(manifest);
+	if (*p != '{')
+		return false;
+	p += strlen(p);
+	while (p > manifest &&
+		   (p[-1] == ' ' || p[-1] == '\t' || p[-1] == '\n' || p[-1] == '\r'))
+		p--;
+	if (p == manifest || p[-1] != '}')
+		return false;
+
+	return pagestore_manifest_get_uint_token(manifest, "format", &format) &&
+		format == 1 &&
+		pagestore_manifest_get_uint_token(manifest, "new_timeline", new_tl) &&
+		*new_tl != 0 &&
+		pagestore_manifest_get_uint_token(manifest, "parent_timeline", parent_tl) &&
+		pagestore_manifest_get_lsn_token(manifest, "fork_lsn", fork_lsn);
+}
+
 static inline bool
 pagestore_branch_backend_active(void)
 {
@@ -4499,7 +4525,6 @@ static void
 pagestore_validate_datadir_branch_manifest(void)
 {
 	char	   *manifest;
-	uint32_t	format;
 	uint32_t	new_tl;
 	uint32_t	parent_tl;
 	XLogRecPtr	fork_lsn;
@@ -4516,19 +4541,16 @@ pagestore_validate_datadir_branch_manifest(void)
 	if (!pagestore_branch_backend_active())
 		ereport(FATAL,
 				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
-	if (!pagestore_manifest_get_uint_token(manifest, "format", &format) ||
-		format != 1 ||
-		!pagestore_manifest_get_uint_token(manifest, "new_timeline", &new_tl) ||
-		new_tl == 0 ||
-		!pagestore_manifest_get_uint_token(manifest, "parent_timeline", &parent_tl) ||
-		!pagestore_manifest_get_lsn_token(manifest, "fork_lsn", &fork_lsn))
+	if (!pagestore_manifest_get_branch_identity(manifest, &new_tl, &parent_tl,
+												&fork_lsn))
 		ereport(FATAL,
 				(errmsg("invalid pagestore branch manifest in data directory")));
 	if (new_tl != pagestore_localsvc_timeline())
 		ereport(FATAL,
 				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
 				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
-	pagestore_localsvc_check_branch(new_tl, parent_tl, (uint64) fork_lsn);
+	pagestore_localsvc_require_branch(new_tl, parent_tl, (uint64) fork_lsn);
+	pagestore_localsvc_detach();
 }
 
 /*

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -381,7 +381,7 @@ pagestore_which(RelFileLocator rlocator, ProcNumber backend)
 static bool
 pagestore_branch_routing_active(void)
 {
-	return pagestore_route_all;
+	return pagestore_route_all || pagestore_route_user_tablespaces;
 }
 
 /* --- GUC plumbing ------------------------------------------------------- */
@@ -4856,7 +4856,7 @@ pagestore_validate_datadir_branch_manifest(void)
 				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
 	if (!pagestore_branch_routing_active())
 		ereport(FATAL,
-				(errmsg("pagestore.route_all must be enabled to use a branch manifest")));
+				(errmsg("pagestore relation routing must be enabled to use a branch manifest")));
 	if (!pagestore_manifest_get_branch_identity(manifest, &new_tl, &parent_tl,
 												&fork_lsn))
 		ereport(FATAL,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -378,6 +378,12 @@ pagestore_which(RelFileLocator rlocator, ProcNumber backend)
 	return SMGR_MD;
 }
 
+static bool
+pagestore_branch_routing_active(void)
+{
+	return pagestore_route_all;
+}
+
 /* --- GUC plumbing ------------------------------------------------------- */
 
 static bool
@@ -4407,7 +4413,7 @@ pagestore_manifest_get_lsn_token(const char *manifest, const char *key,
 	const char *end;
 	char		buf[64];
 	size_t		len;
-	unsigned int hi,
+	unsigned long long hi,
 				lo;
 	char		extra;
 
@@ -4422,7 +4428,9 @@ pagestore_manifest_get_lsn_token(const char *manifest, const char *key,
 		return false;
 	memcpy(buf, field, len);
 	buf[len] = '\0';
-	if (sscanf(buf, "%X/%X%c", &hi, &lo, &extra) != 2)
+	if (sscanf(buf, "%llX/%llX%c", &hi, &lo, &extra) != 2)
+		return false;
+	if (hi > UINT32_MAX || lo > UINT32_MAX)
 		return false;
 	if (!pagestore_manifest_value_delimited(end + 1))
 		return false;
@@ -4846,6 +4854,9 @@ pagestore_validate_datadir_branch_manifest(void)
 	if (!pagestore_branch_backend_active())
 		ereport(FATAL,
 				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
+	if (!pagestore_branch_routing_active())
+		ereport(FATAL,
+				(errmsg("pagestore.route_all must be enabled to use a branch manifest")));
 	if (!pagestore_manifest_get_branch_identity(manifest, &new_tl, &parent_tl,
 												&fork_lsn))
 		ereport(FATAL,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -381,7 +381,7 @@ pagestore_which(RelFileLocator rlocator, ProcNumber backend)
 static bool
 pagestore_branch_routing_active(void)
 {
-	return pagestore_route_all || pagestore_route_user_tablespaces;
+	return pagestore_route_all;
 }
 
 /* --- GUC plumbing ------------------------------------------------------- */
@@ -4856,7 +4856,7 @@ pagestore_validate_datadir_branch_manifest(void)
 				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
 	if (!pagestore_branch_routing_active())
 		ereport(FATAL,
-				(errmsg("pagestore relation routing must be enabled to use a branch manifest")));
+				(errmsg("pagestore.route_all must be enabled to use a branch manifest")));
 	if (!pagestore_manifest_get_branch_identity(manifest, &new_tl, &parent_tl,
 												&fork_lsn))
 		ereport(FATAL,

--- a/contrib/pagestore/pagestore_backend.h
+++ b/contrib/pagestore/pagestore_backend.h
@@ -147,8 +147,11 @@ extern void pagestore_localsvc_read_at(const PageStoreRelKey *key,
 									   BlockNumber blocknum, uint64 lsn, void *out);
 extern void pagestore_localsvc_check_branch(uint32 new_tl, uint32 parent_tl,
 										   uint64 branch_lsn);
+extern void pagestore_localsvc_require_branch(uint32 new_tl, uint32 parent_tl,
+											 uint64 branch_lsn);
 extern void pagestore_localsvc_create_branch(uint32 new_tl, uint32 parent_tl,
 											 uint64 branch_lsn);
+extern void pagestore_localsvc_detach(void);
 extern void pagestore_localsvc_wal_append(uint64 start_lsn, const void *data,
 										  uint32 len);
 extern void pagestore_localsvc_walidx_add(const PageStoreRelKey *key,

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -787,6 +787,15 @@ branch_request_ok(uint32_t new_tl, int parent, uint64_t branch_lsn)
 	return 1;
 }
 
+static int
+branch_exists_with_metadata(uint32_t tl, int parent, uint64_t branch_lsn)
+{
+	return tl < MAX_TIMELINES &&
+		timelines[tl].defined &&
+		timelines[tl].parent == parent &&
+		timelines[tl].branch_lsn == branch_lsn;
+}
+
 /*
  * Resolve a read by walking the timeline ancestry: return the newest version of
  * (key, block) visible at read_lsn on 'timeline'; if the timeline never wrote
@@ -1517,6 +1526,18 @@ ps_handle_meta(PsChannel *ch)
 				/* valid */
 			}
 			else
+				ch->status = PS_STATUS_ERROR;
+			break;
+		case PS_OP_REQUIRE_BRANCH:
+			/*
+			 * Startup-time manifest validation: require the timeline to already
+			 * exist with exactly the manifest ancestry metadata.  This is stricter
+			 * than CHECK_BRANCH, which also accepts a request that would be legal
+			 * to create.
+			 */
+			if (!branch_exists_with_metadata(ch->timeline,
+											 (int) ch->parent_timeline,
+											 ch->req_lsn))
 				ch->status = PS_STATUS_ERROR;
 			break;
 

--- a/contrib/pagestore/pagestore_daemon.c
+++ b/contrib/pagestore/pagestore_daemon.c
@@ -147,6 +147,7 @@ request_is_write(PsOpcode opcode)
 		case PS_OP_NBLOCKS:
 		case PS_OP_READV:
 		case PS_OP_READ_AT:
+		case PS_OP_REQUIRE_BRANCH:
 		case PS_OP_WAL_SIZE:
 		case PS_OP_WAL_READ:
 		case PS_OP_WAL_INDEX_GET:
@@ -166,7 +167,8 @@ run_request(PsChannel *ch)
 	 * alone (no shard lock), so it serializes against map readers/writers but
 	 * not against per-shard work on unrelated shards.
 	 */
-	if (op == PS_OP_CREATE_BRANCH || op == PS_OP_CHECK_BRANCH)
+	if (op == PS_OP_CREATE_BRANCH || op == PS_OP_CHECK_BRANCH ||
+		op == PS_OP_REQUIRE_BRANCH)
 	{
 		ps_lock_map_wr();
 		handle_request(ch);

--- a/contrib/pagestore/pagestore_daemon_spdk.c
+++ b/contrib/pagestore/pagestore_daemon_spdk.c
@@ -112,6 +112,7 @@ request_is_write(PsOpcode opcode)
 		case PS_OP_ZEROEXTEND:
 		case PS_OP_CREATE_BRANCH:
 		case PS_OP_CHECK_BRANCH:
+		case PS_OP_REQUIRE_BRANCH:
 		case PS_OP_EXTEND:
 		case PS_OP_WRITEV:
 		case PS_OP_WAL_APPEND:
@@ -122,6 +123,7 @@ request_is_write(PsOpcode opcode)
 		case PS_OP_NBLOCKS:
 		case PS_OP_READV:
 		case PS_OP_READ_AT:
+		case PS_OP_REQUIRE_BRANCH:
 		case PS_OP_WAL_SIZE:
 		case PS_OP_WAL_READ:
 		case PS_OP_WAL_INDEX_GET:

--- a/contrib/pagestore/pagestore_ipc.h
+++ b/contrib/pagestore/pagestore_ipc.h
@@ -29,7 +29,8 @@
 #include <stdint.h>
 
 #define PS_SHM_MAGIC		0x50414753	/* "PAGS" */
-#define PS_SHM_VERSION		9	/* 9: CHECK_BRANCH opcode added;
+#define PS_SHM_VERSION		10	/* 10: REQUIRE_BRANCH opcode added;
+								 * 9: CHECK_BRANCH opcode added;
 								 * 8: READ_AT reports found-ness in ch->result;
 								 * 7: walidx_get returns timeline-tagged PsWalRec */
 
@@ -68,6 +69,7 @@ typedef enum PsOpcode
 	PS_OP_IMMEDSYNC,
 	PS_OP_READ_AT,				/* read 1 page at blocknum as-of req_lsn (COW) */
 	PS_OP_CHECK_BRANCH,			/* validate timeline creation request, no mutation */
+	PS_OP_REQUIRE_BRANCH,		/* require existing timeline ancestry metadata */
 	PS_OP_CREATE_BRANCH,		/* create timeline from parent_timeline @ req_lsn */
 	PS_OP_WAL_APPEND,			/* append datalen WAL bytes at LSN req_lsn (timeline) */
 	PS_OP_WAL_SIZE,				/* return end LSN of the timeline's WAL in req_lsn */

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -372,6 +372,19 @@ op_check_branch_status(uint32_t new_tl, uint32_t parent_tl, uint64_t branch_lsn)
 	return cl_exec()->status;
 }
 
+static int
+op_require_branch_status(uint32_t new_tl, uint32_t parent_tl,
+						 uint64_t branch_lsn)
+{
+	PsChannel  *ch = ps_channel(cl_shm, cl_chan);
+
+	ch->opcode = PS_OP_REQUIRE_BRANCH;
+	ch->timeline = new_tl;
+	ch->parent_timeline = parent_tl;
+	ch->req_lsn = branch_lsn;
+	return cl_exec()->status;
+}
+
 /* Write one page on a specific timeline. */
 static void
 op_write_tl(uint32_t tl, uint32_t rel, int32_t fork, uint32_t block,
@@ -828,6 +841,14 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 		  "CHECK_BRANCH accepts idempotent retry metadata");
 	check(op_check_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
 		  "CHECK_BRANCH rejects mismatched ancestry for existing timeline");
+	check(op_check_branch_status(9, 0, 1500) == PS_STATUS_OK,
+		  "CHECK_BRANCH accepts a valid not-yet-created branch request");
+	check(op_require_branch_status(1, 0, 1500) == PS_STATUS_OK,
+		  "REQUIRE_BRANCH accepts existing matching timeline metadata");
+	check(op_require_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
+		  "REQUIRE_BRANCH rejects mismatched existing timeline metadata");
+	check(op_require_branch_status(9, 0, 1500) == PS_STATUS_ERROR,
+		  "REQUIRE_BRANCH rejects not-yet-created branch timelines");
 	check(op_create_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
 		  "CREATE_BRANCH rejects re-creating existing timeline with mismatched ancestry");
 	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_OK,


### PR DESCRIPTION
## Summary
- install a postmaster startup hook that checks pagestore_branch.manifest when present
- reject startup when pagestore.timeline does not match the prepared branch manifest
- extend the integration test to verify mismatch rejection and matching timeline startup

## Stack
- stacked on #73 / feat/pagestore-branch-manifest-validate
- #73 is stacked on #72, #71, and #70

## Validation
- not run locally