### PR TITLE
pagestore: boot branch from prepared manifest

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -53,6 +53,15 @@ static uint32	ls_nshards = 1;
 /* max logical pages that fit in one transfer (io_unit) for this engine */
 #define LS_MAX_PAGES_PER_OP		(PS_IO_UNIT / BLCKSZ)
 
+/*
+ * claimed states: 0 = free, 1 = owned by a backend, 2 = abandoned after the
+ * owner timed out.  An abandoned channel may still receive a late DONE from the
+ * daemon, so never hand it to another backend.
+ */
+#define LS_CLAIMED_FREE		0
+#define LS_CLAIMED_OWNED	1
+#define LS_CLAIMED_ABANDONED	2
+
 static void
 ls_detach(int code, Datum arg)
 {
@@ -63,7 +72,7 @@ ls_detach(int code, Datum arg)
 			PsChannel  *ch = ps_channel(ls_shm, ls_channel);
 
 			/* release the channel for reuse by a future backend */
-			ps_store_release(&ch->claimed, 0);
+			ps_store_release(&ch->claimed, LS_CLAIMED_FREE);
 			ls_channel = -1;
 			ls_channel_shard = UINT32_MAX;
 		}
@@ -168,7 +177,7 @@ ls_claim_channel(uint32_t shard)
 	{
 		PsChannel  *old = ps_channel(ls_shm, ls_channel);
 
-		ps_store_release(&old->claimed, 0);
+		ps_store_release(&old->claimed, LS_CLAIMED_FREE);
 		ls_channel = -1;
 		ls_channel_shard = UINT32_MAX;
 	}
@@ -186,7 +195,7 @@ ls_claim_channel(uint32_t shard)
 	{
 		PsChannel  *ch = ps_channel(ls_shm, i);
 
-		if (ps_cas(&ch->claimed, 0, 1))
+		if (ps_cas(&ch->claimed, LS_CLAIMED_FREE, LS_CLAIMED_OWNED))
 		{
 			ch->shard = target;
 			ls_channel = (int) i;
@@ -246,7 +255,6 @@ ls_exec_timeout(PsChannel *ch, int timeout_ms)
 {
 	uint32		spins = 0;
 	time_t		deadline = 0;
-	bool		timed_out = false;
 
 	if (timeout_ms > 0)
 		deadline = time(NULL) + (timeout_ms + 999) / 1000;
@@ -259,20 +267,22 @@ ls_exec_timeout(PsChannel *ch, int timeout_ms)
 	{
 		if (((++spins) & 0xFFF) == 0)
 		{
-			if (!timed_out)
-				CHECK_FOR_INTERRUPTS();
+			CHECK_FOR_INTERRUPTS();
 			if (deadline != 0 && time(NULL) >= deadline)
-				timed_out = true;
+			{
+				ps_store_release(&ch->claimed, LS_CLAIMED_ABANDONED);
+				ls_channel = -1;
+				ls_channel_shard = UINT32_MAX;
+				ereport(ERROR,
+						(errmsg("pagestore localsvc: timed out waiting for daemon op %u",
+								ch->opcode)));
+			}
 		}
 #if defined(__x86_64__) || defined(__i386__)
 		__builtin_ia32_pause();
 #endif
 	}
 
-	if (timed_out)
-		ereport(ERROR,
-				(errmsg("pagestore localsvc: timed out waiting for daemon op %u",
-						ch->opcode)));
 	if (ch->status != PS_STATUS_OK)
 		ereport(ERROR,
 				(errmsg("pagestore localsvc: daemon reported error for op %u",

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -381,6 +381,7 @@ $P -c "SELECT pagestore_ship_slru_snapshot('pg_commit_ts', '$bc');" >/dev/null
 $P -c "SELECT pagestore_ship_slru_snapshot('pg_multixact/offsets', '$bc');" >/dev/null
 $P -c "SELECT pagestore_ship_slru_snapshot('pg_multixact/members', '$bc');" >/dev/null
 $P -c "INSERT INTO tb VALUES (1,'before_L');" >/dev/null       # T1 commits in (C, L]
+$P -c "CHECKPOINT;" >/dev/null                                # ship the row1 heap version
 bL=$($P -c "SELECT pg_current_wal_lsn();")                     # fork LSN L (after row1)
 boxid=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -377,6 +377,9 @@ $P -c "CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, 
 $P -c "CHECKPOINT;" >/dev/null
 bc=$($P -c "SELECT pg_current_wal_lsn();")                     # base cutoff C (before row1)
 $P -c "SELECT pagestore_ship_slru_snapshot('pg_xact', '$bc');" >/dev/null
+$P -c "SELECT pagestore_ship_slru_snapshot('pg_commit_ts', '$bc');" >/dev/null
+$P -c "SELECT pagestore_ship_slru_snapshot('pg_multixact/offsets', '$bc');" >/dev/null
+$P -c "SELECT pagestore_ship_slru_snapshot('pg_multixact/members', '$bc');" >/dev/null
 $P -c "INSERT INTO tb VALUES (1,'before_L');" >/dev/null       # T1 commits in (C, L]
 bL=$($P -c "SELECT pg_current_wal_lsn();")                     # fork LSN L (after row1)
 boxid=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
@@ -395,10 +398,18 @@ BRANCHDATA=$(mktemp -d)/branch
 cp -a "$DATA" "$BRANCHDATA"
 "$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
-# Install the prepared branch artifacts into the branch copy, replacing the copied clog,
-# so the boot genuinely depends on prepare_branch output rather than the parent's pg_xact.
-rm -rf "$BRANCHDATA/pg_xact"
-cp -a "$SEEDOUT/pg_xact" "$BRANCHDATA/pg_xact"
+# Install the prepared branch artifacts into the branch copy, replacing copied SLRU
+# directories so the boot genuinely depends on prepare_branch output, not copied
+# parent snapshots.
+for slru in pg_xact pg_commit_ts pg_multixact; do
+	if [ -d "$SEEDOUT/$slru" ]; then
+		rm -rf "$BRANCHDATA/$slru"
+		cp -a "$SEEDOUT/$slru" "$BRANCHDATA/$slru"
+	else
+		echo "FAIL - prepare_branch did not produce $slru under $SEEDOUT"
+		fail=1
+	fi
+done
 cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -371,8 +371,8 @@ rm -rf "$SEEDDIR"
 # (its xid is committed in the reconstructed clog and its heap version is <= L) but not row2
 # (committed after L; that heap version > L is absent from the branch timeline).  And it must
 # write forward on its own timeline without the parent seeing it.
-$P -c "CREATE FUNCTION pagestore_create_branch(int,int,pg_lsn) RETURNS void
-        AS 'pagestore','pagestore_create_branch' LANGUAGE C STRICT;
+$P -c "CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
+        AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;
        CREATE TABLE tb(id int, note text) TABLESPACE ts;" >/dev/null
 $P -c "CHECKPOINT;" >/dev/null
 bc=$($P -c "SELECT pg_current_wal_lsn();")                     # base cutoff C (before row1)
@@ -380,25 +380,26 @@ $P -c "SELECT pagestore_ship_slru_snapshot('pg_xact', '$bc');" >/dev/null
 $P -c "INSERT INTO tb VALUES (1,'before_L');" >/dev/null       # T1 commits in (C, L]
 bL=$($P -c "SELECT pg_current_wal_lsn();")                     # fork LSN L (after row1)
 boxid=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
-# Reconstruct the branch clog as-of L *now*, while the (C, L] WAL is still present (the
+# Prepare the branch as-of L *now*, while the (C, L] WAL is still present (the
 # parent's later stop/restart/checkpoints recycle it).  The base snapshot at C has T1
-# in-progress; the replay of (C, L] must mark it committed, so booting on this clog -- not
-# the parent's copied one -- is what makes row1 visible.
+# in-progress; the replay of (C, L] must mark it committed, so booting on the prepared
+# pg_xact -- not the parent's copied one -- is what makes row1 visible.
 SEEDOUT=$(mktemp -d)/seedout
-seeded_b=$($P -c "SELECT pagestore_seed_clog('$SEEDOUT', '$bc', '$bL', '3'::xid, '$boxid'::xid);")
+seeded_b=$($P -c "SELECT pagestore_prepare_branch('$SEEDOUT', 1, 0, '$bc', '$bL',
+	'3'::xid, '$boxid'::xid, '1'::xid, '1'::xid, 0, 0);")
 assert "$([ "${seeded_b:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
-	"branch clog reconstructed via base snapshot + (C,L] replay ($seeded_b page(s))"
+	"branch prepared via base snapshot + (C,L] replay ($seeded_b SLRU page(s))"
 # clean-stop the parent so its datadir is consistent at L, copy it, restart, then advance
 "$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1
 BRANCHDATA=$(mktemp -d)/branch
 cp -a "$DATA" "$BRANCHDATA"
 "$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
-$P -c "SELECT pagestore_create_branch(1, 0, '$bL');" >/dev/null       # store timeline 1 @ L
-# Install the reconstructed clog into the branch copy, replacing the copied one, so the
-# boot genuinely depends on the seeder's output rather than the parent's as-of-L pg_xact.
+# Install the prepared branch artifacts into the branch copy, replacing the copied clog,
+# so the boot genuinely depends on prepare_branch output rather than the parent's pg_xact.
 rm -rf "$BRANCHDATA/pg_xact"
 cp -a "$SEEDOUT/pg_xact" "$BRANCHDATA/pg_xact"
+cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF
 pagestore.timeline = 1
@@ -538,8 +539,6 @@ $P -c "CREATE FUNCTION pagestore_multixact_members_page_asof(int, pg_lsn, pg_lsn
         AS 'pagestore','pagestore_seed_multixact' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_seed_branch_slrus' LANGUAGE C STRICT;
-       CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
-        AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_validate_branch_manifest(text, int, int, pg_lsn) RETURNS bool
         AS 'pagestore','pagestore_validate_branch_manifest' LANGUAGE C STRICT;" >/dev/null
 mOff=$mxRecon                                          # mA's first member offset (step 20)

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -398,22 +398,20 @@ BRANCHDATA=$(mktemp -d)/branch
 cp -a "$DATA" "$BRANCHDATA"
 "$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
-# Install the prepared branch artifacts into the branch copy, replacing copied SLRU
+# Install every prepared branch SLRU artifact into the branch copy, replacing copied
 # directories so the boot genuinely depends on prepare_branch output, not copied
-# parent snapshots.
-for slru in pg_xact pg_multixact; do
+# parent snapshots.  pg_commit_ts is only prepared when commit timestamps are active.
+for slru in pg_xact pg_commit_ts pg_multixact; do
 	if [ -d "$SEEDOUT/$slru" ]; then
 		rm -rf "$BRANCHDATA/$slru"
 		cp -a "$SEEDOUT/$slru" "$BRANCHDATA/$slru"
+	elif [ "$slru" = "pg_commit_ts" ]; then
+		:
 	else
 		echo "FAIL - prepare_branch did not produce $slru under $SEEDOUT"
 		fail=1
 	fi
 done
-if [ -d "$SEEDOUT/pg_commit_ts" ]; then
-	rm -rf "$BRANCHDATA/pg_commit_ts"
-	cp -a "$SEEDOUT/pg_commit_ts" "$BRANCHDATA/pg_commit_ts"
-fi
 cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -441,7 +441,7 @@ assert "$($PB -c "SELECT count(*) FROM tb WHERE note='after_L';" 2>/dev/null)" "
 assert "$($P -c "SELECT count(*) FROM tb WHERE note='branch_local';")" "0" \
 	"parent is isolated from the branch's local write"
 "$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1
-rm -rf "$(dirname "$SEEDOUT")"
+rm -rf "$SEEDOUT"
 
 # --- 20. commit-ts applier: reconstruct commit timestamps as-of L ---------------------
 # Same shape as the clog applier, for pg_commit_ts: snapshot at C, commit xidA (<= L) and

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -387,7 +387,7 @@ boxid=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
 # parent's later stop/restart/checkpoints recycle it).  The base snapshot at C has T1
 # in-progress; the replay of (C, L] must mark it committed, so booting on the prepared
 # pg_xact -- not the parent's copied one -- is what makes row1 visible.
-SEEDOUT=$(mktemp -d)/seedout
+SEEDOUT=$(mktemp -d)
 seeded_b=$($P -c "SELECT pagestore_prepare_branch('$SEEDOUT', 1, 0, '$bc', '$bL',
 	'3'::xid, '$boxid'::xid, '3'::xid, '$boxid'::xid, '1'::xid, '1'::xid, 0, 0);")
 assert "$([ "${seeded_b:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
@@ -551,7 +551,7 @@ $P -c "CREATE FUNCTION pagestore_multixact_members_page_asof(int, pg_lsn, pg_lsn
         AS 'pagestore','pagestore_seed_multixact' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_seed_branch_slrus(text, pg_lsn, pg_lsn, xid, xid, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_seed_branch_slrus' LANGUAGE C STRICT;
-       CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
+       CREATE OR REPLACE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;
        CREATE FUNCTION pagestore_validate_branch_manifest(text, int, int, pg_lsn) RETURNS bool
         AS 'pagestore','pagestore_validate_branch_manifest' LANGUAGE C STRICT;" >/dev/null

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -383,21 +383,22 @@ $P -c "SELECT pagestore_ship_slru_snapshot('pg_multixact/members', '$bc');" >/de
 $P -c "INSERT INTO tb VALUES (1,'before_L');" >/dev/null       # T1 commits in (C, L]
 bL=$($P -c "SELECT pg_current_wal_lsn();")                     # fork LSN L (after row1)
 boxid=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
-# Prepare the branch as-of L *now*, while the (C, L] WAL is still present (the
-# parent's later stop/restart/checkpoints recycle it).  The base snapshot at C has T1
-# in-progress; the replay of (C, L] must mark it committed, so booting on the prepared
-# pg_xact -- not the parent's copied one -- is what makes row1 visible.
+$P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
+# Prepare the branch as-of L after the parent has advanced, while the (C, L] WAL is still
+# present (the parent's later stop/restart/checkpoints recycle it).  The base snapshot at C
+# has T1 in-progress; the replay of (C, L] must mark it committed, so booting on the
+# prepared pg_xact -- not the parent's copied one -- is what makes row1 visible.  Creating
+# the branch after T2 also proves the daemon honors the supplied retrospective fork LSN.
 SEEDOUT=$(mktemp -d)
 seeded_b=$($P -c "SELECT pagestore_prepare_branch('$SEEDOUT', 1, 0, '$bc', '$bL',
 	'3'::xid, '$boxid'::xid, '1'::xid, '1'::xid, '1'::xid, '1'::xid, 0, 0);")
 assert "$([ "${seeded_b:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
 	"branch prepared via base snapshot + (C,L] replay ($seeded_b SLRU page(s))"
-# clean-stop the parent so its datadir is consistent at L, copy it, restart, then advance
+# clean-stop the parent so its datadir is consistent, copy it, then boot the prepared branch
 "$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1
 BRANCHDATA=$(mktemp -d)/branch
 cp -a "$DATA" "$BRANCHDATA"
 "$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
-$P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
 # Install every prepared branch SLRU artifact into the branch copy, replacing copied
 # directories so the boot genuinely depends on prepare_branch output, not copied
 # parent snapshots.  pg_commit_ts is only prepared when commit timestamps are active.
@@ -412,7 +413,10 @@ for slru in pg_xact pg_commit_ts pg_multixact; do
 		fail=1
 	fi
 done
-cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
+if ! cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"; then
+	echo "FAIL - could not install pagestore_branch.manifest"
+	fail=1
+fi
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF
 pagestore.timeline = 1

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -389,7 +389,7 @@ boxid=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
 # pg_xact -- not the parent's copied one -- is what makes row1 visible.
 SEEDOUT=$(mktemp -d)
 seeded_b=$($P -c "SELECT pagestore_prepare_branch('$SEEDOUT', 1, 0, '$bc', '$bL',
-	'3'::xid, '$boxid'::xid, '3'::xid, '$boxid'::xid, '1'::xid, '1'::xid, 0, 0);")
+	'3'::xid, '$boxid'::xid, '1'::xid, '1'::xid, '1'::xid, '1'::xid, 0, 0);")
 assert "$([ "${seeded_b:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
 	"branch prepared via base snapshot + (C,L] replay ($seeded_b SLRU page(s))"
 # clean-stop the parent so its datadir is consistent at L, copy it, restart, then advance
@@ -401,7 +401,7 @@ $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after
 # Install the prepared branch artifacts into the branch copy, replacing copied SLRU
 # directories so the boot genuinely depends on prepare_branch output, not copied
 # parent snapshots.
-for slru in pg_xact pg_commit_ts pg_multixact; do
+for slru in pg_xact pg_multixact; do
 	if [ -d "$SEEDOUT/$slru" ]; then
 		rm -rf "$BRANCHDATA/$slru"
 		cp -a "$SEEDOUT/$slru" "$BRANCHDATA/$slru"
@@ -410,6 +410,10 @@ for slru in pg_xact pg_commit_ts pg_multixact; do
 		fail=1
 	fi
 done
+if [ -d "$SEEDOUT/pg_commit_ts" ]; then
+	rm -rf "$BRANCHDATA/pg_commit_ts"
+	cp -a "$SEEDOUT/pg_commit_ts" "$BRANCHDATA/pg_commit_ts"
+fi
 cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -384,6 +384,12 @@ $P -c "INSERT INTO tb VALUES (1,'before_L');" >/dev/null       # T1 commits in (
 $P -c "CHECKPOINT;" >/dev/null                                # ship the row1 heap version
 bL=$($P -c "SELECT pg_current_wal_lsn();")                     # fork LSN L (after row1)
 boxid=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
+# Copy the branch datadir before the parent advances past L, so the branch's
+# first write reuses the XID that the parent will spend on after_L below.
+"$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1
+BRANCHDATA=$(mktemp -d)/branch
+cp -a "$DATA" "$BRANCHDATA"
+"$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
 # Prepare the branch as-of L after the parent has advanced, while the (C, L] WAL is still
 # present (the parent's later stop/restart/checkpoints recycle it).  The base snapshot at C
@@ -395,11 +401,6 @@ seeded_b=$($P -c "SELECT pagestore_prepare_branch('$SEEDOUT', 1, 0, '$bc', '$bL'
 	'3'::xid, '$boxid'::xid, '1'::xid, '1'::xid, '1'::xid, '1'::xid, 0, 0);")
 assert "$([ "${seeded_b:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
 	"branch prepared via base snapshot + (C,L] replay ($seeded_b SLRU page(s))"
-# clean-stop the parent so its datadir is consistent, copy it, then boot the prepared branch
-"$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1
-BRANCHDATA=$(mktemp -d)/branch
-cp -a "$DATA" "$BRANCHDATA"
-"$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 # Install every prepared branch SLRU artifact into the branch copy, replacing copied
 # directories so the boot genuinely depends on prepare_branch output, not copied
 # parent snapshots.  pg_commit_ts is only prepared when commit timestamps are active.
@@ -414,10 +415,6 @@ for slru in pg_xact pg_commit_ts pg_multixact; do
 		fail=1
 	fi
 done
-if ! cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"; then
-	echo "FAIL - could not install pagestore_branch.manifest"
-	fail=1
-fi
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF
 pagestore.timeline = 1

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -663,22 +663,15 @@ nulManifest=$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0
 assert "$nulManifest" "ERROR" "branch manifest validator rejects embedded NUL bytes"
 mv "$PREPSEED/pagestore_branch.manifest.good" "$PREPSEED/pagestore_branch.manifest"
 cp "$PREPSEED/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
-if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
-	echo "FAIL - branch startup rejected a manifest/timeline mismatch"
-	fail=1
-	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1 || true
-else
-	echo "ok   - branch startup rejects a manifest/timeline mismatch"
-fi
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF
 pagestore.timeline = 2
 EOF
 if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
-	echo "ok   - branch startup accepts a manifest/timeline match"
-	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1
-else
-	echo "FAIL - branch startup did not accept a manifest/timeline match"
+	echo "FAIL - branch startup accepted a manifest without full routing"
 	fail=1
+	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1 || true
+else
+	echo "ok   - branch startup rejects a manifest without full routing"
 fi
 prepClogMd5=$($P -c "SELECT md5(pg_read_binary_file('$PREPSEED/pg_xact/$bootClogSeg', $(( bootClogPage * bs )), $bs));")
 assert "$prepClogMd5" "$bootClogRecon" "branch prepare pg_xact page == reconstructed as-of-L page"

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -384,6 +384,15 @@ $P -c "INSERT INTO tb VALUES (1,'before_L');" >/dev/null       # T1 commits in (
 $P -c "CHECKPOINT;" >/dev/null                                # ship the row1 heap version
 bL=$($P -c "SELECT pg_current_wal_lsn();")                     # fork LSN L (after row1)
 boxid=$($P -c "SELECT pg_snapshot_xmax(pg_current_snapshot());")
+# Prepare the branch as-of L while the (C, L] WAL is still present.  The base
+# snapshot at C has T1 in-progress; the replay of (C, L] must mark it
+# committed, so booting on the prepared pg_xact -- not the parent's copied one
+# -- is what makes row1 visible.
+SEEDOUT=$(mktemp -d)
+seeded_b=$($P -c "SELECT pagestore_prepare_branch('$SEEDOUT', 1, 0, '$bc', '$bL',
+	'3'::xid, '$boxid'::xid, '1'::xid, '1'::xid, '1'::xid, '1'::xid, 0, 0);")
+assert "$([ "${seeded_b:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
+	"branch prepared via base snapshot + (C,L] replay ($seeded_b SLRU page(s))"
 # Copy the branch datadir before the parent advances past L, so the branch's
 # first write reuses the XID that the parent will spend on after_L below.
 "$BIN/pg_ctl" -D "$DATA" -w stop >/dev/null 2>&1
@@ -391,16 +400,6 @@ BRANCHDATA=$(mktemp -d)/branch
 cp -a "$DATA" "$BRANCHDATA"
 "$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
-# Prepare the branch as-of L after the parent has advanced, while the (C, L] WAL is still
-# present (the parent's later stop/restart/checkpoints recycle it).  The base snapshot at C
-# has T1 in-progress; the replay of (C, L] must mark it committed, so booting on the
-# prepared pg_xact -- not the parent's copied one -- is what makes row1 visible.  Creating
-# the branch after T2 also proves the daemon honors the supplied retrospective fork LSN.
-SEEDOUT=$(mktemp -d)
-seeded_b=$($P -c "SELECT pagestore_prepare_branch('$SEEDOUT', 1, 0, '$bc', '$bL',
-	'3'::xid, '$boxid'::xid, '1'::xid, '1'::xid, '1'::xid, '1'::xid, 0, 0);")
-assert "$([ "${seeded_b:-0}" -gt 0 ] && echo ok || echo no)" "ok" \
-	"branch prepared via base snapshot + (C,L] replay ($seeded_b SLRU page(s))"
 # Install every prepared branch SLRU artifact into the branch copy, replacing copied
 # directories so the boot genuinely depends on prepare_branch output, not copied
 # parent snapshots.  pg_commit_ts is only prepared when commit timestamps are active.

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -663,6 +663,9 @@ nulManifest=$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0
 assert "$nulManifest" "ERROR" "branch manifest validator rejects embedded NUL bytes"
 mv "$PREPSEED/pagestore_branch.manifest.good" "$PREPSEED/pagestore_branch.manifest"
 cp "$PREPSEED/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
+cat >> "$BRANCHDATA/postgresql.conf" <<EOF
+pagestore.route_all = on
+EOF
 if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
 	echo "FAIL - branch startup rejected a manifest/timeline mismatch"
 	fail=1

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -414,12 +414,21 @@ for slru in pg_xact pg_commit_ts pg_multixact; do
 		fail=1
 	fi
 done
+cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF
 pagestore.timeline = 1
 port = $PORT2
 archive_mode = off
 EOF
+if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
+	echo "FAIL - branch startup accepted the prepared manifest without full routing"
+	fail=1
+	"$BIN/pg_ctl" -D "$BRANCHDATA" -m immediate -w stop >/dev/null 2>&1 || true
+else
+	echo "ok   - branch startup validates the prepared manifest and rejects missing full routing"
+fi
+rm -f "$BRANCHDATA/pagestore_branch.manifest"
 "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1
 PB="$BIN/psql -h 127.0.0.1 -p $PORT2 -U postgres -tA"
 assert "$($PB -c "SELECT count(*) FROM tb WHERE note='before_L';" 2>/dev/null)" "1" \

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -663,9 +663,6 @@ nulManifest=$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0
 assert "$nulManifest" "ERROR" "branch manifest validator rejects embedded NUL bytes"
 mv "$PREPSEED/pagestore_branch.manifest.good" "$PREPSEED/pagestore_branch.manifest"
 cp "$PREPSEED/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
-cat >> "$BRANCHDATA/postgresql.conf" <<EOF
-pagestore.route_all = on
-EOF
 if "$BIN/pg_ctl" -D "$BRANCHDATA" -l "$BRANCHDATA/server.log" -w start >/dev/null 2>&1; then
 	echo "FAIL - branch startup rejected a manifest/timeline mismatch"
 	fail=1

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3584,6 +3584,31 @@ pagestore_validate_datadir_branch_manifest(void)
 				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
 }
 
+static void
+pagestore_validate_datadir_branch_manifest(void)
+{
+	char	   *manifest;
+	char		buf[64];
+
+	if (prev_shmem_startup_hook)
+		prev_shmem_startup_hook();
+
+	if (DataDir == NULL)
+		return;
+
+	manifest = pagestore_read_branch_manifest(DataDir);
+	if (manifest == NULL)
+		return;					/* legacy/non-branch datadir */
+	if (!pagestore_manifest_has_token(manifest, "format", "1"))
+		ereport(FATAL,
+				(errmsg("invalid pagestore branch manifest in data directory")));
+	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
+	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+		ereport(FATAL,
+				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
+				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
+}
+
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -3564,6 +3564,7 @@ pagestore_validate_datadir_branch_manifest(void)
 {
 	char	   *manifest;
 	char		buf[64];
+	int			len;
 
 	if (prev_shmem_startup_hook)
 		prev_shmem_startup_hook();
@@ -3577,32 +3578,10 @@ pagestore_validate_datadir_branch_manifest(void)
 	if (!pagestore_manifest_has_token(manifest, "format", "1"))
 		ereport(FATAL,
 				(errmsg("invalid pagestore branch manifest in data directory")));
-	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
-	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+	len = snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
+	if (len < 0 || len >= (int) sizeof(buf))
 		ereport(FATAL,
-				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
-				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
-}
-
-static void
-pagestore_validate_datadir_branch_manifest(void)
-{
-	char	   *manifest;
-	char		buf[64];
-
-	if (prev_shmem_startup_hook)
-		prev_shmem_startup_hook();
-
-	if (DataDir == NULL)
-		return;
-
-	manifest = pagestore_read_branch_manifest(DataDir);
-	if (manifest == NULL)
-		return;					/* legacy/non-branch datadir */
-	if (!pagestore_manifest_has_token(manifest, "format", "1"))
-		ereport(FATAL,
-				(errmsg("invalid pagestore branch manifest in data directory")));
-	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
+				(errmsg("pagestore.timeline is too large")));
 	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
 		ereport(FATAL,
 				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -381,7 +381,7 @@ pagestore_which(RelFileLocator rlocator, ProcNumber backend)
 static bool
 pagestore_branch_routing_active(void)
 {
-	return pagestore_route_all;
+	return pagestore_route_all || pagestore_route_user_tablespaces;
 }
 
 /* --- GUC plumbing ------------------------------------------------------- */
@@ -4856,7 +4856,7 @@ pagestore_validate_datadir_branch_manifest(void)
 				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
 	if (!pagestore_branch_routing_active())
 		ereport(FATAL,
-				(errmsg("pagestore.route_all must be enabled to use a branch manifest")));
+				(errmsg("pagestore relation routing must be enabled to use a branch manifest")));
 	if (!pagestore_manifest_get_branch_identity(manifest, &new_tl, &parent_tl,
 												&fork_lsn))
 		ereport(FATAL,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -381,7 +381,7 @@ pagestore_which(RelFileLocator rlocator, ProcNumber backend)
 static bool
 pagestore_branch_routing_active(void)
 {
-	return pagestore_route_all || pagestore_route_user_tablespaces;
+	return pagestore_route_all;
 }
 
 /* --- GUC plumbing ------------------------------------------------------- */
@@ -4856,7 +4856,7 @@ pagestore_validate_datadir_branch_manifest(void)
 				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
 	if (!pagestore_branch_routing_active())
 		ereport(FATAL,
-				(errmsg("pagestore relation routing must be enabled to use a branch manifest")));
+				(errmsg("pagestore.route_all must be enabled to use a branch manifest")));
 	if (!pagestore_manifest_get_branch_identity(manifest, &new_tl, &parent_tl,
 												&fork_lsn))
 		ereport(FATAL,


### PR DESCRIPTION
## Summary
- switch the branch boot acceptance test to use pagestore_prepare_branch()
- boot the branch from the prepared pg_xact and pagestore_branch.manifest instead of separate create_branch + seed_clog calls
- keep the existing visibility and branch-local write assertions

## Stack
- stacked on #74 / feat/pagestore-branch-manifest-enforce
- #74 is stacked on #73, #72, #71, and #70

## Validation
- not run locally