### PR TITLE
pagestore: guard prepared branch artifacts

### DIFF
--- a/contrib/pagestore/backend_localsvc.c
+++ b/contrib/pagestore/backend_localsvc.c
@@ -246,6 +246,7 @@ ls_exec_timeout(PsChannel *ch, int timeout_ms)
 {
 	uint32		spins = 0;
 	time_t		deadline = 0;
+	bool		timed_out = false;
 
 	if (timeout_ms > 0)
 		deadline = time(NULL) + (timeout_ms + 999) / 1000;
@@ -258,17 +259,20 @@ ls_exec_timeout(PsChannel *ch, int timeout_ms)
 	{
 		if (((++spins) & 0xFFF) == 0)
 		{
-			CHECK_FOR_INTERRUPTS();
+			if (!timed_out)
+				CHECK_FOR_INTERRUPTS();
 			if (deadline != 0 && time(NULL) >= deadline)
-				ereport(ERROR,
-						(errmsg("pagestore localsvc: timed out waiting for daemon op %u",
-								ch->opcode)));
+				timed_out = true;
 		}
 #if defined(__x86_64__) || defined(__i386__)
 		__builtin_ia32_pause();
 #endif
 	}
 
+	if (timed_out)
+		ereport(ERROR,
+				(errmsg("pagestore localsvc: timed out waiting for daemon op %u",
+						ch->opcode)));
 	if (ch->status != PS_STATUS_OK)
 		ereport(ERROR,
 				(errmsg("pagestore localsvc: daemon reported error for op %u",

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -401,6 +401,11 @@ $P -c "INSERT INTO tb VALUES (2,'after_L'); CHECKPOINT;" >/dev/null   # T2 after
 # so the boot genuinely depends on prepare_branch output rather than parent state.
 bad_install=$($P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA', 2, 0, '$bL');" 2>/dev/null || echo error)
 assert "$bad_install" "error" "prepared branch install rejects the wrong branch identity"
+BADSEED=$(mktemp -d)
+cp "$SEEDOUT/pagestore_branch.manifest" "$BADSEED/pagestore_branch.manifest"
+missing_artifact=$($P -c "SELECT pagestore_install_prepared_branch('$BADSEED', '$BRANCHDATA', 1, 0, '$bL');" 2>/dev/null || echo error)
+assert "$missing_artifact" "error" "prepared branch install rejects a missing pg_xact artifact"
+rm -rf "$BADSEED"
 $P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA', 1, 0, '$bL');" >/dev/null
 $P -c "SELECT pagestore_install_prepared_branch('$SEEDOUT', '$BRANCHDATA', 1, 0, '$bL');" >/dev/null
 echo "ok   - prepared branch install is idempotent for the same branch identity"

--- a/contrib/pagestore/integration_test.sh
+++ b/contrib/pagestore/integration_test.sh
@@ -630,6 +630,11 @@ EOF
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');")" "f" \
 	"branch manifest validator rejects malformed JSON"
 cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
+{ "format": 1, "new_timeline": 2, "new_\u0074imeline": 3, "parent_timeline": 0, "fork_lsn": "$mxL" }
+EOF
+assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 2, 0, '$mxL');")" "f" \
+	"branch manifest validator rejects escaped duplicate keys"
+cat > "$PREPSEED/pagestore_branch.manifest" <<EOF
 { "format": 1, "new_timeline": 0, "parent_timeline": 0, "fork_lsn": "$mxL" }
 EOF
 assert "$($P -c "SELECT pagestore_validate_branch_manifest('$PREPSEED', 0, 0, '$mxL');")" "f" \

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -31,6 +31,7 @@
 #include "postgres.h"
 
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "access/clog.h"
@@ -3527,6 +3528,30 @@ pagestore_manifest_matches(const char *manifest, int32 new_tl, int32 parent_tl,
 	return true;
 }
 
+static void
+pagestore_require_prepared_artifact(const char *prepared_dir,
+									const char *relpath, bool directory)
+{
+	char		path[MAXPGPATH];
+	struct stat st;
+
+	if (strlen(prepared_dir) + strlen(relpath) + sizeof("/") > MAXPGPATH)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("prepared branch artifact path is too long")));
+
+	snprintf(path, sizeof(path), "%s/%s", prepared_dir, relpath);
+	if (stat(path, &st) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("prepared branch artifact \"%s\" is missing: %m", path)));
+	if (directory ? !S_ISDIR(st.st_mode) : !S_ISREG(st.st_mode))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("prepared branch artifact \"%s\" has the wrong file type",
+						path)));
+}
+
 /*
  * pagestore_validate_branch_manifest(target_dir text, new_timeline int,
  *                                    parent_timeline int, fork_lsn pg_lsn)
@@ -3698,6 +3723,9 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 	if (!pagestore_manifest_matches(manifest, new_tl, parent_tl, fork_lsn))
 		ereport(ERROR,
 				(errmsg("prepared branch manifest does not match the requested branch identity")));
+	pagestore_require_prepared_artifact(prepared_dir, "pg_xact", true);
+	pagestore_require_prepared_artifact(prepared_dir,
+										"pagestore_branch.manifest", false);
 	target_manifest = pagestore_read_branch_manifest(target_dir);
 	if (target_manifest != NULL &&
 		!pagestore_manifest_matches(target_manifest, new_tl, parent_tl, fork_lsn))

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4769,6 +4769,8 @@ pagestore_install_prepared_branch(PG_FUNCTION_ARGS)
 				(errmsg("prepared branch manifest does not match the requested branch identity")));
 	pagestore_require_prepared_artifact(prepared_dir, "pg_xact", true);
 	pagestore_require_prepared_artifact(prepared_dir, "pg_multixact", true);
+	pagestore_require_prepared_artifact(prepared_dir, "pg_multixact/offsets", true);
+	pagestore_require_prepared_artifact(prepared_dir, "pg_multixact/members", true);
 	pagestore_require_prepared_artifact(prepared_dir,
 										"pagestore_branch.manifest", false);
 	target_manifest = pagestore_read_branch_manifest(target_dir);

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4657,6 +4657,7 @@ pagestore_existing_branch_manifest_matches(const char *target_dir,
 	char	   *seeded_end;
 	long long	seeded;
 	int			len;
+	volatile bool read_failed = false;
 
 #define CHECK_MANIFEST_LINE(...) \
 	do { \
@@ -4666,7 +4667,18 @@ pagestore_existing_branch_manifest_matches(const char *target_dir,
 			return false; \
 	} while (0)
 
-	manifest = pagestore_read_branch_manifest(target_dir);
+	PG_TRY();
+	{
+		manifest = pagestore_read_branch_manifest(target_dir);
+	}
+	PG_CATCH();
+	{
+		FlushErrorState();
+		read_failed = true;
+	}
+	PG_END_TRY();
+	if (read_failed)
+		return false;
 	if (manifest == NULL)
 		return false;
 	if (!pagestore_manifest_matches(manifest, new_tl, parent_tl, target))

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4159,14 +4159,21 @@ pagestore_write_branch_manifest(const char *target_dir,
 				(errcode_for_file_access(),
 				 errmsg("could not close branch manifest \"%s\": %m", tmppath)));
 	}
-	if (rename(tmppath, path) != 0)
+	/*
+	 * The manifest is the marker that this dir is consumable, so if any part
+	 * of the durable publish (rename + directory fsync) fails it must not
+	 * stay visible while the caller reports the prepare as failed.  The
+	 * unlinks are best-effort: if the directory fsync itself is failing
+	 * there is no stronger rollback available.
+	 */
+	if (durable_rename(tmppath, path, LOG) != 0)
 	{
 		(void) unlink(tmppath);
+		(void) unlink(path);
 		ereport(ERROR,
 				(errcode_for_file_access(),
-				 errmsg("could not publish branch manifest \"%s\": %m", path)));
+				 errmsg("could not durably publish branch manifest \"%s\"", path)));
 	}
-	fsync_fname(target_dir, true);
 }
 
 /*

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -31,6 +31,7 @@
 #include "postgres.h"
 
 #include <fcntl.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "access/clog.h"
@@ -4176,6 +4177,102 @@ pagestore_write_branch_manifest(const char *target_dir,
 	}
 }
 
+static bool
+pagestore_manifest_has_line(const char *manifest, const char *line)
+{
+	return strstr(manifest, line) != NULL;
+}
+
+static bool
+pagestore_existing_branch_manifest_matches(const char *target_dir,
+										   int32 new_tl, int32 parent_tl,
+										   XLogRecPtr base, XLogRecPtr target,
+										   TransactionId oldest_xid,
+										   TransactionId next_xid,
+										   TransactionId oldest_commit_ts_xid,
+										   TransactionId next_commit_ts_xid,
+										   MultiXactId oldest_multi,
+										   MultiXactId next_multi,
+										   int64 oldest_member,
+										   int64 next_member,
+										   int64 *seeded_pages)
+{
+	char		path[MAXPGPATH];
+	char		manifest[4096];
+	char		line[128];
+	char	   *seeded_start;
+	char	   *seeded_end;
+	long long	seeded;
+	FILE	   *file;
+	size_t		nread;
+	int			len;
+
+#define CHECK_MANIFEST_LINE(...) \
+	do { \
+		len = snprintf(line, sizeof(line), __VA_ARGS__); \
+		if (len < 0 || len >= (int) sizeof(line) || \
+			!pagestore_manifest_has_line(manifest, line)) \
+			return false; \
+	} while (0)
+
+	len = snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
+	PS_CHECK_PATH_FORMAT(len, path);
+	file = AllocateFile(path, PG_BINARY_R);
+	if (file == NULL)
+	{
+		if (errno == ENOENT)
+			return false;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open branch manifest \"%s\": %m", path)));
+	}
+	nread = fread(manifest, 1, sizeof(manifest) - 1, file);
+	if (ferror(file))
+	{
+		FreeFile(file);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read branch manifest \"%s\": %m", path)));
+	}
+	if (!feof(file))
+	{
+		FreeFile(file);
+		return false;
+	}
+	FreeFile(file);
+	if (memchr(manifest, '\0', nread) != NULL)
+		return false;
+	manifest[nread] = '\0';
+
+	CHECK_MANIFEST_LINE("  \"format\": 1,\n");
+	CHECK_MANIFEST_LINE("  \"new_timeline\": %d,\n", new_tl);
+	CHECK_MANIFEST_LINE("  \"parent_timeline\": %d,\n", parent_tl);
+	CHECK_MANIFEST_LINE("  \"base_lsn\": \"%X/%08X\",\n", LSN_FORMAT_ARGS(base));
+	CHECK_MANIFEST_LINE("  \"fork_lsn\": \"%X/%08X\",\n", LSN_FORMAT_ARGS(target));
+	CHECK_MANIFEST_LINE("  \"oldest_xid\": \"%u\",\n", oldest_xid);
+	CHECK_MANIFEST_LINE("  \"next_xid\": \"%u\",\n", next_xid);
+	CHECK_MANIFEST_LINE("  \"oldest_commit_ts_xid\": \"%u\",\n", oldest_commit_ts_xid);
+	CHECK_MANIFEST_LINE("  \"next_commit_ts_xid\": \"%u\",\n", next_commit_ts_xid);
+	CHECK_MANIFEST_LINE("  \"oldest_multi\": \"%u\",\n", oldest_multi);
+	CHECK_MANIFEST_LINE("  \"next_multi\": \"%u\",\n", next_multi);
+	CHECK_MANIFEST_LINE("  \"oldest_member\": \"%lld\",\n", (long long) oldest_member);
+	CHECK_MANIFEST_LINE("  \"next_member\": \"%lld\",\n", (long long) next_member);
+
+	seeded_start = strstr(manifest, "  \"seeded_slru_pages\": \"");
+	if (seeded_start == NULL)
+		return false;
+	seeded_start += strlen("  \"seeded_slru_pages\": \"");
+	errno = 0;
+	seeded = strtoll(seeded_start, &seeded_end, 10);
+	if (errno != 0 || seeded_end == seeded_start || seeded < 0 ||
+		strncmp(seeded_end, "\"\n", 2) != 0)
+		return false;
+	*seeded_pages = (int64) seeded;
+	return true;
+
+#undef CHECK_MANIFEST_LINE
+}
+
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,
@@ -4232,6 +4329,20 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 
 	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
 									(uint64) target);
+
+	if (pagestore_existing_branch_manifest_matches(target_dir, new_tl, parent_tl,
+												   base, target,
+												   oldest_xid, next_xid,
+												   oldest_commit_ts_xid,
+												   next_commit_ts_xid,
+												   oldest_multi, next_multi,
+												   oldest_member, next_member,
+												   &seeded))
+	{
+		pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+										 (uint64) target);
+		PG_RETURN_INT64(seeded);
+	}
 
 	/*
 	 * From here until the new manifest is published the target's SLRUs may

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4229,6 +4229,18 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 											  next_commit_ts_xid,
 											  oldest_multi, next_multi,
 											  oldest_member, next_member);
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) target);
+
+	/*
+	 * Publish the manifest only after the store-side timeline exists: the
+	 * manifest is the durable handoff artifact for later bootstrap, so it must
+	 * never advertise a branch that CREATE_BRANCH refused (e.g. the same
+	 * timeline raced into existence with different ancestry during seeding).
+	 * The reverse window is retry-safe: if the manifest write fails here, the
+	 * timeline already exists and a retried prepare passes CHECK_BRANCH and
+	 * re-runs CREATE_BRANCH idempotently.
+	 */
 	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl,
 									base, target,
 									oldest_xid, next_xid,
@@ -4237,8 +4249,6 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 									oldest_multi, next_multi,
 									oldest_member, next_member,
 									seeded);
-	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-									 (uint64) target);
 
 	PG_RETURN_INT64(seeded);
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4313,6 +4313,8 @@ pagestore_manifest_find_unique_field(const char *manifest, const char *key)
 			{
 				const char *value = pagestore_manifest_skip_ws(end + 1);
 
+				if (memchr(name, '\\', end - name) != NULL)
+					return NULL;
 				if (*value == ':' &&
 					(size_t) (end - name) == keylen &&
 					strncmp(name, key, keylen) == 0)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4071,11 +4071,6 @@ pagestore_write_branch_manifest(const char *target_dir,
 	int			fd;
 	int			done = 0;
 
-	if (strlen(target_dir) + sizeof("/pagestore_branch.manifest.tmp") > MAXPGPATH)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("branch target directory path is too long")));
-
 	len = snprintf(manifest, sizeof(manifest),
 				   "{\n"
 				   "  \"format\": 1,\n"
@@ -4112,10 +4107,14 @@ pagestore_write_branch_manifest(const char *target_dir,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch dir \"%s\": %m", target_dir)));
 
-	snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
-	snprintf(tmppath, sizeof(tmppath), "%s/pagestore_branch.manifest.tmp", target_dir);
+	len = snprintf(path, sizeof(path), "%s/pagestore_branch.manifest", target_dir);
+	PS_CHECK_PATH_FORMAT(len, path);
+	len = snprintf(tmppath, sizeof(tmppath),
+				   "%s/pagestore_branch.manifest.tmp.%ld",
+				   target_dir, (long) MyProcPid);
+	PS_CHECK_PATH_FORMAT(len, tmppath);
 	fd = OpenTransientFilePerm(tmppath,
-							   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY,
+							   O_WRONLY | O_CREAT | O_EXCL | PG_BINARY,
 							   pg_file_create_mode);
 	if (fd < 0)
 		ereport(ERROR,
@@ -4200,20 +4199,24 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 	if (parent_tl < 0)
 		ereport(ERROR,
 				(errmsg("pagestore parent timeline must be >= 0")));
+	if ((uint32) parent_tl != pagestore_localsvc_timeline())
+		ereport(ERROR,
+				(errmsg("pagestore parent timeline %d is not the active localsvc timeline %u",
+						parent_tl, pagestore_localsvc_timeline())));
 	if (target < base)
 		ereport(ERROR,
 				(errmsg("target LSN precedes the base cutoff")));
 
 	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
 									(uint64) target);
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) target);
 	seeded = pagestore_seed_branch_slrus_impl(target_dir, base, target,
 											  oldest_xid, next_xid,
 											  oldest_commit_ts_xid,
 											  next_commit_ts_xid,
 											  oldest_multi, next_multi,
 											  oldest_member, next_member);
-	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-									 (uint64) target);
 	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl, base, target,
 									oldest_xid, next_xid,
 									oldest_commit_ts_xid, next_commit_ts_xid,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4202,6 +4202,8 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 	int64		oldest_member = PG_GETARG_INT64(11);
 	int64		next_member = PG_GETARG_INT64(12);
 	int64		seeded;
+	char		manifest_path[MAXPGPATH];
+	int			pathlen;
 
 	if (!superuser())
 		ereport(ERROR,
@@ -4223,6 +4225,27 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 
 	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
 									(uint64) target);
+
+	/*
+	 * From here until the new manifest is published the target's SLRUs may
+	 * not match any manifest, so durably invalidate a manifest left by a
+	 * previous prepare before touching them.  The manifest is what marks a
+	 * prepared dir as consumable, so every failure below -- SLRU seeding,
+	 * CREATE_BRANCH being refused after the store raced ahead, the manifest
+	 * write itself -- leaves the dir inert instead of advertising stale or
+	 * half-updated contents.
+	 */
+	pathlen = snprintf(manifest_path, sizeof(manifest_path),
+					   "%s/pagestore_branch.manifest", target_dir);
+	PS_CHECK_PATH_FORMAT(pathlen, manifest_path);
+	if (unlink(manifest_path) == 0)
+		fsync_fname(target_dir, true);
+	else if (errno != ENOENT)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not remove stale branch manifest \"%s\": %m",
+						manifest_path)));
+
 	seeded = pagestore_seed_branch_slrus_impl(target_dir, base, target,
 											  oldest_xid, next_xid,
 											  oldest_commit_ts_xid,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4068,36 +4068,37 @@ pagestore_write_branch_manifest(const char *target_dir,
 	char		tmppath[MAXPGPATH];
 	char		manifest[2048];
 	int			len;
+	int			manifest_len;
 	int			fd;
 	int			done = 0;
 
-	len = snprintf(manifest, sizeof(manifest),
-				   "{\n"
-				   "  \"format\": 1,\n"
-				   "  \"new_timeline\": %d,\n"
-				   "  \"parent_timeline\": %d,\n"
-				   "  \"base_lsn\": \"%X/%08X\",\n"
-				   "  \"fork_lsn\": \"%X/%08X\",\n"
-				   "  \"oldest_xid\": \"%u\",\n"
-				   "  \"next_xid\": \"%u\",\n"
-				   "  \"oldest_commit_ts_xid\": \"%u\",\n"
-				   "  \"next_commit_ts_xid\": \"%u\",\n"
-				   "  \"oldest_multi\": \"%u\",\n"
-				   "  \"next_multi\": \"%u\",\n"
-				   "  \"oldest_member\": \"%lld\",\n"
-				   "  \"next_member\": \"%lld\",\n"
-				   "  \"seeded_slru_pages\": \"%lld\"\n"
-				   "}\n",
-				   new_tl, parent_tl,
-				   LSN_FORMAT_ARGS(base),
-				   LSN_FORMAT_ARGS(target),
-				   oldest_xid, next_xid,
-				   oldest_commit_ts_xid, next_commit_ts_xid,
-				   oldest_multi, next_multi,
-				   (long long) oldest_member,
-				   (long long) next_member,
-				   (long long) seeded_pages);
-	if (len < 0 || len >= (int) sizeof(manifest))
+	manifest_len = snprintf(manifest, sizeof(manifest),
+							"{\n"
+							"  \"format\": 1,\n"
+							"  \"new_timeline\": %d,\n"
+							"  \"parent_timeline\": %d,\n"
+							"  \"base_lsn\": \"%X/%08X\",\n"
+							"  \"fork_lsn\": \"%X/%08X\",\n"
+							"  \"oldest_xid\": \"%u\",\n"
+							"  \"next_xid\": \"%u\",\n"
+							"  \"oldest_commit_ts_xid\": \"%u\",\n"
+							"  \"next_commit_ts_xid\": \"%u\",\n"
+							"  \"oldest_multi\": \"%u\",\n"
+							"  \"next_multi\": \"%u\",\n"
+							"  \"oldest_member\": \"%lld\",\n"
+							"  \"next_member\": \"%lld\",\n"
+							"  \"seeded_slru_pages\": \"%lld\"\n"
+							"}\n",
+							new_tl, parent_tl,
+							LSN_FORMAT_ARGS(base),
+							LSN_FORMAT_ARGS(target),
+							oldest_xid, next_xid,
+							oldest_commit_ts_xid, next_commit_ts_xid,
+							oldest_multi, next_multi,
+							(long long) oldest_member,
+							(long long) next_member,
+							(long long) seeded_pages);
+	if (manifest_len < 0 || manifest_len >= (int) sizeof(manifest))
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("branch manifest is too large")));
@@ -4120,12 +4121,12 @@ pagestore_write_branch_manifest(const char *target_dir,
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not create branch manifest \"%s\": %m", tmppath)));
-	while (done < len)
+	while (done < manifest_len)
 	{
 		ssize_t		written;
 
 		errno = 0;
-		written = write(fd, manifest + done, len - done);
+		written = write(fd, manifest + done, manifest_len - done);
 		if (written <= 0)
 		{
 			if (written == 0)

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4114,6 +4114,11 @@ pagestore_write_branch_manifest(const char *target_dir,
 				   "%s/pagestore_branch.manifest.tmp.%ld",
 				   target_dir, (long) MyProcPid);
 	PS_CHECK_PATH_FORMAT(len, tmppath);
+	if (access(tmppath, F_OK) == 0 && unlink(tmppath) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not clear stale branch manifest temp file \"%s\": %m",
+						tmppath)));
 	fd = OpenTransientFilePerm(tmppath,
 							   O_WRONLY | O_CREAT | O_EXCL | PG_BINARY,
 							   pg_file_create_mode);
@@ -4132,6 +4137,7 @@ pagestore_write_branch_manifest(const char *target_dir,
 			if (written == 0)
 				errno = ENOSPC;
 			CloseTransientFile(fd);
+			(void) unlink(tmppath);
 			ereport(ERROR,
 					(errcode_for_file_access(),
 					 errmsg("could not write branch manifest \"%s\": %m", tmppath)));
@@ -4141,19 +4147,62 @@ pagestore_write_branch_manifest(const char *target_dir,
 	if (pg_fsync(fd) != 0)
 	{
 		CloseTransientFile(fd);
+		(void) unlink(tmppath);
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not fsync branch manifest \"%s\": %m", tmppath)));
 	}
 	if (CloseTransientFile(fd) != 0)
+	{
+		(void) unlink(tmppath);
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not close branch manifest \"%s\": %m", tmppath)));
+	}
 	if (rename(tmppath, path) != 0)
+	{
+		(void) unlink(tmppath);
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not publish branch manifest \"%s\": %m", path)));
+	}
 	fsync_fname(target_dir, true);
+}
+
+static void
+pagestore_cleanup_prepared_branch_output(const char *target_dir)
+{
+	const char *artifacts[] = {
+		"pg_multixact",
+		"pg_commit_ts",
+		"pg_xact",
+		"pagestore_branch.manifest",
+	};
+	char		path[MAXPGPATH];
+
+	for (int i = 0; i < lengthof(artifacts); i++)
+	{
+		int			len;
+
+		len = snprintf(path, sizeof(path), "%s/%s", target_dir,
+					   artifacts[i]);
+		PS_CHECK_PATH_FORMAT(len, path);
+		if (access(path, F_OK) != 0)
+			continue;
+		if (strcmp(artifacts[i], "pagestore_branch.manifest") == 0)
+		{
+			if (unlink(path) != 0)
+				ereport(WARNING,
+						(errcode_for_file_access(),
+						 errmsg("could not remove branch prepare artifact \"%s\": %m",
+								path)));
+		}
+		else if (!rmtree(path, true))
+			ereport(WARNING,
+					(errcode_for_file_access(),
+					 errmsg("could not remove branch prepare artifact \"%s\"",
+							path)));
+	}
 }
 
 /*
@@ -4210,20 +4259,31 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 
 	pagestore_localsvc_check_branch((uint32) new_tl, (uint32) parent_tl,
 									(uint64) target);
-	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-									 (uint64) target);
 	seeded = pagestore_seed_branch_slrus_impl(target_dir, base, target,
 											  oldest_xid, next_xid,
 											  oldest_commit_ts_xid,
 											  next_commit_ts_xid,
 											  oldest_multi, next_multi,
 											  oldest_member, next_member);
-	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl, base, target,
-									oldest_xid, next_xid,
-									oldest_commit_ts_xid, next_commit_ts_xid,
-									oldest_multi, next_multi,
-									oldest_member, next_member,
-									seeded);
+	PG_TRY();
+	{
+		pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+										 (uint64) target);
+		pagestore_write_branch_manifest(target_dir, new_tl, parent_tl,
+										base, target,
+										oldest_xid, next_xid,
+										oldest_commit_ts_xid,
+										next_commit_ts_xid,
+										oldest_multi, next_multi,
+										oldest_member, next_member,
+										seeded);
+	}
+	PG_CATCH();
+	{
+		pagestore_cleanup_prepared_branch_output(target_dir);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	PG_RETURN_INT64(seeded);
 }

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -378,6 +378,12 @@ pagestore_which(RelFileLocator rlocator, ProcNumber backend)
 	return SMGR_MD;
 }
 
+static bool
+pagestore_branch_routing_active(void)
+{
+	return pagestore_route_all;
+}
+
 /* --- GUC plumbing ------------------------------------------------------- */
 
 static bool
@@ -4407,7 +4413,7 @@ pagestore_manifest_get_lsn_token(const char *manifest, const char *key,
 	const char *end;
 	char		buf[64];
 	size_t		len;
-	unsigned int hi,
+	unsigned long long hi,
 				lo;
 	char		extra;
 
@@ -4422,7 +4428,9 @@ pagestore_manifest_get_lsn_token(const char *manifest, const char *key,
 		return false;
 	memcpy(buf, field, len);
 	buf[len] = '\0';
-	if (sscanf(buf, "%X/%X%c", &hi, &lo, &extra) != 2)
+	if (sscanf(buf, "%llX/%llX%c", &hi, &lo, &extra) != 2)
+		return false;
+	if (hi > UINT32_MAX || lo > UINT32_MAX)
 		return false;
 	if (!pagestore_manifest_value_delimited(end + 1))
 		return false;
@@ -4846,6 +4854,9 @@ pagestore_validate_datadir_branch_manifest(void)
 	if (!pagestore_branch_backend_active())
 		ereport(FATAL,
 				(errmsg("pagestore.backend must be \"localsvc\" to validate a branch manifest")));
+	if (!pagestore_branch_routing_active())
+		ereport(FATAL,
+				(errmsg("pagestore.route_all must be enabled to use a branch manifest")));
 	if (!pagestore_manifest_get_branch_identity(manifest, &new_tl, &parent_tl,
 												&fork_lsn))
 		ereport(FATAL,

--- a/contrib/pagestore/pagestore.c
+++ b/contrib/pagestore/pagestore.c
@@ -4169,42 +4169,6 @@ pagestore_write_branch_manifest(const char *target_dir,
 	fsync_fname(target_dir, true);
 }
 
-static void
-pagestore_cleanup_prepared_branch_output(const char *target_dir)
-{
-	const char *artifacts[] = {
-		"pg_multixact",
-		"pg_commit_ts",
-		"pg_xact",
-		"pagestore_branch.manifest",
-	};
-	char		path[MAXPGPATH];
-
-	for (int i = 0; i < lengthof(artifacts); i++)
-	{
-		int			len;
-
-		len = snprintf(path, sizeof(path), "%s/%s", target_dir,
-					   artifacts[i]);
-		PS_CHECK_PATH_FORMAT(len, path);
-		if (access(path, F_OK) != 0)
-			continue;
-		if (strcmp(artifacts[i], "pagestore_branch.manifest") == 0)
-		{
-			if (unlink(path) != 0)
-				ereport(WARNING,
-						(errcode_for_file_access(),
-						 errmsg("could not remove branch prepare artifact \"%s\": %m",
-								path)));
-		}
-		else if (!rmtree(path, true))
-			ereport(WARNING,
-					(errcode_for_file_access(),
-					 errmsg("could not remove branch prepare artifact \"%s\"",
-							path)));
-	}
-}
-
 /*
  * pagestore_prepare_branch(target_dir text, new_timeline int, parent_timeline int,
  *                          base pg_lsn, target pg_lsn,
@@ -4265,25 +4229,16 @@ pagestore_prepare_branch(PG_FUNCTION_ARGS)
 											  next_commit_ts_xid,
 											  oldest_multi, next_multi,
 											  oldest_member, next_member);
-	PG_TRY();
-	{
-		pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
-										 (uint64) target);
-		pagestore_write_branch_manifest(target_dir, new_tl, parent_tl,
-										base, target,
-										oldest_xid, next_xid,
-										oldest_commit_ts_xid,
-										next_commit_ts_xid,
-										oldest_multi, next_multi,
-										oldest_member, next_member,
-										seeded);
-	}
-	PG_CATCH();
-	{
-		pagestore_cleanup_prepared_branch_output(target_dir);
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
+	pagestore_write_branch_manifest(target_dir, new_tl, parent_tl,
+									base, target,
+									oldest_xid, next_xid,
+									oldest_commit_ts_xid,
+									next_commit_ts_xid,
+									oldest_multi, next_multi,
+									oldest_member, next_member,
+									seeded);
+	pagestore_localsvc_create_branch((uint32) new_tl, (uint32) parent_tl,
+									 (uint64) target);
 
 	PG_RETURN_INT64(seeded);
 }

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -534,7 +534,7 @@ static TimelineMeta timelines[MAX_TIMELINES];
 
 /*
  * Branch-local usage marker: set once a timeline acquires any local state (a
- * page version or fork entry here; shipped WAL is tracked by wal_end[]).  An
+ * page version, fork entry, WAL-index entry, or shipped WAL).  An
  * exact-match duplicate CREATE_BRANCH is accepted only while the timeline is
  * still unused: that keeps a prepare retry idempotent (retries happen before
  * a compute ever boots on the branch), while reusing the id of a live branch
@@ -561,6 +561,30 @@ timeline_is_used(uint32_t timeline)
 
 /* highest end LSN (start+len) of shipped WAL received per timeline */
 static uint64_t wal_end[MAX_TIMELINES];
+
+static inline uint64_t
+wal_end_read(uint32_t timeline)
+{
+	if (timeline >= MAX_TIMELINES)
+		return 0;
+	return __atomic_load_n(&wal_end[timeline], __ATOMIC_ACQUIRE);
+}
+
+static inline void
+wal_end_advance(uint32_t timeline, uint64_t end_lsn)
+{
+	uint64_t	old_end;
+
+	if (timeline >= MAX_TIMELINES)
+		return;
+	old_end = __atomic_load_n(&wal_end[timeline], __ATOMIC_RELAXED);
+	while (end_lsn > old_end &&
+		   !__atomic_compare_exchange_n(&wal_end[timeline], &old_end,
+										end_lsn, false,
+										__ATOMIC_RELEASE,
+										__ATOMIC_RELAXED))
+		;
+}
 
 /* FNV-1a hash over a byte range (used to hash keys into buckets). */
 
@@ -806,11 +830,11 @@ branch_request_ok(uint32_t new_tl, int parent, uint64_t branch_lsn)
 	 * only while the timeline has no branch-local state yet.  Once it has
 	 * pages, forks or shipped WAL, the duplicate is timeline-id reuse, not a
 	 * retry, and accepting it would hand the caller the old branch's data.
-		 */
+	 */
 	if (new_tl < MAX_TIMELINES && timelines[new_tl].defined)
 		return timelines[new_tl].parent == parent &&
 			timelines[new_tl].branch_lsn == branch_lsn &&
-			!timeline_is_used(new_tl) && wal_end[new_tl] == 0;
+			!timeline_is_used(new_tl) && wal_end_read(new_tl) == 0;
 
 	if (new_tl == 0 || new_tl >= MAX_TIMELINES || parent < 0 ||
 		parent >= MAX_TIMELINES || !timelines[parent].defined)
@@ -964,14 +988,14 @@ wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,
 	if (tl >= MAX_TIMELINES)
 		return -1;
 
+	timeline_mark_used(tl);
 	h.magic = WAL_MAGIC;
 	h.len = len;
 	h.start_lsn = start_lsn;
 	if (ps_storage->wal_append(tl, &h, sizeof(h), data, len) != 0)
 		return -1;
 
-	if (start_lsn + len > wal_end[tl])
-		wal_end[tl] = start_lsn + len;
+	wal_end_advance(tl, start_lsn + len);
 	return 0;
 }
 
@@ -1028,8 +1052,11 @@ wal_recover_one(uint32_t tl)
 	while (ps_storage->wal_read(tl, off, &h, sizeof(h)) == (int) sizeof(h) &&
 		   h.magic == WAL_MAGIC)
 	{
-		if (h.start_lsn + h.len > wal_end[tl])
-			wal_end[tl] = h.start_lsn + h.len;
+		if (h.start_lsn + h.len > wal_end_read(tl))
+		{
+			timeline_mark_used(tl);
+			wal_end_advance(tl, h.start_lsn + h.len);
+		}
 		off += sizeof(h) + h.len;
 	}
 }
@@ -1564,7 +1591,7 @@ ps_handle_meta(PsChannel *ch)
 			break;
 
 		case PS_OP_WAL_SIZE:
-			ch->req_lsn = wal_end[tl];	/* output: end LSN of this timeline's WAL */
+			ch->req_lsn = wal_end_read(tl);	/* output: end LSN of this timeline's WAL */
 			break;
 
 		case PS_OP_WAL_READ:

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -532,6 +532,24 @@ typedef struct TimelineMeta
 
 static TimelineMeta timelines[MAX_TIMELINES];
 
+/*
+ * Branch-local usage marker: set once a timeline acquires any local state (a
+ * page version or fork entry here; shipped WAL is tracked by wal_end[]).  An
+ * exact-match duplicate CREATE_BRANCH is accepted only while the timeline is
+ * still unused: that keeps a prepare retry idempotent (retries happen before
+ * a compute ever boots on the branch), while reusing the id of a live branch
+ * is refused -- read_through() resolves timeline-local versions before the
+ * parent snapshot, so a "fresh" branch recreated over a written timeline
+ * would silently serve the previous branch's pages.  Plain ints, not
+ * atomics: every writer stores 1, and a duplicate create racing the
+ * timeline's very first write is indistinguishable from that write landing
+ * just after an accepted create.
+ */
+static int timeline_used[MAX_TIMELINES];
+
+/* highest end LSN (start+len) of shipped WAL received per timeline */
+static uint64_t wal_end[MAX_TIMELINES];
+
 /* FNV-1a hash over a byte range (used to hash keys into buckets). */
 
 static uint32_t
@@ -592,6 +610,8 @@ page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
 	Shard	   *s = shard_for(key);
 	PageEnt    *e = page_find(timeline, key, block);
 
+	if (timeline < MAX_TIMELINES)
+		timeline_used[timeline] = 1;
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
@@ -651,6 +671,8 @@ fork_get_or_create(uint32_t timeline, const PsKey *key)
 	Shard	   *s = shard_for(key);
 	ForkEnt    *e = fork_find(timeline, key);
 
+	if (timeline < MAX_TIMELINES)
+		timeline_used[timeline] = 1;
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
@@ -758,7 +780,8 @@ tl_walk_next(TlWalk *w)
  * the fork-size walks follow the parent chain assuming it is finite and well
  * formed, so a bad CREATE_BRANCH must be rejected rather than persisted.  Refuse:
  *	- a new id that is out of range, or an already-defined id with mismatched
- *	  ancestry metadata (unless it exactly matches for idempotent retry);
+ *	  ancestry metadata (an exact match is an idempotent retry, but only while
+ *	  the timeline is still unused -- see timeline_used[]);
  *	- a parent that is out of range or not yet defined (the requested parent must
  *	  actually exist, else the branch silently inherits from nothing);
  *	- a parent whose ancestry already reaches the new id, which would turn the
@@ -768,10 +791,16 @@ tl_walk_next(TlWalk *w)
 static int
 branch_request_ok(uint32_t new_tl, int parent, uint64_t branch_lsn)
 {
-	/* Exact matches to an existing definition are idempotent retries. */
+	/*
+	 * Exact matches to an existing definition are idempotent retries -- but
+	 * only while the timeline has no branch-local state yet.  Once it has
+	 * pages, forks or shipped WAL, the duplicate is timeline-id reuse, not a
+	 * retry, and accepting it would hand the caller the old branch's data.
+	 */
 	if (new_tl < MAX_TIMELINES && timelines[new_tl].defined)
 		return timelines[new_tl].parent == parent &&
-			timelines[new_tl].branch_lsn == branch_lsn;
+			timelines[new_tl].branch_lsn == branch_lsn &&
+			!timeline_used[new_tl] && wal_end[new_tl] == 0;
 
 	if (new_tl == 0 || new_tl >= MAX_TIMELINES || parent < 0 ||
 		parent >= MAX_TIMELINES || !timelines[parent].defined)
@@ -915,9 +944,6 @@ typedef struct WalRecHdr
 	uint32_t	len;			/* WAL bytes following the header */
 	uint64_t	start_lsn;		/* LSN of the first byte */
 } WalRecHdr;
-
-/* highest end LSN (start+len) received per timeline */
-static uint64_t wal_end[MAX_TIMELINES];
 
 static int
 wal_append(uint32_t tl, uint64_t start_lsn, const unsigned char *data,

--- a/contrib/pagestore/pagestore_core.c
+++ b/contrib/pagestore/pagestore_core.c
@@ -303,7 +303,7 @@ gc_resume(void)
 		 * write error may have torn the manifest tail; stop so that record stays
 		 * the recoverable tail instead of becoming interior corruption, and the
 		 * next start retries from the last valid manifest state.
-		 */
+	 */
 		if (ps_layer_store->delete_local_layer(&dead[k]) != 0)
 			continue;
 		if (ps_manifest_remove_layer(dead[k].layer_id) != 0)
@@ -540,12 +540,24 @@ static TimelineMeta timelines[MAX_TIMELINES];
  * a compute ever boots on the branch), while reusing the id of a live branch
  * is refused -- read_through() resolves timeline-local versions before the
  * parent snapshot, so a "fresh" branch recreated over a written timeline
- * would silently serve the previous branch's pages.  Plain ints, not
- * atomics: every writer stores 1, and a duplicate create racing the
- * timeline's very first write is indistinguishable from that write landing
- * just after an accepted create.
+ * would silently serve the previous branch's pages.
  */
 static int timeline_used[MAX_TIMELINES];
+
+static inline void
+timeline_mark_used(uint32_t timeline)
+{
+	if (timeline < MAX_TIMELINES)
+		__atomic_store_n(&timeline_used[timeline], 1, __ATOMIC_RELEASE);
+}
+
+static inline int
+timeline_is_used(uint32_t timeline)
+{
+	if (timeline >= MAX_TIMELINES)
+		return 0;
+	return __atomic_load_n(&timeline_used[timeline], __ATOMIC_ACQUIRE);
+}
 
 /* highest end LSN (start+len) of shipped WAL received per timeline */
 static uint64_t wal_end[MAX_TIMELINES];
@@ -610,8 +622,7 @@ page_add_version(uint32_t timeline, const PsKey *key, uint32_t block,
 	Shard	   *s = shard_for(key);
 	PageEnt    *e = page_find(timeline, key, block);
 
-	if (timeline < MAX_TIMELINES)
-		timeline_used[timeline] = 1;
+	timeline_mark_used(timeline);
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
@@ -671,8 +682,7 @@ fork_get_or_create(uint32_t timeline, const PsKey *key)
 	Shard	   *s = shard_for(key);
 	ForkEnt    *e = fork_find(timeline, key);
 
-	if (timeline < MAX_TIMELINES)
-		timeline_used[timeline] = 1;
+	timeline_mark_used(timeline);
 	if (!e)
 	{
 		e = calloc(1, sizeof(*e));
@@ -796,11 +806,11 @@ branch_request_ok(uint32_t new_tl, int parent, uint64_t branch_lsn)
 	 * only while the timeline has no branch-local state yet.  Once it has
 	 * pages, forks or shipped WAL, the duplicate is timeline-id reuse, not a
 	 * retry, and accepting it would hand the caller the old branch's data.
-	 */
+		 */
 	if (new_tl < MAX_TIMELINES && timelines[new_tl].defined)
 		return timelines[new_tl].parent == parent &&
 			timelines[new_tl].branch_lsn == branch_lsn &&
-			!timeline_used[new_tl] && wal_end[new_tl] == 0;
+			!timeline_is_used(new_tl) && wal_end[new_tl] == 0;
 
 	if (new_tl == 0 || new_tl >= MAX_TIMELINES || parent < 0 ||
 		parent >= MAX_TIMELINES || !timelines[parent].defined)
@@ -1052,6 +1062,8 @@ walidx_add(uint32_t tl, const PsKey *key, uint32_t block, uint64_t lsn)
 	uint32_t	h = page_hash(tl, key, block);
 	Shard	   *s = shard_for(key);
 	WalIdxEnt  *e;
+
+	timeline_mark_used(tl);
 
 	for (e = s->walidx[h & IDX_MASK]; e; e = e->next)
 		if (e->timeline == tl && e->block == block && key_eq(&e->key, key))

--- a/contrib/pagestore/pagestore_test.c
+++ b/contrib/pagestore/pagestore_test.c
@@ -824,14 +824,14 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 
 	/* CREATE_BRANCH validation: reject requests that would corrupt the parent
 	 * walk (timelines 0,1,2 are defined here) */
-	check(op_check_branch_status(1, 0, 1500) == PS_STATUS_OK,
-		  "CHECK_BRANCH accepts idempotent retry metadata");
+	check(op_check_branch_status(1, 0, 1500) == PS_STATUS_ERROR,
+		  "CHECK_BRANCH rejects retry of a timeline with branch-local writes");
 	check(op_check_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
 		  "CHECK_BRANCH rejects mismatched ancestry for existing timeline");
 	check(op_create_branch_status(1, 0, 1501) == PS_STATUS_ERROR,
 		  "CREATE_BRANCH rejects re-creating existing timeline with mismatched ancestry");
-	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_OK,
-		  "re-create existing timeline id with identical ancestry is idempotent");
+	check(op_create_branch_status(1, 0, 1500) == PS_STATUS_ERROR,
+		  "re-create of a written timeline id is rejected (would expose its pages)");
 	check(op_create_branch_status(9, 900, 1500) == PS_STATUS_ERROR,
 		  "reject branch off an undefined parent");
 	check(op_create_branch_status(9, 9, 1500) == PS_STATUS_ERROR,
@@ -842,6 +842,18 @@ run_branch_suite(const char *daemon_path, const char *tmpbase)
 		  "valid branch off a defined branch still accepted");
 	op_read_tl(7, REL_B, FORK0, 0, rb);
 	check(page_has_tag(rb, ps, 11), "new valid branch reads through to root");
+
+	/* the idempotent-retry window: an unused timeline may be re-created (a
+	 * prepare retry), but the first branch-local write closes it -- reads on
+	 * the timeline do not */
+	check(op_check_branch_status(7, 2, 1500) == PS_STATUS_OK,
+		  "CHECK_BRANCH accepts retry of an unused timeline after reads");
+	check(op_create_branch_status(7, 2, 1500) == PS_STATUS_OK,
+		  "re-create of an unused timeline with identical ancestry is idempotent");
+	fill_page(p, ps, 4000, 77);
+	op_write_tl(7, REL_B, FORK0, 0, p);
+	check(op_create_branch_status(7, 2, 1500) == PS_STATUS_ERROR,
+		  "the timeline's first write closes the idempotent-retry window");
 
 	client_detach();
 	stop_daemon(dpid);
@@ -913,6 +925,8 @@ run_wal_suite(const char *daemon_path, const char *tmpbase)
 	client_attach(shm, ps);
 	check(op_wal_size(0) == 2000, "main WAL end LSN survives daemon restart");
 	check(op_wal_size(1) == 2300, "branch WAL end LSN survives daemon restart");
+	check(op_create_branch_status(1, 0, 2000) == PS_STATUS_ERROR,
+		  "shipped WAL also closes the idempotent re-create window (post-restart)");
 
 	client_detach();
 	stop_daemon(dpid);

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -327,6 +327,25 @@ posix_truncate_best_effort(int fd, off_t old_size)
 	}
 }
 
+static void
+posix_fsync_dir_best_effort(void)
+{
+	int		fd = open(posix_dir, O_RDONLY | O_DIRECTORY);
+
+	if (fd >= 0)
+	{
+		(void) fsync(fd);
+		close(fd);
+	}
+}
+
+static void
+posix_unlink_created_meta(const char *path)
+{
+	if (unlink(path) == 0)
+		posix_fsync_dir_best_effort();
+}
+
 /*
  * Roll back an append whose record may already be durable in the metadata
  * log: reopen the log, truncate it back to old_size, and push the truncate
@@ -347,7 +366,7 @@ posix_meta_rollback(const char *path, off_t old_size, int created)
 		close(fd);
 	}
 	if (created && old_size == 0)
-		(void) unlink(path);
+		posix_unlink_created_meta(path);
 }
 
 static int
@@ -368,7 +387,7 @@ posix_meta_append(const void *buf, uint32_t len)
 	{
 		close(fd);
 		if (created)
-			(void) unlink(path);
+			posix_unlink_created_meta(path);
 		return -1;
 	}
 
@@ -384,7 +403,7 @@ posix_meta_append(const void *buf, uint32_t len)
 		posix_truncate_best_effort(fd, old_size);
 		close(fd);
 		if (created)
-			(void) unlink(path);
+			posix_unlink_created_meta(path);
 		return -1;
 	}
 	if (fsync(fd) != 0)
@@ -393,7 +412,7 @@ posix_meta_append(const void *buf, uint32_t len)
 		(void) fsync(fd);
 		close(fd);
 		if (created)
-			(void) unlink(path);
+			posix_unlink_created_meta(path);
 		return -1;
 	}
 	if (close(fd) != 0)

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -319,24 +319,43 @@ posix_meta_append(const void *buf, uint32_t len)
 	char		path[4096];
 	int		fd;
 	int		created;
+	off_t		old_size;
 
 	snprintf(path, sizeof(path), "%s/timelines", posix_dir);
 	created = access(path, F_OK) != 0;
 	fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
 	if (fd < 0)
 		return -1;
+	old_size = lseek(fd, 0, SEEK_END);
+	if (old_size < 0)
+	{
+		close(fd);
+		return -1;
+	}
 	if (write(fd, buf, len) != (ssize_t) len)
 	{
+		(void) ftruncate(fd, old_size);
 		close(fd);
 		return -1;
 	}
 	if (fsync(fd) != 0)
 	{
+		(void) ftruncate(fd, old_size);
+		(void) fsync(fd);
 		close(fd);
 		return -1;
 	}
 	if (close(fd) != 0)
+	{
+		fd = open(path, O_WRONLY);
+		if (fd >= 0)
+		{
+			(void) ftruncate(fd, old_size);
+			(void) fsync(fd);
+			close(fd);
+		}
 		return -1;
+	}
 	if (created)
 	{
 		fd = open(posix_dir, O_RDONLY | O_DIRECTORY);
@@ -345,10 +364,30 @@ posix_meta_append(const void *buf, uint32_t len)
 		if (fsync(fd) != 0)
 		{
 			close(fd);
+			fd = open(path, O_WRONLY);
+			if (fd >= 0)
+			{
+				(void) ftruncate(fd, old_size);
+				(void) fsync(fd);
+				close(fd);
+			}
+			if (old_size == 0)
+				(void) unlink(path);
 			return -1;
 		}
 		if (close(fd) != 0)
+		{
+			fd = open(path, O_WRONLY);
+			if (fd >= 0)
+			{
+				(void) ftruncate(fd, old_size);
+				(void) fsync(fd);
+				close(fd);
+			}
+			if (old_size == 0)
+				(void) unlink(path);
 			return -1;
+		}
 	}
 	return 0;
 }

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -367,12 +367,24 @@ posix_meta_append(const void *buf, uint32_t len)
 	if (old_size < 0)
 	{
 		close(fd);
+		if (created)
+			(void) unlink(path);
 		return -1;
 	}
+
+	/*
+	 * Every failure below must also remove a file this append created (not
+	 * just truncate it): if an empty log lingered, the next successful append
+	 * would see the file as pre-existing and skip the directory fsync, so its
+	 * directory entry would never be made durable and a crash could drop an
+	 * acknowledged record with it.
+	 */
 	if (write(fd, buf, len) != (ssize_t) len)
 	{
 		posix_truncate_best_effort(fd, old_size);
 		close(fd);
+		if (created)
+			(void) unlink(path);
 		return -1;
 	}
 	if (fsync(fd) != 0)
@@ -380,6 +392,8 @@ posix_meta_append(const void *buf, uint32_t len)
 		posix_truncate_best_effort(fd, old_size);
 		(void) fsync(fd);
 		close(fd);
+		if (created)
+			(void) unlink(path);
 		return -1;
 	}
 	if (close(fd) != 0)

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -327,6 +327,29 @@ posix_truncate_best_effort(int fd, off_t old_size)
 	}
 }
 
+/*
+ * Roll back an append whose record may already be durable in the metadata
+ * log: reopen the log, truncate it back to old_size, and push the truncate
+ * out.  If this append created the file, remove it again -- otherwise a
+ * failed append is reported as an error yet a daemon restart would replay
+ * the record from the log and resurrect it.  Best-effort, like
+ * posix_truncate_best_effort().
+ */
+static void
+posix_meta_rollback(const char *path, off_t old_size, int created)
+{
+	int		fd = open(path, O_WRONLY);
+
+	if (fd >= 0)
+	{
+		posix_truncate_best_effort(fd, old_size);
+		(void) fsync(fd);
+		close(fd);
+	}
+	if (created && old_size == 0)
+		(void) unlink(path);
+}
+
 static int
 posix_meta_append(const void *buf, uint32_t len)
 {
@@ -361,45 +384,26 @@ posix_meta_append(const void *buf, uint32_t len)
 	}
 	if (close(fd) != 0)
 	{
-		fd = open(path, O_WRONLY);
-		if (fd >= 0)
-		{
-			posix_truncate_best_effort(fd, old_size);
-			(void) fsync(fd);
-			close(fd);
-		}
+		posix_meta_rollback(path, old_size, created);
 		return -1;
 	}
 	if (created)
 	{
 		fd = open(posix_dir, O_RDONLY | O_DIRECTORY);
 		if (fd < 0)
+		{
+			posix_meta_rollback(path, old_size, created);
 			return -1;
+		}
 		if (fsync(fd) != 0)
 		{
 			close(fd);
-			fd = open(path, O_WRONLY);
-			if (fd >= 0)
-			{
-				posix_truncate_best_effort(fd, old_size);
-				(void) fsync(fd);
-				close(fd);
-			}
-			if (old_size == 0)
-				(void) unlink(path);
+			posix_meta_rollback(path, old_size, created);
 			return -1;
 		}
 		if (close(fd) != 0)
 		{
-			fd = open(path, O_WRONLY);
-			if (fd >= 0)
-			{
-				posix_truncate_best_effort(fd, old_size);
-				(void) fsync(fd);
-				close(fd);
-			}
-			if (old_size == 0)
-				(void) unlink(path);
+			posix_meta_rollback(path, old_size, created);
 			return -1;
 		}
 	}

--- a/contrib/pagestore/storage_posix.c
+++ b/contrib/pagestore/storage_posix.c
@@ -313,6 +313,20 @@ posix_wal_read(uint32_t tl, uint64_t off, void *buf, uint32_t len)
 	return (int) n;
 }
 
+/*
+ * Truncate fd back to old_size on an error path.  Best-effort: the caller
+ * is already returning an error and cannot act on a rollback failure; the
+ * torn tail is detected and discarded on the next meta read.
+ */
+static void
+posix_truncate_best_effort(int fd, off_t old_size)
+{
+	if (ftruncate(fd, old_size) != 0)
+	{
+		/* nothing we can do; see above */
+	}
+}
+
 static int
 posix_meta_append(const void *buf, uint32_t len)
 {
@@ -334,13 +348,13 @@ posix_meta_append(const void *buf, uint32_t len)
 	}
 	if (write(fd, buf, len) != (ssize_t) len)
 	{
-		(void) ftruncate(fd, old_size);
+		posix_truncate_best_effort(fd, old_size);
 		close(fd);
 		return -1;
 	}
 	if (fsync(fd) != 0)
 	{
-		(void) ftruncate(fd, old_size);
+		posix_truncate_best_effort(fd, old_size);
 		(void) fsync(fd);
 		close(fd);
 		return -1;
@@ -350,7 +364,7 @@ posix_meta_append(const void *buf, uint32_t len)
 		fd = open(path, O_WRONLY);
 		if (fd >= 0)
 		{
-			(void) ftruncate(fd, old_size);
+			posix_truncate_best_effort(fd, old_size);
 			(void) fsync(fd);
 			close(fd);
 		}
@@ -367,7 +381,7 @@ posix_meta_append(const void *buf, uint32_t len)
 			fd = open(path, O_WRONLY);
 			if (fd >= 0)
 			{
-				(void) ftruncate(fd, old_size);
+				posix_truncate_best_effort(fd, old_size);
 				(void) fsync(fd);
 				close(fd);
 			}
@@ -380,7 +394,7 @@ posix_meta_append(const void *buf, uint32_t len)
 			fd = open(path, O_WRONLY);
 			if (fd >= 0)
 			{
-				(void) ftruncate(fd, old_size);
+				posix_truncate_best_effort(fd, old_size);
 				(void) fsync(fd);
 				close(fd);
 			}


### PR DESCRIPTION
## Summary
- preflight required prepared branch artifacts before installing into a datadir
- require the prepared manifest and pg_xact artifact to exist with the expected file types
- add an integration assertion that a prepared directory missing pg_xact is rejected

## Stack
- stacked on #78 / feat/pagestore-install-idempotent
- #78 is stacked on #77, #76, #75, #74, #73, #72, #71, and #70

## Validation
- not run locally