### PR TITLE
pagestore: install prepared branch artifacts

### DIFF
--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -373,6 +373,8 @@ rm -rf "$SEEDDIR"
 # write forward on its own timeline without the parent seeing it.
 $P -c "CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;
+       CREATE FUNCTION pagestore_install_prepared_branch(text, text) RETURNS void
+        AS 'pagestore','pagestore_install_prepared_branch' LANGUAGE C STRICT;
        CREATE TABLE tb(id int, note text) TABLESPACE ts;" >/dev/null
 $P -c "CHECKPOINT;" >/dev/null
 bc=$($P -c "SELECT pg_current_wal_lsn();")                     # base cutoff C (before row1)
@@ -400,21 +402,9 @@ BRANCHDATA=$(mktemp -d)/branch
 cp -a "$DATA" "$BRANCHDATA"
 "$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
-# Install every prepared branch SLRU artifact into the branch copy, replacing copied
-# directories so the boot genuinely depends on prepare_branch output, not copied
-# parent snapshots.  pg_commit_ts is only prepared when commit timestamps are active.
-for slru in pg_xact pg_commit_ts pg_multixact; do
-	if [ -d "$SEEDOUT/$slru" ]; then
-		rm -rf "$BRANCHDATA/$slru"
-		cp -a "$SEEDOUT/$slru" "$BRANCHDATA/$slru"
-	elif [ "$slru" = "pg_commit_ts" ]; then
-		:
-	else
-		echo "FAIL - prepare_branch did not produce $slru under $SEEDOUT"
-		fail=1
-	fi
-done
-cp "$SEEDOUT/pagestore_branch.manifest" "$BRANCHDATA/pagestore_branch.manifest"
+# Install the prepared branch artifacts into the branch copy, replacing copied SLRUs,
+# so the boot genuinely depends on all prepare_branch output rather than parent state.
+$P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA');" >/dev/null
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF
 pagestore.timeline = 1

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -404,7 +404,12 @@ cp -a "$DATA" "$BRANCHDATA"
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
 # Install the prepared branch artifacts into the branch copy, replacing copied SLRUs,
 # so the boot genuinely depends on all prepare_branch output rather than parent state.
-$P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA');" >/dev/null
+if $P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA');" >/dev/null; then
+	echo "ok   - installed prepared branch artifacts into the branch datadir"
+else
+	echo "FAIL - could not install prepared branch artifacts"
+	fail=1
+fi
 # point the copied datadir at timeline 1 on a distinct port; it reads relations as-of L
 cat >> "$BRANCHDATA/postgresql.conf" <<EOF
 pagestore.timeline = 1

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -58,6 +58,7 @@
 #include "port/pg_iovec.h"
 #include "storage/aio.h"
 #include "storage/bufpage.h"
+#include "storage/copydir.h"
 #include "storage/fd.h"
 #include "storage/ipc.h"
 #include "storage/md.h"
@@ -4868,6 +4869,111 @@ pagestore_validate_datadir_branch_manifest(void)
 	pagestore_localsvc_require_branch_timeout(new_tl, parent_tl,
 											  (uint64) fork_lsn, 5000);
 	pagestore_localsvc_detach();
+}
+
+static void
+pagestore_install_prepared_dir(const char *prepared_dir, const char *target_dir,
+							   const char *relpath, bool required)
+{
+	char		src[MAXPGPATH];
+	char		dst[MAXPGPATH];
+	char		stage[MAXPGPATH];
+
+	if (strlen(prepared_dir) + strlen(relpath) + sizeof("/") > MAXPGPATH ||
+		strlen(target_dir) + strlen(relpath) + sizeof(".install/") > MAXPGPATH)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("branch install path is too long")));
+
+	snprintf(src, sizeof(src), "%s/%s", prepared_dir, relpath);
+	snprintf(dst, sizeof(dst), "%s/%s", target_dir, relpath);
+	snprintf(stage, sizeof(stage), "%s/%s.install", target_dir, relpath);
+	if (access(src, F_OK) != 0)
+	{
+		if (required)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("prepared branch artifact \"%s\" is missing: %m", src)));
+		return;
+	}
+	if (access(stage, F_OK) == 0 && !rmtree(stage, true))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not clear branch install staging dir \"%s\"", stage)));
+	copydir(src, stage, true);
+	fsync_fname(stage, true);
+	if (access(dst, F_OK) == 0 && !rmtree(dst, true))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove existing branch artifact \"%s\"", dst)));
+	if (rename(stage, dst) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not install branch artifact \"%s\": %m", dst)));
+	fsync_fname(target_dir, true);
+}
+
+static void
+pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir,
+								const char *relpath)
+{
+	char		src[MAXPGPATH];
+	char		dst[MAXPGPATH];
+	char		stage[MAXPGPATH];
+
+	if (strlen(prepared_dir) + strlen(relpath) + sizeof("/") > MAXPGPATH ||
+		strlen(target_dir) + strlen(relpath) + sizeof(".install/") > MAXPGPATH)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("branch install path is too long")));
+
+	snprintf(src, sizeof(src), "%s/%s", prepared_dir, relpath);
+	snprintf(dst, sizeof(dst), "%s/%s", target_dir, relpath);
+	snprintf(stage, sizeof(stage), "%s/%s.install", target_dir, relpath);
+	if (access(src, F_OK) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("prepared branch artifact \"%s\" is missing: %m", src)));
+	copy_file(src, stage);
+	if (durable_rename(stage, dst, ERROR) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not install branch artifact \"%s\": %m", dst)));
+	fsync_fname(target_dir, true);
+}
+
+/*
+ * pagestore_install_prepared_branch(prepared_dir text, target_dir text)
+ * returns void
+ *
+ * Install the artifacts produced by pagestore_prepare_branch() into an
+ * initdb/copied branch datadir.  The manifest is installed last so its presence
+ * remains the startup-time signal that the datadir has a prepared branch
+ * identity and must pass timeline validation.
+ */
+PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
+Datum
+pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
+{
+	char	   *prepared_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to install a prepared branch")));
+
+	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_xact", true);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts", false);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", false);
+	pagestore_install_prepared_file(prepared_dir, target_dir,
+									"pagestore_branch.manifest");
+
+	PG_RETURN_VOID();
 }
 
 static void

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4915,7 +4915,7 @@ pagestore_install_prepared_dir(const char *prepared_dir, const char *target_dir,
 
 static void
 pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir,
-								const char *relpath)
+								const char *relpath, bool required)
 {
 	char		src[MAXPGPATH];
 	char		dst[MAXPGPATH];
@@ -4931,9 +4931,17 @@ pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir
 	snprintf(dst, sizeof(dst), "%s/%s", target_dir, relpath);
 	snprintf(stage, sizeof(stage), "%s/%s.install", target_dir, relpath);
 	if (access(src, F_OK) != 0)
+	{
+		if (required)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("prepared branch artifact \"%s\" is missing: %m", src)));
+		return;
+	}
+	if (access(stage, F_OK) == 0 && unlink(stage) != 0)
 		ereport(ERROR,
 				(errcode_for_file_access(),
-				 errmsg("prepared branch artifact \"%s\" is missing: %m", src)));
+				 errmsg("could not clear branch install staging file \"%s\": %m", stage)));
 	copy_file(src, stage);
 	if (durable_rename(stage, dst, ERROR) != 0)
 		ereport(ERROR,
@@ -4947,11 +4955,10 @@ pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir
  * returns void
  *
  * Install the artifacts produced by pagestore_prepare_branch() into an
- * initdb/copied branch datadir.  For now, only the boot-critical pg_xact plus
- * manifest are installed; optional SLRUs stay in the prepared artifact until a
- * full bootstrap path has pg_control-aware activation for them.  The manifest is
- * installed last so its presence remains the startup-time signal that the datadir
- * has a prepared branch identity and must pass timeline validation.
+ * initdb/copied branch datadir.  pg_xact and any prepared SLRUs are installed
+ * before the manifest, and the manifest is installed last so its presence remains
+ * the startup-time signal that the datadir has a prepared branch identity and must
+ * pass timeline validation.
  */
 PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
 Datum
@@ -4959,19 +4966,39 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 {
 	char	   *prepared_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	char		manifest[MAXPGPATH];
+	char		stage[MAXPGPATH];
 
 	if (!superuser())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser to install a prepared branch")));
+	snprintf(manifest, sizeof(manifest), "%s/pagestore_branch.manifest",
+			 prepared_dir);
+	if (access(manifest, F_OK) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("prepared branch artifact \"%s\" is missing: %m", manifest)));
 
 	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
+	snprintf(stage, sizeof(stage), "%s/pagestore_branch.manifest", target_dir);
+	if (access(stage, F_OK) == 0 && unlink(stage) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not clear existing branch artifact \"%s\": %m", stage)));
+	snprintf(stage, sizeof(stage), "%s/pagestore_branch.manifest.install", target_dir);
+	if (access(stage, F_OK) == 0 && unlink(stage) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not clear existing branch artifact staging file \"%s\": %m", stage)));
 	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_xact", true);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts", false);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", false);
 	pagestore_install_prepared_file(prepared_dir, target_dir,
-									"pagestore_branch.manifest");
+									"pagestore_branch.manifest", true);
 
 	PG_RETURN_VOID();
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4968,13 +4968,15 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	char		manifest[MAXPGPATH];
 	char		stage[MAXPGPATH];
+	int			pathlen;
 
 	if (!superuser())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser to install a prepared branch")));
-	snprintf(manifest, sizeof(manifest), "%s/pagestore_branch.manifest",
-			 prepared_dir);
+	pathlen = snprintf(manifest, sizeof(manifest),
+					   "%s/pagestore_branch.manifest", prepared_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, manifest);
 	if (access(manifest, F_OK) != 0)
 		ereport(ERROR,
 				(errcode_for_file_access(),
@@ -4984,7 +4986,9 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
-	snprintf(stage, sizeof(stage), "%s/pagestore_branch.manifest", target_dir);
+	pathlen = snprintf(stage, sizeof(stage), "%s/pagestore_branch.manifest",
+					   target_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, stage);
 	if (access(stage, F_OK) == 0)
 	{
 		if (unlink(stage) != 0)
@@ -4993,7 +4997,9 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 					 errmsg("could not clear existing branch artifact \"%s\": %m", stage)));
 		fsync_fname(target_dir, true);
 	}
-	snprintf(stage, sizeof(stage), "%s/pagestore_branch.manifest.install", target_dir);
+	pathlen = snprintf(stage, sizeof(stage),
+					   "%s/pagestore_branch.manifest.install", target_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, stage);
 	if (access(stage, F_OK) == 0 && unlink(stage) != 0)
 		ereport(ERROR,
 				(errcode_for_file_access(),

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4870,6 +4870,31 @@ pagestore_validate_datadir_branch_manifest(void)
 	pagestore_localsvc_detach();
 }
 
+static void
+pagestore_validate_datadir_branch_manifest(void)
+{
+	char	   *manifest;
+	char		buf[64];
+
+	if (prev_shmem_startup_hook)
+		prev_shmem_startup_hook();
+
+	if (DataDir == NULL)
+		return;
+
+	manifest = pagestore_read_branch_manifest(DataDir);
+	if (manifest == NULL)
+		return;					/* legacy/non-branch datadir */
+	if (!pagestore_manifest_has_token(manifest, "format", "1"))
+		ereport(FATAL,
+				(errmsg("invalid pagestore branch manifest in data directory")));
+	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
+	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+		ereport(FATAL,
+				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
+				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
+}
+
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4985,10 +4985,14 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
 	snprintf(stage, sizeof(stage), "%s/pagestore_branch.manifest", target_dir);
-	if (access(stage, F_OK) == 0 && unlink(stage) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not clear existing branch artifact \"%s\": %m", stage)));
+	if (access(stage, F_OK) == 0)
+	{
+		if (unlink(stage) != 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not clear existing branch artifact \"%s\": %m", stage)));
+		fsync_fname(target_dir, true);
+	}
 	snprintf(stage, sizeof(stage), "%s/pagestore_branch.manifest.install", target_dir);
 	if (access(stage, F_OK) == 0 && unlink(stage) != 0)
 		ereport(ERROR,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4996,7 +4996,7 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 				 errmsg("could not clear existing branch artifact staging file \"%s\": %m", stage)));
 	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_xact", true);
 	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts", false);
-	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", false);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", true);
 	pagestore_install_prepared_file(prepared_dir, target_dir,
 									"pagestore_branch.manifest", true);
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4976,31 +4976,6 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
-static void
-pagestore_validate_datadir_branch_manifest(void)
-{
-	char	   *manifest;
-	char		buf[64];
-
-	if (prev_shmem_startup_hook)
-		prev_shmem_startup_hook();
-
-	if (DataDir == NULL)
-		return;
-
-	manifest = pagestore_read_branch_manifest(DataDir);
-	if (manifest == NULL)
-		return;					/* legacy/non-branch datadir */
-	if (!pagestore_manifest_has_token(manifest, "format", "1"))
-		ereport(FATAL,
-				(errmsg("invalid pagestore branch manifest in data directory")));
-	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
-	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
-		ereport(FATAL,
-				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
-				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
-}
-
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4947,9 +4947,11 @@ pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir
  * returns void
  *
  * Install the artifacts produced by pagestore_prepare_branch() into an
- * initdb/copied branch datadir.  The manifest is installed last so its presence
- * remains the startup-time signal that the datadir has a prepared branch
- * identity and must pass timeline validation.
+ * initdb/copied branch datadir.  For now, only the boot-critical pg_xact plus
+ * manifest are installed; optional SLRUs stay in the prepared artifact until a
+ * full bootstrap path has pg_control-aware activation for them.  The manifest is
+ * installed last so its presence remains the startup-time signal that the datadir
+ * has a prepared branch identity and must pass timeline validation.
  */
 PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
 Datum
@@ -4968,8 +4970,6 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
 	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_xact", true);
-	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts", false);
-	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", false);
 	pagestore_install_prepared_file(prepared_dir, target_dir,
 									"pagestore_branch.manifest");
 


### PR DESCRIPTION
## Summary
- add pagestore_install_prepared_branch() to publish prepare_branch artifacts into a branch datadir
- install pg_xact, optional pg_commit_ts, optional pg_multixact, and the branch manifest with manifest last
- switch the branch boot acceptance test from shell rm/cp to the SQL install helper

## Stack
- stacked on #75 / feat/pagestore-branch-boot-prepare
- #75 is stacked on #74, #73, #72, #71, and #70

## Validation
- not run locally