### PR TITLE
pagestore: validate prepared branch install identity

### DIFF
--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -373,7 +373,7 @@ rm -rf "$SEEDDIR"
 # write forward on its own timeline without the parent seeing it.
 $P -c "CREATE FUNCTION pagestore_prepare_branch(text, int, int, pg_lsn, pg_lsn, xid, xid, xid, xid, xid, xid, bigint, bigint) RETURNS bigint
         AS 'pagestore','pagestore_prepare_branch' LANGUAGE C STRICT;
-       CREATE FUNCTION pagestore_install_prepared_branch(text, text) RETURNS void
+       CREATE FUNCTION pagestore_install_prepared_branch(text, text, int, int, pg_lsn) RETURNS void
         AS 'pagestore','pagestore_install_prepared_branch' LANGUAGE C STRICT;
        CREATE TABLE tb(id int, note text) TABLESPACE ts;" >/dev/null
 $P -c "CHECKPOINT;" >/dev/null
@@ -403,8 +403,10 @@ cp -a "$DATA" "$BRANCHDATA"
 "$BIN/pg_ctl" -D "$DATA" -l "$DATA/server.log" -w start >/dev/null 2>&1
 $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after L (heap ver > L)
 # Install the prepared branch artifacts into the branch copy, replacing copied SLRUs,
-# so the boot genuinely depends on all prepare_branch output rather than parent state.
-if $P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA');" >/dev/null; then
+# so the boot genuinely depends on prepare_branch output rather than parent state.
+bad_install=$($P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA', 2, 0, '$bL');" 2>/dev/null || echo error)
+assert "$bad_install" "error" "prepared branch install rejects the wrong branch identity"
+if $P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA', 1, 0, '$bL');" >/dev/null; then
 	echo "ok   - installed prepared branch artifacts into the branch datadir"
 else
 	echo "FAIL - could not install prepared branch artifacts"

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -5014,12 +5014,14 @@ pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir
  * returns void
  *
  * Install the artifacts produced by pagestore_prepare_branch() into an
- * initdb/copied branch datadir.  For now, only boot-critical SLRUs plus the
- * manifest are installed; optional SLRUs stay in the prepared artifact unless
- * the manifest says they are required.  The prepared manifest must match the
- * expected branch identity before any artifact is installed.  The manifest is
- * installed last so its presence remains the startup-time signal that the
- * datadir has a prepared branch identity and must pass timeline validation.
+ * initdb/copied branch datadir.  pg_xact and pg_multixact are always
+ * materialized by prepare (multixact seeds bootstrap pages even for an empty
+ * horizon), so both are required; pg_commit_ts is required only when the
+ * manifest's commit-ts horizons say it was seeded.  The prepared manifest must
+ * match the expected branch identity before any artifact is installed.  The
+ * manifest is installed last so its presence remains the startup-time signal
+ * that the datadir has a prepared branch identity and must pass timeline
+ * validation.
  */
 PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
 Datum
@@ -5032,6 +5034,8 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 	XLogRecPtr	fork_lsn;
 	char	   *manifest;
 	bool		commit_ts_required;
+	char		manifest_path[MAXPGPATH];
+	int			pathlen;
 
 	if (PG_NARGS() != 5)
 		ereport(ERROR,
@@ -5068,10 +5072,29 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
+
+	/*
+	 * From here until the prepared manifest is installed the target's SLRUs
+	 * may not match any manifest, so durably invalidate a manifest left by a
+	 * previous install before touching them.  Otherwise a failure between the
+	 * SLRU swaps below would leave the old manifest advertising a branch
+	 * identity over partially updated SLRUs.
+	 */
+	pathlen = snprintf(manifest_path, sizeof(manifest_path),
+					   "%s/pagestore_branch.manifest", target_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, manifest_path);
+	if (unlink(manifest_path) == 0)
+		fsync_fname(target_dir, true);
+	else if (errno != ENOENT)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove stale branch manifest \"%s\": %m",
+						manifest_path)));
+
 	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_xact", true);
 	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts",
 								commit_ts_required);
-	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", false);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", true);
 	pagestore_install_prepared_file(prepared_dir, target_dir,
 								 "pagestore_branch.manifest", true);
 

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -5078,31 +5078,6 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
-static void
-pagestore_validate_datadir_branch_manifest(void)
-{
-	char	   *manifest;
-	char		buf[64];
-
-	if (prev_shmem_startup_hook)
-		prev_shmem_startup_hook();
-
-	if (DataDir == NULL)
-		return;
-
-	manifest = pagestore_read_branch_manifest(DataDir);
-	if (manifest == NULL)
-		return;					/* legacy/non-branch datadir */
-	if (!pagestore_manifest_has_token(manifest, "format", "1"))
-		ereport(FATAL,
-				(errmsg("invalid pagestore branch manifest in data directory")));
-	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
-	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
-		ereport(FATAL,
-				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
-				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
-}
-
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -5013,6 +5013,31 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
+static void
+pagestore_validate_datadir_branch_manifest(void)
+{
+	char	   *manifest;
+	char		buf[64];
+
+	if (prev_shmem_startup_hook)
+		prev_shmem_startup_hook();
+
+	if (DataDir == NULL)
+		return;
+
+	manifest = pagestore_read_branch_manifest(DataDir);
+	if (manifest == NULL)
+		return;					/* legacy/non-branch datadir */
+	if (!pagestore_manifest_has_token(manifest, "format", "1"))
+		ereport(FATAL,
+				(errmsg("invalid pagestore branch manifest in data directory")));
+	snprintf(buf, sizeof(buf), "%u", pagestore_localsvc_timeline());
+	if (!pagestore_manifest_has_token(manifest, "new_timeline", buf))
+		ereport(FATAL,
+				(errmsg("pagestore.timeline does not match pagestore_branch.manifest"),
+				 errdetail("Configured timeline is %u.", pagestore_localsvc_timeline())));
+}
+
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -5085,13 +5085,19 @@ pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir
 }
 
 /*
- * pagestore_install_prepared_branch(prepared_dir text, target_dir text)
+ * pagestore_install_prepared_branch(prepared_dir text, target_dir text,
+ *                                  new_timeline int, parent_timeline int,
+ *                                  fork_lsn pg_lsn)
  * returns void
  *
  * Install the artifacts produced by pagestore_prepare_branch() into an
- * initdb/copied branch datadir.  The manifest is installed last so its presence
- * remains the startup-time signal that the datadir has a prepared branch
- * identity and must pass timeline validation.
+ * initdb/copied branch datadir.  For now, only the boot-critical pg_xact plus
+ * manifest are installed; optional SLRUs stay in the prepared artifact until a
+ * full bootstrap path has pg_control-aware activation for them.  The prepared
+ * manifest must match the expected branch identity before any artifact is
+ * installed.  The manifest is installed last so its presence remains the
+ * startup-time signal that the datadir has a prepared branch identity and must
+ * pass timeline validation.
  */
 PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
 Datum
@@ -5099,11 +5105,22 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 {
 	char	   *prepared_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	int32		new_tl = PG_GETARG_INT32(2);
+	int32		parent_tl = PG_GETARG_INT32(3);
+	XLogRecPtr	fork_lsn = PG_GETARG_LSN(4);
+	char	   *manifest;
 
 	if (!superuser())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser to install a prepared branch")));
+	manifest = pagestore_read_branch_manifest(prepared_dir);
+	if (manifest == NULL)
+		ereport(ERROR,
+				(errmsg("prepared branch manifest is missing")));
+	if (!pagestore_manifest_matches(manifest, new_tl, parent_tl, fork_lsn))
+		ereport(ERROR,
+				(errmsg("prepared branch manifest does not match the requested branch identity")));
 
 	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
 		ereport(ERROR,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -5014,6 +5014,111 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 }
 
 static void
+pagestore_install_prepared_dir(const char *prepared_dir, const char *target_dir,
+							   const char *relpath, bool required)
+{
+	char		src[MAXPGPATH];
+	char		dst[MAXPGPATH];
+	char		stage[MAXPGPATH];
+
+	if (strlen(prepared_dir) + strlen(relpath) + sizeof("/") > MAXPGPATH ||
+		strlen(target_dir) + strlen(relpath) + sizeof(".install/") > MAXPGPATH)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("branch install path is too long")));
+
+	snprintf(src, sizeof(src), "%s/%s", prepared_dir, relpath);
+	snprintf(dst, sizeof(dst), "%s/%s", target_dir, relpath);
+	snprintf(stage, sizeof(stage), "%s/%s.install", target_dir, relpath);
+	if (access(src, F_OK) != 0)
+	{
+		if (required)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("prepared branch artifact \"%s\" is missing: %m", src)));
+		return;
+	}
+	if (access(stage, F_OK) == 0 && !rmtree(stage, true))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not clear branch install staging dir \"%s\"", stage)));
+	copydir(src, stage, true);
+	fsync_fname(stage, true);
+	if (access(dst, F_OK) == 0 && !rmtree(dst, true))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove existing branch artifact \"%s\"", dst)));
+	if (rename(stage, dst) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not install branch artifact \"%s\": %m", dst)));
+	fsync_fname(target_dir, true);
+}
+
+static void
+pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir,
+								const char *relpath)
+{
+	char		src[MAXPGPATH];
+	char		dst[MAXPGPATH];
+	char		stage[MAXPGPATH];
+
+	if (strlen(prepared_dir) + strlen(relpath) + sizeof("/") > MAXPGPATH ||
+		strlen(target_dir) + strlen(relpath) + sizeof(".install/") > MAXPGPATH)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("branch install path is too long")));
+
+	snprintf(src, sizeof(src), "%s/%s", prepared_dir, relpath);
+	snprintf(dst, sizeof(dst), "%s/%s", target_dir, relpath);
+	snprintf(stage, sizeof(stage), "%s/%s.install", target_dir, relpath);
+	if (access(src, F_OK) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("prepared branch artifact \"%s\" is missing: %m", src)));
+	copy_file(src, stage);
+	if (durable_rename(stage, dst, ERROR) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not install branch artifact \"%s\": %m", dst)));
+	fsync_fname(target_dir, true);
+}
+
+/*
+ * pagestore_install_prepared_branch(prepared_dir text, target_dir text)
+ * returns void
+ *
+ * Install the artifacts produced by pagestore_prepare_branch() into an
+ * initdb/copied branch datadir.  The manifest is installed last so its presence
+ * remains the startup-time signal that the datadir has a prepared branch
+ * identity and must pass timeline validation.
+ */
+PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
+Datum
+pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
+{
+	char	   *prepared_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to install a prepared branch")));
+
+	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_xact", true);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts", false);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", false);
+	pagestore_install_prepared_file(prepared_dir, target_dir,
+									"pagestore_branch.manifest");
+
+	PG_RETURN_VOID();
+}
+
+static void
 pagestore_validate_datadir_branch_manifest(void)
 {
 	char	   *manifest;

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4388,6 +4388,33 @@ pagestore_manifest_has_uint_token(const char *manifest, const char *key,
 }
 
 static bool
+pagestore_manifest_get_xid_string_token(const char *manifest, const char *key,
+										TransactionId *value)
+{
+	const char *field = pagestore_manifest_find_unique_field(manifest, key);
+	char	   *endptr;
+	unsigned long long parsed;
+
+	if (field == NULL || *field != '"')
+		return false;
+	field++;
+	if (*field < '0' || *field > '9')
+		return false;
+	errno = 0;
+	parsed = strtoull(field, &endptr, 10);
+	if (errno != 0 || endptr == field)
+		return false;
+	if (parsed > UINT32_MAX)
+		return false;
+	if (*endptr != '"')
+		return false;
+	if (!pagestore_manifest_value_delimited(endptr + 1))
+		return false;
+	*value = (TransactionId) parsed;
+	return true;
+}
+
+static bool
 pagestore_manifest_has_string_token(const char *manifest, const char *key,
 									const char *value)
 {
@@ -4794,19 +4821,17 @@ pagestore_manifest_get_branch_identity(const char *manifest, uint32_t *new_tl,
 static bool
 pagestore_manifest_get_commit_ts_required(const char *manifest, bool *required)
 {
-	uint32_t	oldest_raw;
-	uint32_t	next_raw;
 	TransactionId oldest_xid;
 	TransactionId next_xid;
 
-	if (!pagestore_manifest_get_uint_token(manifest, "oldest_commit_ts_xid",
-										   &oldest_raw) ||
-		!pagestore_manifest_get_uint_token(manifest, "next_commit_ts_xid",
-										   &next_raw))
+	if (!pagestore_manifest_get_xid_string_token(manifest,
+												 "oldest_commit_ts_xid",
+												 &oldest_xid) ||
+		!pagestore_manifest_get_xid_string_token(manifest,
+												 "next_commit_ts_xid",
+												 &next_xid))
 		return false;
 
-	oldest_xid = (TransactionId) oldest_raw;
-	next_xid = (TransactionId) next_raw;
 	if (!TransactionIdIsNormal(oldest_xid) &&
 		!TransactionIdIsNormal(next_xid))
 	{

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -5103,6 +5103,10 @@ PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
 Datum
 pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 {
+	if (PG_NARGS() != 5)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("pagestore_install_prepared_branch requires 5 arguments (prepared_dir, target_dir, new_timeline, parent_timeline, fork_lsn)")));
 	char	   *prepared_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	int32		new_tl = PG_GETARG_INT32(2);

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4791,6 +4791,38 @@ pagestore_manifest_get_branch_identity(const char *manifest, uint32_t *new_tl,
 		pagestore_manifest_get_lsn_token(manifest, "fork_lsn", fork_lsn);
 }
 
+static bool
+pagestore_manifest_get_commit_ts_required(const char *manifest, bool *required)
+{
+	uint32_t	oldest_raw;
+	uint32_t	next_raw;
+	TransactionId oldest_xid;
+	TransactionId next_xid;
+
+	if (!pagestore_manifest_get_uint_token(manifest, "oldest_commit_ts_xid",
+										   &oldest_raw) ||
+		!pagestore_manifest_get_uint_token(manifest, "next_commit_ts_xid",
+										   &next_raw))
+		return false;
+
+	oldest_xid = (TransactionId) oldest_raw;
+	next_xid = (TransactionId) next_raw;
+	if (!TransactionIdIsNormal(oldest_xid) &&
+		!TransactionIdIsNormal(next_xid))
+	{
+		*required = false;
+		return true;
+	}
+	if (TransactionIdIsNormal(oldest_xid) &&
+		TransactionIdIsNormal(next_xid) &&
+		!TransactionIdFollows(oldest_xid, next_xid))
+	{
+		*required = true;
+		return true;
+	}
+	return false;
+}
+
 static inline bool
 pagestore_branch_backend_active(void)
 {
@@ -4951,173 +4983,50 @@ pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir
 }
 
 /*
- * pagestore_install_prepared_branch(prepared_dir text, target_dir text)
- * returns void
- *
- * Install the artifacts produced by pagestore_prepare_branch() into an
- * initdb/copied branch datadir.  pg_xact and any prepared SLRUs are installed
- * before the manifest, and the manifest is installed last so its presence remains
- * the startup-time signal that the datadir has a prepared branch identity and must
- * pass timeline validation.
- */
-PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
-Datum
-pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
-{
-	char	   *prepared_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
-	char		manifest[MAXPGPATH];
-	char		stage[MAXPGPATH];
-	int			pathlen;
-
-	if (!superuser())
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to install a prepared branch")));
-	pathlen = snprintf(manifest, sizeof(manifest),
-					   "%s/pagestore_branch.manifest", prepared_dir);
-	PS_CHECK_PATH_FORMAT(pathlen, manifest);
-	if (access(manifest, F_OK) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("prepared branch artifact \"%s\" is missing: %m", manifest)));
-
-	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
-	pathlen = snprintf(stage, sizeof(stage), "%s/pagestore_branch.manifest",
-					   target_dir);
-	PS_CHECK_PATH_FORMAT(pathlen, stage);
-	if (access(stage, F_OK) == 0)
-	{
-		if (unlink(stage) != 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not clear existing branch artifact \"%s\": %m", stage)));
-		fsync_fname(target_dir, true);
-	}
-	pathlen = snprintf(stage, sizeof(stage),
-					   "%s/pagestore_branch.manifest.install", target_dir);
-	PS_CHECK_PATH_FORMAT(pathlen, stage);
-	if (access(stage, F_OK) == 0 && unlink(stage) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not clear existing branch artifact staging file \"%s\": %m", stage)));
-	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_xact", true);
-	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts", false);
-	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", true);
-	pagestore_install_prepared_file(prepared_dir, target_dir,
-									"pagestore_branch.manifest", true);
-
-	PG_RETURN_VOID();
-}
-
-static void
-pagestore_install_prepared_dir(const char *prepared_dir, const char *target_dir,
-							   const char *relpath, bool required)
-{
-	char		src[MAXPGPATH];
-	char		dst[MAXPGPATH];
-	char		stage[MAXPGPATH];
-
-	if (strlen(prepared_dir) + strlen(relpath) + sizeof("/") > MAXPGPATH ||
-		strlen(target_dir) + strlen(relpath) + sizeof(".install/") > MAXPGPATH)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("branch install path is too long")));
-
-	snprintf(src, sizeof(src), "%s/%s", prepared_dir, relpath);
-	snprintf(dst, sizeof(dst), "%s/%s", target_dir, relpath);
-	snprintf(stage, sizeof(stage), "%s/%s.install", target_dir, relpath);
-	if (access(src, F_OK) != 0)
-	{
-		if (required)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("prepared branch artifact \"%s\" is missing: %m", src)));
-		return;
-	}
-	if (access(stage, F_OK) == 0 && !rmtree(stage, true))
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not clear branch install staging dir \"%s\"", stage)));
-	copydir(src, stage, true);
-	fsync_fname(stage, true);
-	if (access(dst, F_OK) == 0 && !rmtree(dst, true))
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not remove existing branch artifact \"%s\"", dst)));
-	if (rename(stage, dst) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not install branch artifact \"%s\": %m", dst)));
-	fsync_fname(target_dir, true);
-}
-
-static void
-pagestore_install_prepared_file(const char *prepared_dir, const char *target_dir,
-								const char *relpath)
-{
-	char		src[MAXPGPATH];
-	char		dst[MAXPGPATH];
-	char		stage[MAXPGPATH];
-
-	if (strlen(prepared_dir) + strlen(relpath) + sizeof("/") > MAXPGPATH ||
-		strlen(target_dir) + strlen(relpath) + sizeof(".install/") > MAXPGPATH)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("branch install path is too long")));
-
-	snprintf(src, sizeof(src), "%s/%s", prepared_dir, relpath);
-	snprintf(dst, sizeof(dst), "%s/%s", target_dir, relpath);
-	snprintf(stage, sizeof(stage), "%s/%s.install", target_dir, relpath);
-	if (access(src, F_OK) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("prepared branch artifact \"%s\" is missing: %m", src)));
-	copy_file(src, stage);
-	if (durable_rename(stage, dst, ERROR) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not install branch artifact \"%s\": %m", dst)));
-	fsync_fname(target_dir, true);
-}
-
-/*
  * pagestore_install_prepared_branch(prepared_dir text, target_dir text,
  *                                  new_timeline int, parent_timeline int,
  *                                  fork_lsn pg_lsn)
  * returns void
  *
  * Install the artifacts produced by pagestore_prepare_branch() into an
- * initdb/copied branch datadir.  For now, only the boot-critical pg_xact plus
- * manifest are installed; optional SLRUs stay in the prepared artifact until a
- * full bootstrap path has pg_control-aware activation for them.  The prepared
- * manifest must match the expected branch identity before any artifact is
- * installed.  The manifest is installed last so its presence remains the
- * startup-time signal that the datadir has a prepared branch identity and must
- * pass timeline validation.
+ * initdb/copied branch datadir.  For now, only boot-critical SLRUs plus the
+ * manifest are installed; optional SLRUs stay in the prepared artifact unless
+ * the manifest says they are required.  The prepared manifest must match the
+ * expected branch identity before any artifact is installed.  The manifest is
+ * installed last so its presence remains the startup-time signal that the
+ * datadir has a prepared branch identity and must pass timeline validation.
  */
 PG_FUNCTION_INFO_V1(pagestore_install_prepared_branch);
 Datum
 pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 {
+	char	   *prepared_dir;
+	char	   *target_dir;
+	int32		new_tl;
+	int32		parent_tl;
+	XLogRecPtr	fork_lsn;
+	char	   *manifest;
+	bool		commit_ts_required;
+
 	if (PG_NARGS() != 5)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("pagestore_install_prepared_branch requires 5 arguments (prepared_dir, target_dir, new_timeline, parent_timeline, fork_lsn)")));
-	char	   *prepared_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	char	   *target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
-	int32		new_tl = PG_GETARG_INT32(2);
-	int32		parent_tl = PG_GETARG_INT32(3);
-	XLogRecPtr	fork_lsn = PG_GETARG_LSN(4);
-	char	   *manifest;
+
+	prepared_dir = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	target_dir = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	new_tl = PG_GETARG_INT32(2);
+	parent_tl = PG_GETARG_INT32(3);
+	fork_lsn = PG_GETARG_LSN(4);
 
 	if (!superuser())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser to install a prepared branch")));
+	if (new_tl <= 0 || parent_tl < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid branch timeline identity")));
 	manifest = pagestore_read_branch_manifest(prepared_dir);
 	if (manifest == NULL)
 		ereport(ERROR,
@@ -5125,16 +5034,21 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 	if (!pagestore_manifest_matches(manifest, new_tl, parent_tl, fork_lsn))
 		ereport(ERROR,
 				(errmsg("prepared branch manifest does not match the requested branch identity")));
+	if (!pagestore_manifest_get_commit_ts_required(manifest,
+											   &commit_ts_required))
+		ereport(ERROR,
+				(errmsg("prepared branch manifest has invalid commit-ts horizons")));
 
 	if (MakePGDirectory(target_dir) != 0 && errno != EEXIST)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
 	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_xact", true);
-	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts", false);
+	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_commit_ts",
+								commit_ts_required);
 	pagestore_install_prepared_dir(prepared_dir, target_dir, "pg_multixact", false);
 	pagestore_install_prepared_file(prepared_dir, target_dir,
-									"pagestore_branch.manifest");
+								 "pagestore_branch.manifest", true);
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
## Summary
- extend pagestore_install_prepared_branch() to require the expected branch identity
- validate the prepared manifest before installing any artifact into the branch datadir
- share manifest matching logic with pagestore_validate_branch_manifest()
- add an integration assertion that installing with the wrong timeline is rejected

## Stack
- stacked on #76 / feat/pagestore-install-prepared-branch
- #76 is stacked on #75, #74, #73, #72, #71, and #70

## Validation
- not run locally